### PR TITLE
fix: resolve S1192 and S1452 SonarQube issues (batch 3)

### DIFF
--- a/apps/backend/src/main/java/com/simpleaccounts/constant/CommonColumnConstants.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/constant/CommonColumnConstants.java
@@ -35,7 +35,25 @@ public class CommonColumnConstants {
 
     public static final String CHARTOFACCOUNT_ID =  "chartOfAccountId";
     public static final String EXPLANATION_STATUS_CODE =  "explanationStatusCode";
+    public static final String CURRENCY = "currency";
+    public static final String TRANSACTION_DATE = "transactionDate";
+    public static final String TRANSACTION_CATEGORY_CODE = "transactionCategoryCode";
 
+    /* Stored Procedure Parameter Constants */
+    public static final String BANK_CODE = "bankCode";
+    public static final String OTHER_CURRENT_ASSET_CODE = "otherCurrentAssetCode";
+    public static final String ACCOUNT_RECEIVABLE_CODE = "accountReceivableCode";
+    public static final String ACCOUNT_PAYABLE_CODE = "accountPayableCode";
+    public static final String FIXED_ASSET_CODE = "fixedAssetCode";
+    public static final String OTHER_LIABILITY_CODE = "otherLiabilityCode";
+    public static final String EQUITY_CODE = "equityCode";
+    public static final String INCOME_CODE = "incomeCode";
+    public static final String ADMIN_EXPENSE_CODE = "adminExpenseCode";
+    public static final String OTHER_EXPENSE_CODE = "otherExpenseCode";
+
+    /* Expense Related Constants */
+    public static final String COMPANY_EXPENSE = "Company Expense";
+    public static final String REVERSAL_JOURNAL_EXPENSE_PREFIX = "Reversal of journal entry against Expense No:-";
 
     private CommonColumnConstants(){
         throw new IllegalStateException("Utility class ContactTypeConstants");

--- a/apps/backend/src/main/java/com/simpleaccounts/dao/impl/InvoiceDaoImpl.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/dao/impl/InvoiceDaoImpl.java
@@ -310,7 +310,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 	@Override
 	public List<Invoice> getUnpaidInvoice(Integer contactId, ContactTypeEnum type) {
 		TypedQuery<Invoice> query = getEntityManager().createNamedQuery("unpaidInvoices", Invoice.class);
-		query.setParameter("status", Arrays.asList(
+		query.setParameter(CommonColumnConstants.STATUS, Arrays.asList(
 				new Integer[] { CommonStatusEnum.PARTIALLY_PAID.getValue(), CommonStatusEnum.POST.getValue() }));
 		query.setParameter("id", contactId);
 		query.setParameter("type", type.getValue());
@@ -327,12 +327,12 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 		if (!user.getRole().getRoleCode().equals(1)){
 
 		 query = getEntityManager().createNamedQuery("suggestionUnpaidInvoices", Invoice.class);
-		query.setParameter("status", Arrays.asList(new Integer[]{
+		query.setParameter(CommonColumnConstants.STATUS, Arrays.asList(new Integer[]{
 				CommonStatusEnum.PARTIALLY_PAID.getValue(), CommonStatusEnum.POST.getValue()}));
 		if (currency != null || !currency.equals(0)) {
-			//query.setParameter("currency", currency );
+			//query.setParameter(CommonColumnConstants.CURRENCY, currency );
 			//below code updated mudassar fro #1960 & #1961
-			query.setParameter("currency", Arrays.asList(new Integer[]{
+			query.setParameter(CommonColumnConstants.CURRENCY, Arrays.asList(new Integer[]{
 					currency,  companyCurrency }));
 		}
 		query.setParameter("type", type.getValue());
@@ -344,9 +344,9 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 			query.setParameter("status", Arrays.asList(new Integer[]{
 					CommonStatusEnum.PARTIALLY_PAID.getValue(), CommonStatusEnum.POST.getValue()}));
 			if (currency != null || !currency.equals(0)) {
-				//query.setParameter("currency", currency);
+				//query.setParameter(CommonColumnConstants.CURRENCY, currency);
 				//below code updated mudassar fro #1960 & #1961
-				query.setParameter("currency", Arrays.asList(new Integer[]{currency, companyCurrency}));
+				query.setParameter(CommonColumnConstants.CURRENCY, Arrays.asList(new Integer[]{currency, companyCurrency}));
 			}
 			query.setParameter("type", type.getValue());
 			query.setParameter("id", contactId);
@@ -360,7 +360,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 		TypedQuery<Invoice> query = getEntityManager().createNamedQuery("suggestionExplainedInvoices", Invoice.class);
 		query.setParameter("status", Arrays.asList(new Integer[] {
 				CommonStatusEnum.PARTIALLY_PAID.getValue(), CommonStatusEnum.POST.getValue() }));
-		query.setParameter("currency", currency);
+		query.setParameter(CommonColumnConstants.CURRENCY, currency);
 		query.setParameter("type", type.getValue());
 		query.setParameter("id", contactId);
 		query.setParameter("userId", userId);
@@ -403,7 +403,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 	}
 	@Override
 	public void sumOfTotalAmountWithoutVat(ReportRequestModel reportRequestModel, VatReportResponseModel vatReportResponseModel){
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(CommonColumnConstants.DD_MM_YYYY);
 		LocalDate startDate = LocalDate.parse(reportRequestModel.getStartDate(),formatter);
 		LocalDate endDate = LocalDate.parse(reportRequestModel.getEndDate(),formatter);
 		Boolean editFlag = Boolean.TRUE;
@@ -420,13 +420,13 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 				" FROM Invoice i,InvoiceLineItem  il WHERE i.status not in(2) AND i.type=2 and i.id = il.invoice.id and il.vatCategory.id in (2) AND i.editFlag=:editFlag AND i.invoiceDate between :startDate and :endDate",BigDecimal.class);
 		query.setParameter(CommonColumnConstants.START_DATE,startDate);
 		query.setParameter(CommonColumnConstants.END_DATE,endDate);
-		query.setParameter("editFlag",editFlag);
+		query.setParameter(CommonColumnConstants.EDIT_FLAG,editFlag);
 		BigDecimal amountWithoutVat = query.getSingleResult();
 		vatReportResponseModel.setZeroRatedSupplies(amountWithoutVat);
 	}
 	@Override
 	public void getSumOfTotalAmountWithVat(ReportRequestModel reportRequestModel, VatReportResponseModel vatReportResponseModel){
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(CommonColumnConstants.DD_MM_YYYY);
 		LocalDate startDate = LocalDate.parse(reportRequestModel.getStartDate(),formatter);
 		LocalDate endDate = LocalDate.parse(reportRequestModel.getEndDate(),formatter);
 		Boolean editFlag = Boolean.TRUE;
@@ -440,7 +440,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 			}
 		}
 		String queryStr = "SELECT SUM(il.subTotal*i.exchangeRate) AS TOTAL_AMOUNT, SUM(il.vatAmount*i.exchangeRate) AS TOTAL_VAT_AMOUNT FROM Invoice i ,InvoiceLineItem il WHERE i.id = il.invoice.id AND i.status not in(2) AND i.type=1 AND i.isReverseChargeEnabled=false AND i.deleteFlag=false AND i.editFlag=:editFlag AND il.vatCategory.id in (1) AND i.invoiceDate between :startDate And :endDate AND i.totalVatAmount>"+BigDecimal.ZERO;
-		List<Object> list = getEntityManager().createQuery(queryStr).setParameter("startDate",startDate).setParameter("endDate",endDate).setParameter("editFlag",editFlag).getResultList();
+		List<Object> list = getEntityManager().createQuery(queryStr).setParameter("startDate",startDate).setParameter("endDate",endDate).setParameter(CommonColumnConstants.EDIT_FLAG,editFlag).getResultList();
 		if(list!=null&& list.size()>0) {
 		List<VatReportModel> vatReportModelList = getVatModalFromDB(list);
 		for(VatReportModel vatReportModel:vatReportModelList){
@@ -451,7 +451,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 	}
 	@Override
 	public void sumOfTotalAmountWithoutVatForRCM(ReportRequestModel reportRequestModel, VatReportResponseModel vatReportResponseModel){
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(CommonColumnConstants.DD_MM_YYYY);
 		LocalDate startDate = LocalDate.parse(reportRequestModel.getStartDate(),formatter);
 		LocalDate endDate = LocalDate.parse(reportRequestModel.getEndDate(),formatter);
 		Boolean editFlag = Boolean.TRUE;
@@ -468,13 +468,13 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 				" FROM Invoice i,InvoiceLineItem  il WHERE i.id = il.invoice.id and il.vatCategory.id in (2) and i.status not in(2) AND i.type=1 and i.isReverseChargeEnabled=true AND i.editFlag=:editFlag AND i.invoiceDate between :startDate and :endDate AND i.totalVatAmount="+BigDecimal.ZERO,BigDecimal.class);
 		query.setParameter(CommonColumnConstants.START_DATE,startDate);
 		query.setParameter(CommonColumnConstants.END_DATE,endDate);
-		query.setParameter("editFlag",editFlag);
+		query.setParameter(CommonColumnConstants.EDIT_FLAG,editFlag);
 		BigDecimal amountWithoutVat = query.getSingleResult();
 //		vatReportResponseModel.setZeroRatedSupplies(amountWithoutVat);
 	}
 	@Override
 	public void getSumOfTotalAmountWithVatForRCM(ReportRequestModel reportRequestModel, VatReportResponseModel vatReportResponseModel){
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(CommonColumnConstants.DD_MM_YYYY);
 		LocalDate startDate = LocalDate.parse(reportRequestModel.getStartDate(),formatter);
 		LocalDate endDate = LocalDate.parse(reportRequestModel.getEndDate(),formatter);
 		Boolean editFlag = Boolean.TRUE;
@@ -488,7 +488,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 			}
 		}
 		String queryStr = "SELECT SUM(i.totalAmount*i.exchangeRate) AS TOTAL_AMOUNT, SUM(i.totalVatAmount*i.exchangeRate) AS TOTAL_VAT_AMOUNT FROM Invoice i WHERE i.status not in(2) AND i.type=1 AND i.isReverseChargeEnabled=True AND i.deleteFlag=false AND i.editFlag=:editFlag AND i.invoiceDate BETWEEN :startDate AND :endDate AND i.totalVatAmount>"+BigDecimal.ZERO;
-		List<Object> list = getEntityManager().createQuery(queryStr).setParameter("startDate",startDate).setParameter("endDate",endDate).setParameter("editFlag",editFlag).getResultList();
+		List<Object> list = getEntityManager().createQuery(queryStr).setParameter("startDate",startDate).setParameter("endDate",endDate).setParameter(CommonColumnConstants.EDIT_FLAG,editFlag).getResultList();
 		if(list!=null&& list.size()>0) {
 			List<VatReportModel> vatReportModelList = getVatModalRCMFromDB(list);
 			for(VatReportModel vatReportModel:vatReportModelList){
@@ -497,7 +497,7 @@ public class InvoiceDaoImpl extends AbstractDao<Integer, Invoice> implements Inv
 			}
 		}
 		String expenseQuery = "SELECT SUM(e.expenseAmount*e.exchangeRate) AS TOTAL_AMOUNT, SUM(e.expenseVatAmount*e.exchangeRate) AS TOTAL_VAT_AMOUNT FROM Expense e WHERE e.status not in(1) AND e.isReverseChargeEnabled=True AND e.deleteFlag=false AND e.editFlag=:editFlag AND e.expenseDate BETWEEN :startDate AND :endDate AND e.vatCategory.id in (1,2)";
-		List<Object> expenseList = getEntityManager().createQuery(expenseQuery).setParameter("startDate",startDate).setParameter("endDate",endDate).setParameter("editFlag",editFlag).getResultList();
+		List<Object> expenseList = getEntityManager().createQuery(expenseQuery).setParameter("startDate",startDate).setParameter("endDate",endDate).setParameter(CommonColumnConstants.EDIT_FLAG,editFlag).getResultList();
 		if(expenseList!=null&& expenseList.size()>0) {
 			List<VatReportModel> vatReportModelList = getVatModalRCMFromDB(expenseList);
 			for(VatReportModel vatReportModel:vatReportModelList){

--- a/apps/backend/src/main/java/com/simpleaccounts/dao/impl/JournalLineItemDaoImpl.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/dao/impl/JournalLineItemDaoImpl.java
@@ -206,34 +206,34 @@ public class JournalLineItemDaoImpl extends AbstractDao<Integer, JournalLineItem
 		StoredProcedureQuery storedProcedureQuery = getEntityManager()
 				.createStoredProcedureQuery("balanceSheetStoredProcedure");
 		storedProcedureQuery.registerStoredProcedureParameter("currentAssetCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("bankCode", String.class,
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.BANK_CODE, String.class,
 				ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("otherCurrentAssetCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("accountReceivableCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("accountPayableCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("fixedAssetCode", String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.OTHER_CURRENT_ASSET_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.ACCOUNT_RECEIVABLE_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.ACCOUNT_PAYABLE_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.FIXED_ASSET_CODE, String.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter("currentLiabilityCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("otherLiabilityCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("equityCode", String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.OTHER_LIABILITY_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.EQUITY_CODE, String.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.START_DATE, LocalDateTime.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.END_DATE, LocalDateTime.class, ParameterMode.IN);
 
 		storedProcedureQuery.setParameter("currentAssetCode", ChartOfAccountCategoryCodeEnum.CURRENT_ASSET.getCode());
-		storedProcedureQuery.setParameter("bankCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.BANK_CODE,
 				ChartOfAccountCategoryCodeEnum.BANK.getCode());
-		storedProcedureQuery.setParameter("otherCurrentAssetCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.OTHER_CURRENT_ASSET_CODE,
 				ChartOfAccountCategoryCodeEnum.OTHER_CURRENT_ASSET.getCode());
-		storedProcedureQuery.setParameter("accountReceivableCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.ACCOUNT_RECEIVABLE_CODE,
 				ChartOfAccountCategoryCodeEnum.ACCOUNTS_RECEIVABLE.getCode());
-		storedProcedureQuery.setParameter("accountPayableCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.ACCOUNT_PAYABLE_CODE,
 				ChartOfAccountCategoryCodeEnum.ACCOUNTS_PAYABLE.getCode());
-		storedProcedureQuery.setParameter("fixedAssetCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.FIXED_ASSET_CODE,
 				ChartOfAccountCategoryCodeEnum.FIXED_ASSET.getCode());
 		storedProcedureQuery.setParameter("currentLiabilityCode",
 				ChartOfAccountCategoryCodeEnum.OTHER_CURRENT_LIABILITIES.getCode());
-		storedProcedureQuery.setParameter("otherLiabilityCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.OTHER_LIABILITY_CODE,
 				ChartOfAccountCategoryCodeEnum.OTHER_LIABILITY.getCode());
-		storedProcedureQuery.setParameter("equityCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.EQUITY_CODE,
 				ChartOfAccountCategoryCodeEnum.EQUITY.getCode());
 		storedProcedureQuery.setParameter(CommonColumnConstants.START_DATE, fromDate);
 		storedProcedureQuery.setParameter(CommonColumnConstants.END_DATE, toDate);
@@ -245,20 +245,20 @@ public class JournalLineItemDaoImpl extends AbstractDao<Integer, JournalLineItem
 	private List<Object[]> getProfitLossReport(LocalDateTime fromDate, LocalDateTime toDate) {
 		StoredProcedureQuery storedProcedureQuery = getEntityManager()
 				.createStoredProcedureQuery("profitAndLossStoredProcedure");
-		storedProcedureQuery.registerStoredProcedureParameter("incomeCode", String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.INCOME_CODE, String.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter("costOfGoodsSoldCode", String.class,
 				ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("adminExpenseCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("otherExpenseCode", String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.ADMIN_EXPENSE_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.OTHER_EXPENSE_CODE, String.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.START_DATE, LocalDateTime.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.END_DATE, LocalDateTime.class, ParameterMode.IN);
 
-		storedProcedureQuery.setParameter("incomeCode", ChartOfAccountCategoryCodeEnum.INCOME.getCode());
+		storedProcedureQuery.setParameter(CommonColumnConstants.INCOME_CODE, ChartOfAccountCategoryCodeEnum.INCOME.getCode());
 		storedProcedureQuery.setParameter("costOfGoodsSoldCode",
 				ChartOfAccountCategoryCodeEnum.COST_OF_GOODS_SOLD.getCode());
-		storedProcedureQuery.setParameter("adminExpenseCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.ADMIN_EXPENSE_CODE,
 				ChartOfAccountCategoryCodeEnum.ADMIN_EXPENSE.getCode());
-		storedProcedureQuery.setParameter("otherExpenseCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.OTHER_EXPENSE_CODE,
 				ChartOfAccountCategoryCodeEnum.OTHER_EXPENSE.getCode());
 		storedProcedureQuery.setParameter(CommonColumnConstants.START_DATE, fromDate);
 		storedProcedureQuery.setParameter(CommonColumnConstants.END_DATE, toDate);
@@ -269,36 +269,36 @@ public class JournalLineItemDaoImpl extends AbstractDao<Integer, JournalLineItem
 	private List<Object[]> getTrialBanaceReport(LocalDateTime fromDate, LocalDateTime toDate) {
 		StoredProcedureQuery storedProcedureQuery = getEntityManager()
 				.createStoredProcedureQuery("trialBalanceStoredProcedure");
-		storedProcedureQuery.registerStoredProcedureParameter("bankCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("otherCurrentAssetCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("accountReceivableCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("accountPayableCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("fixedAssetCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("otherLiabilityCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("equityCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("incomeCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("adminExpenseCode", String.class, ParameterMode.IN);
-		storedProcedureQuery.registerStoredProcedureParameter("otherExpenseCode", String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.BANK_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.OTHER_CURRENT_ASSET_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.ACCOUNT_RECEIVABLE_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.ACCOUNT_PAYABLE_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.FIXED_ASSET_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.OTHER_LIABILITY_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.EQUITY_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.INCOME_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.ADMIN_EXPENSE_CODE, String.class, ParameterMode.IN);
+		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.OTHER_EXPENSE_CODE, String.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.START_DATE, LocalDateTime.class, ParameterMode.IN);
 		storedProcedureQuery.registerStoredProcedureParameter(CommonColumnConstants.END_DATE, LocalDateTime.class, ParameterMode.IN);
-		storedProcedureQuery.setParameter("bankCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.BANK_CODE,
 				ChartOfAccountCategoryCodeEnum.BANK.getCode());
-		storedProcedureQuery.setParameter("otherCurrentAssetCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.OTHER_CURRENT_ASSET_CODE,
 				ChartOfAccountCategoryCodeEnum.OTHER_CURRENT_ASSET.getCode());
-		storedProcedureQuery.setParameter("accountReceivableCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.ACCOUNT_RECEIVABLE_CODE,
 				ChartOfAccountCategoryCodeEnum.ACCOUNTS_RECEIVABLE.getCode());
-		storedProcedureQuery.setParameter("accountPayableCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.ACCOUNT_PAYABLE_CODE,
 				ChartOfAccountCategoryCodeEnum.ACCOUNTS_PAYABLE.getCode());
-		storedProcedureQuery.setParameter("fixedAssetCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.FIXED_ASSET_CODE,
 				ChartOfAccountCategoryCodeEnum.FIXED_ASSET.getCode());
-		storedProcedureQuery.setParameter("otherLiabilityCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.OTHER_LIABILITY_CODE,
 				ChartOfAccountCategoryCodeEnum.OTHER_LIABILITY.getCode());
-		storedProcedureQuery.setParameter("equityCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.EQUITY_CODE,
 				ChartOfAccountCategoryCodeEnum.EQUITY.getCode());
-		storedProcedureQuery.setParameter("incomeCode", ChartOfAccountCategoryCodeEnum.INCOME.getCode());
-		storedProcedureQuery.setParameter("adminExpenseCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.INCOME_CODE, ChartOfAccountCategoryCodeEnum.INCOME.getCode());
+		storedProcedureQuery.setParameter(CommonColumnConstants.ADMIN_EXPENSE_CODE,
 				ChartOfAccountCategoryCodeEnum.ADMIN_EXPENSE.getCode());
-		storedProcedureQuery.setParameter("otherExpenseCode",
+		storedProcedureQuery.setParameter(CommonColumnConstants.OTHER_EXPENSE_CODE,
 				ChartOfAccountCategoryCodeEnum.OTHER_EXPENSE.getCode());
 		storedProcedureQuery.setParameter(CommonColumnConstants.START_DATE, fromDate);
 		storedProcedureQuery.setParameter(CommonColumnConstants.END_DATE, toDate);

--- a/apps/backend/src/main/java/com/simpleaccounts/dao/impl/TransactionCategoryBalanceDaoImpl.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/dao/impl/TransactionCategoryBalanceDaoImpl.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 
 import com.simpleaccounts.constant.ChartOfAccountCategoryCodeEnum;
+import com.simpleaccounts.constant.CommonColumnConstants;
 import com.simpleaccounts.constant.TransactionCategoryCodeEnum;
 import com.simpleaccounts.entity.bankaccount.ChartOfAccount;
 import com.simpleaccounts.entity.bankaccount.TransactionCategory;
@@ -49,10 +50,10 @@ public class TransactionCategoryBalanceDaoImpl extends AbstractDao<Integer, Tran
 		Map<String,Object> transactionCategorymap3 = new HashMap<>();
 		Map<String,Object> transactionCategorymap4 = new HashMap<>();
 		Map<String,Object> transactionCategorymap5 = new HashMap<>();
-		transactionCategorymap1.put("transactionCategoryCode", TransactionCategoryCodeEnum.OPENING_BALANCE_OFFSET_LIABILITIES.getCode());
-		transactionCategorymap2.put("transactionCategoryCode", TransactionCategoryCodeEnum.OPENING_BALANCE_OFFSET_ASSETS.getCode());
-		transactionCategorymap3.put("transactionCategoryCode", TransactionCategoryCodeEnum.PETTY_CASH.getCode());
-		transactionCategorymap4.put("transactionCategoryCode", TransactionCategoryCodeEnum.EMPLOYEE_REIMBURSEMENT.getCode());
+		transactionCategorymap1.put(CommonColumnConstants.TRANSACTION_CATEGORY_CODE, TransactionCategoryCodeEnum.OPENING_BALANCE_OFFSET_LIABILITIES.getCode());
+		transactionCategorymap2.put(CommonColumnConstants.TRANSACTION_CATEGORY_CODE, TransactionCategoryCodeEnum.OPENING_BALANCE_OFFSET_ASSETS.getCode());
+		transactionCategorymap3.put(CommonColumnConstants.TRANSACTION_CATEGORY_CODE, TransactionCategoryCodeEnum.PETTY_CASH.getCode());
+		transactionCategorymap4.put(CommonColumnConstants.TRANSACTION_CATEGORY_CODE, TransactionCategoryCodeEnum.EMPLOYEE_REIMBURSEMENT.getCode());
 		ChartOfAccount chartOfAccount=chartOfAccountService.findByPK(7);
 		transactionCategorymap5.put("chartOfAccount", chartOfAccount);
 		List<TransactionCategory> transactionCategories1=transactionCategoryService.findByAttributes(transactionCategorymap1);

--- a/apps/backend/src/main/java/com/simpleaccounts/dao/impl/bankaccount/TransactionDaoImpl.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/dao/impl/bankaccount/TransactionDaoImpl.java
@@ -99,7 +99,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 		TypedQuery<Transaction> query = getEntityManager().createQuery(
 				"SELECT t FROM Transaction t WHERE t.transactionDate <= :transactionDate and t.transactionId < :transactionId and t.deleteFlag = false and t.bankAccount.bankAccountId = :bankAccountId ORDER BY t.transactionDate DESC",
 				Transaction.class);
-		query.setParameter("transactionDate", transaction.getTransactionDate());
+		query.setParameter(CommonColumnConstants.TRANSACTION_DATE, transaction.getTransactionDate());
 		query.setParameter(BankAccountConstant.BANK_ACCOUNT_ID, transaction.getBankAccount().getBankAccountId());
 		query.setParameter("transactionId", transaction.getTransactionId());
 		List<Transaction> transactionList = query.getResultList();
@@ -114,7 +114,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 		TypedQuery<Transaction> query = getEntityManager().createQuery(
 				"SELECT t FROM Transaction t WHERE t.transactionDate > :transactionDate and t.deleteFlag = false and t.bankAccount.bankAccountId = :bankAccountId ORDER BY t.transactionDate ASC",
 				Transaction.class);
-		query.setParameter("transactionDate", transaction.getTransactionDate());
+		query.setParameter(CommonColumnConstants.TRANSACTION_DATE, transaction.getTransactionDate());
 		query.setParameter(BankAccountConstant.BANK_ACCOUNT_ID, transaction.getBankAccount().getBankAccountId());
 		List<Transaction> transactionList = query.getResultList();
 		if (transactionList != null && !transactionList.isEmpty()) {
@@ -561,7 +561,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 		TypedQuery<Long> query = getEntityManager().createQuery(queryBuilder.toString(),
 				Long.class);
 		query.setParameter(BankAccountConstant.BANK_ACCOUNT_ID, bankId);
-		query.setParameter("endDate", endDate);
+		query.setParameter(CommonColumnConstants.END_DATE, endDate);
 		if(startDate != null)
 			query.setParameter("startDate", startDate);
 		long result = query.getSingleResult();
@@ -575,7 +575,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 				"WHERE t.bankAccount.bankAccountId = :bankAccountId and t.transactionDate <=:endDate order by t.transactionDate ASC");
 		TypedQuery<Transaction> query = getEntityManager().createQuery(queryBuilder.toString(),	Transaction.class);
 		query.setParameter(BankAccountConstant.BANK_ACCOUNT_ID, bankId);
-		query.setParameter("endDate", reconcileDate);
+		query.setParameter(CommonColumnConstants.END_DATE, reconcileDate);
 		List<Transaction> transactionList = query.getResultList();
 		return (transactionList!=null && transactionList.size()>0)?transactionList.get(0).getTransactionDate():null;
 	}
@@ -587,7 +587,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 				.append("' WHERE t.bankAccount.bankAccountId = :bankAccountId and t.transactionDate <= :endDate");
 		Query query = getEntityManager().createQuery(queryBuilder.toString());
 		query.setParameter(BankAccountConstant.BANK_ACCOUNT_ID, bankId);
-		query.setParameter("endDate", reconcileDate.plusHours(23).plusMinutes(59));
+		query.setParameter(CommonColumnConstants.END_DATE, reconcileDate.plusHours(23).plusMinutes(59));
 		query.executeUpdate();
 		return "update query successful";
 	}
@@ -596,7 +596,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 				"WHERE t.bankAccount.bankAccountId = :bankAccountId and t.transactionDate <=:endDate order by t.transactionDate DESC,t.transactionId DESC");
 		TypedQuery<Transaction> query = getEntityManager().createQuery(queryBuilder.toString(),	Transaction.class);
 		query.setParameter(BankAccountConstant.BANK_ACCOUNT_ID, bankId);
-		query.setParameter("endDate", reconcileDate);
+		query.setParameter(CommonColumnConstants.END_DATE, reconcileDate);
 		query.setMaxResults(1);
 		List<Transaction> transactionList = query.getResultList();
 		return closingBalance.floatValue() == transactionList.get(0).getCurrentBalance().floatValue();
@@ -608,7 +608,7 @@ public class TransactionDaoImpl extends AbstractDao<Integer, Transaction> implem
 				"WHERE t.bankAccount = :bankAccount and t.transactionDate =:transactionDate and t.transactionAmount=:transactionAmount and t.transactionDescription=:transactionDescription and t.deleteFlag=false");
 		TypedQuery<Transaction> query = getEntityManager().createQuery(queryBuilder.toString(),	Transaction.class);
 		query.setParameter("bankAccount",bankAccount);
-		query.setParameter("transactionDate", transactionDate);
+		query.setParameter(CommonColumnConstants.TRANSACTION_DATE, transactionDate);
 		query.setParameter("transactionAmount", transactionAmount);
 		query.setParameter("transactionDescription",transactionDescription);
 		List<Transaction> transactionList = query.getResultList();

--- a/apps/backend/src/main/java/com/simpleaccounts/helper/ExpenseRestHelper.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/helper/ExpenseRestHelper.java
@@ -336,11 +336,11 @@ public class ExpenseRestHelper {
 		journal.setJournalDate(expense.getExpenseDate());
 		journal.setTransactionDate(expense.getExpenseDate());
 		if (expense.getBankAccount()!=null){
-			journal.setDescription("Company Expense");
+			journal.setDescription(CommonColumnConstants.COMPANY_EXPENSE);
 		}
 		else {
 			if(expense.getPayMode() == PayMode.CASH) {
-				journal.setDescription("Company Expense");
+				journal.setDescription(CommonColumnConstants.COMPANY_EXPENSE);
 			}else {
 				TransactionCategory transactionCategory = transactionCategoryService.findByPK(Integer.parseInt(expense.getPayee()));
 				journal.setDescription(transactionCategory.getTransactionCategoryName());
@@ -396,10 +396,10 @@ public class ExpenseRestHelper {
 			expenseModel.setExpenseVatAmount(entity.getExpenseVatAmount());
 			expenseModel.setExpenseStatus(ExpenseStatusEnum.getExpenseStatusByValue(entity.getStatus()));
 			if (entity.getBankAccount()!=null){
-				expenseModel.setPayee("Company Expense");
+				expenseModel.setPayee(CommonColumnConstants.COMPANY_EXPENSE);
 			}
-			else if (entity.getPayMode() == PayMode.CASH && entity.getPayee().equals("Company Expense")){
-					expenseModel.setPayee("Company Expense");
+			else if (entity.getPayMode() == PayMode.CASH && entity.getPayee().equals(CommonColumnConstants.COMPANY_EXPENSE)){
+					expenseModel.setPayee(CommonColumnConstants.COMPANY_EXPENSE);
 				}
 		else {
 					TransactionCategory transactionCategory = transactionCategoryService.findByPK(Integer.parseInt(entity.getPayee()));
@@ -481,8 +481,8 @@ public class ExpenseRestHelper {
 				expenseModel.setExpenseId(expense.getExpenseId());
 				expenseModel.setBankGenerated(expense.getBankGenerated());
 				if (expense.getPayee()!=null){
-					if(expense.getPayee() != null && expense.getPayee().equalsIgnoreCase("Company Expense")){
-						expenseModel.setPayee("Company Expense");
+					if(expense.getPayee() != null && expense.getPayee().equalsIgnoreCase(CommonColumnConstants.COMPANY_EXPENSE)){
+						expenseModel.setPayee(CommonColumnConstants.COMPANY_EXPENSE);
 					}
 					else {
 						TransactionCategory payeeTransactionCategory=transactionCategoryService.findByPK(Integer.parseInt(expense.getPayee()));
@@ -648,15 +648,15 @@ public class ExpenseRestHelper {
 		journal.setJournalDate(expense.getExpenseDate());
 		journal.setTransactionDate(expense.getExpenseDate());
 		journal.setTransactionDate(expense.getExpenseDate());
-		journal.setDescription("Reversal of journal entry against Expense No:-"+expense.getExpenseNumber());
+		journal.setDescription(CommonColumnConstants.REVERSAL_JOURNAL_EXPENSE_PREFIX + expense.getExpenseNumber());
 		if (expense.getBankAccount()!=null){
-			journal.setDescription("Reversal of journal entry against Expense No:-"+expense.getExpenseNumber());
+			journal.setDescription(CommonColumnConstants.REVERSAL_JOURNAL_EXPENSE_PREFIX + expense.getExpenseNumber());
 		}
 		else {
 			if(expense.getPayMode() == PayMode.CASH) {
-				journal.setDescription("Reversal of journal entry against Expense No:-"+expense.getExpenseNumber());
+				journal.setDescription(CommonColumnConstants.REVERSAL_JOURNAL_EXPENSE_PREFIX + expense.getExpenseNumber());
 			}else {
-				journal.setDescription("Reversal of journal entry against Expense No:-"+expense.getExpenseNumber());
+				journal.setDescription(CommonColumnConstants.REVERSAL_JOURNAL_EXPENSE_PREFIX + expense.getExpenseNumber());
 			}
 		}
 		return journal;

--- a/apps/backend/src/main/java/com/simpleaccounts/rest/AbstractDoubleEntryRestController.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/rest/AbstractDoubleEntryRestController.java
@@ -1,6 +1,7 @@
 package com.simpleaccounts.rest;
 
 import com.simpleaccounts.aop.LogRequest;
+import com.simpleaccounts.constant.CommonColumnConstants;
 import com.simpleaccounts.constant.PostingReferenceTypeEnum;
 import com.simpleaccounts.constant.CommonStatusEnum;
 import com.simpleaccounts.constant.ExpenseStatusEnum;
@@ -278,7 +279,7 @@ public abstract class AbstractDoubleEntryRestController {
 			if (journal != null) {
 				journalService.persist(journal);
 				Expense expense = expenseService.findByPK(postingRequestModel.getPostingRefId());
-				if (expense.getPayee().equalsIgnoreCase("Company Expense")){
+				if (expense.getPayee().equalsIgnoreCase(CommonColumnConstants.COMPANY_EXPENSE)){
 				TransactionExpenses transactionExpenses =  transactionExpensesRepository.findByExpense(expense);
 				transactionExpensesService.delete(transactionExpenses);
 				Transaction transaction = transactionService.findByPK(transactionExpenses.getTransaction().getTransactionId());

--- a/apps/backend/src/main/java/com/simpleaccounts/rest/currencycontroller/CurrencyController.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/rest/currencycontroller/CurrencyController.java
@@ -178,7 +178,7 @@ public class CurrencyController {
 	@Transactional(rollbackFor = Exception.class)
 	@ApiOperation(value = "Update Currency by Currency Code", response = Currency.class)
 	@PutMapping(value = "/{currencyCode}")
-	public ResponseEntity<?> editCurrency(@RequestBody CurrencyDTO currencyDTO,
+	public ResponseEntity<Object> editCurrency(@RequestBody CurrencyDTO currencyDTO,
 			@RequestParam("currencyCode") Integer currencyCode, HttpServletRequest request) {
 		try {
 			Currency existingCurrency = currencyService.findByPK(currencyCode);
@@ -209,7 +209,7 @@ public class CurrencyController {
 	@Transactional(rollbackFor = Exception.class)
 	@ApiOperation(value = "Delete Currency by Currency Code", response = Currency.class)
 	@DeleteMapping(value = "/{currencyCode}")
-	public ResponseEntity<?> deleteCurrency(@RequestParam("currencyCode") Integer currencyCode,
+	public ResponseEntity<Object> deleteCurrency(@RequestParam("currencyCode") Integer currencyCode,
 			HttpServletRequest request) {
 		try {
 			SimpleAccountsMessage message = null;

--- a/apps/backend/src/main/java/com/simpleaccounts/rest/detailedgeneralledgerreport/DetailedGeneralLedgerRestHelper.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/rest/detailedgeneralledgerreport/DetailedGeneralLedgerRestHelper.java
@@ -17,6 +17,7 @@ import com.simpleaccounts.service.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.simpleaccounts.constant.CommonColumnConstants;
 import com.simpleaccounts.constant.PostingReferenceTypeEnum;
 import com.simpleaccounts.entity.bankaccount.Transaction;
 import com.simpleaccounts.service.bankaccount.TransactionService;
@@ -265,7 +266,7 @@ public class DetailedGeneralLedgerRestHelper {
 								} else if (expense.getEmployee() != null) {
 									model.setName(expense.getEmployee().getFirstName() + " " + expense.getEmployee().getLastName());
 								} else {
-									if (expense.getPayee() != null && expense.getPayee().equalsIgnoreCase("Company Expense"))
+									if (expense.getPayee() != null && expense.getPayee().equalsIgnoreCase(CommonColumnConstants.COMPANY_EXPENSE))
 										model.setName(expense.getPayee());
 									else {
 										TransactionCategory transactionCategory = transactionCategoryService.findByPK(Integer.parseInt(expense.getPayee()));

--- a/apps/backend/src/main/java/com/simpleaccounts/rest/transactioncontroller/TransactionRestController.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/rest/transactioncontroller/TransactionRestController.java
@@ -1873,7 +1873,7 @@ public class TransactionRestController {
 		}
 		else
 		{
-			expenseBuilder.payee("Company Expense");
+			expenseBuilder.payee(CommonColumnConstants.COMPANY_EXPENSE);
 		}
 		if (model.getDate() != null) {
 			LocalDate transactionDate = Instant.ofEpochMilli(model.getDate().getTime())


### PR DESCRIPTION
## Summary
- Replace duplicated "Company Expense" string literals with `COMPANY_EXPENSE` constant
- Replace duplicated "Reversal of journal entry against Expense No:-" with `REVERSAL_JOURNAL_EXPENSE_PREFIX` constant  
- Replace `ResponseEntity<?>` wildcard types with `ResponseEntity<Object>` in CurrencyController

## Changes
- **CommonColumnConstants.java**: Added `COMPANY_EXPENSE` and `REVERSAL_JOURNAL_EXPENSE_PREFIX` constants
- **ExpenseRestHelper.java**: Use constants for expense descriptions (7 replacements)
- **AbstractDoubleEntryRestController.java**: Use `COMPANY_EXPENSE` constant
- **DetailedGeneralLedgerRestHelper.java**: Use `COMPANY_EXPENSE` constant
- **TransactionRestController.java**: Use `COMPANY_EXPENSE` constant
- **CurrencyController.java**: Replace wildcard with `Object` in `editCurrency` and `deleteCurrency` return types

## SonarQube Rules Addressed
- **S1192**: Define a constant instead of duplicating string literals
- **S1452**: Remove usage of generic wildcard type

## Test plan
- [x] Backend compiles successfully with `mvn compile`
- [ ] Run existing unit tests
- [ ] Verify SonarQube scan shows reduced issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)