### PR TITLE
fix(backend): resolve sonar reliability issues

### DIFF
--- a/apps/backend/src/main/java/com/simpleaccounts/rest/invoicecontroller/InvoiceRestHelper.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/rest/invoicecontroller/InvoiceRestHelper.java
@@ -261,17 +261,19 @@ public class InvoiceRestHelper {
 				lineItem.setCreatedBy(userId);
 				lineItem.setCreatedDate(LocalDateTime.now());
 				lineItem.setDeleteFlag(false);
-				lineItem.setQuantity(model.getQuantity());
-				lineItem.setDescription(model.getDescription());
-				lineItem.setUnitPrice(model.getUnitPrice());
-				lineItem.setSubTotal(model.getSubTotal());
-				if(model.getUnitType()!=null)
-					lineItem.setUnitType(model.getUnitType());
-				if(model.getUnitTypeId()!=null)
-					lineItem.setUnitTypeId(unitTypesRepository.findById(model.getUnitTypeId()).get());
-				if (model.getExciseTaxId()!=null){
-					lineItem.setExciseCategory(exciseTaxService.getExciseTax(model.getExciseTaxId()));
-				}
+					lineItem.setQuantity(model.getQuantity());
+					lineItem.setDescription(model.getDescription());
+					lineItem.setUnitPrice(model.getUnitPrice());
+					lineItem.setSubTotal(model.getSubTotal());
+					if(model.getUnitType()!=null)
+						lineItem.setUnitType(model.getUnitType());
+					if(model.getUnitTypeId()!=null)
+						lineItem.setUnitTypeId(unitTypesRepository.findById(model.getUnitTypeId())
+								.orElseThrow(() -> new IllegalArgumentException(
+										"Invalid unitTypeId: " + model.getUnitTypeId())));
+					if (model.getExciseTaxId()!=null){
+						lineItem.setExciseCategory(exciseTaxService.getExciseTax(model.getExciseTaxId()));
+					}
 				if (model.getExciseAmount()!=null){
 					lineItem.setExciseAmount(model.getExciseAmount());
 				}

--- a/apps/backend/src/main/java/com/simpleaccounts/utils/FileHelper.java
+++ b/apps/backend/src/main/java/com/simpleaccounts/utils/FileHelper.java
@@ -20,14 +20,12 @@ import javax.activation.FileDataSource;
 import javax.mail.BodyPart;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMultipart;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
+	import javax.mail.internet.MimeMultipart;
+	import lombok.Getter;
+	import lombok.Setter;
+	import lombok.extern.slf4j.Slf4j;
+	import org.springframework.stereotype.Component;
+	import org.springframework.web.multipart.MultipartFile;
 
 /**
  *
@@ -35,11 +33,9 @@ import org.springframework.web.multipart.MultipartFile;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class FileHelper {
 
-	 @Value("resources/migrationuploadedfiles/")
-	private final String basePath;
+	private final String basePath = "resources/migrationuploadedfiles/";
 
 	@Getter @Setter
 	public static String rootPath;

--- a/apps/backend/src/test/java/com/simpleaccounts/dao/impl/RoleModuleRelationDaoImplTest.java
+++ b/apps/backend/src/test/java/com/simpleaccounts/dao/impl/RoleModuleRelationDaoImplTest.java
@@ -268,11 +268,11 @@ class RoleModuleRelationDaoImplTest {
             .thenReturn(relations);
 
         // Act
-        List<RoleModuleRelation> result = roleModuleRelationDao.getRoleModuleRelationByRoleCode(roleCode);
+	        List<RoleModuleRelation> result = roleModuleRelationDao.getRoleModuleRelationByRoleCode(roleCode);
 
-        // Assert
-        assertThat(result).allMatch(r -> r.getRole().getRoleCode().equals(roleCode));
-    }
+	        // Assert
+	        assertThat(result).hasSize(relations.size()).allMatch(r -> r.getRole().getRoleCode().equals(roleCode));
+	    }
 
     @Test
     @DisplayName("Should return single relation when role has one module")

--- a/apps/backend/src/test/java/com/simpleaccounts/service/impl/ExpenseServiceImplTest.java
+++ b/apps/backend/src/test/java/com/simpleaccounts/service/impl/ExpenseServiceImplTest.java
@@ -220,23 +220,25 @@ class ExpenseServiceImplTest {
 
         @Test
         @DisplayName("Should set credit flag to false for all expenses")
-        void getExpensesForReportSetsCreditFlagFalse() {
-            // Arrange
-            Date startDate = new Date();
-            Date endDate = new Date();
-            List<Object[]> rows = new ArrayList<>();
-            List<BankAccountTransactionReportModel> models = createReportModels(2);
+	        void getExpensesForReportSetsCreditFlagFalse() {
+	            // Arrange
+	            Date startDate = new Date();
+	            Date endDate = new Date();
+	            List<Object[]> rows = new ArrayList<>();
+	            List<BankAccountTransactionReportModel> models = createReportModels(2);
 
             when(expenseDao.getExpenses(startDate, endDate)).thenReturn(rows);
             when(util.convertToTransactionReportModel(rows)).thenReturn(models);
 
             // Act
-            List<BankAccountTransactionReportModel> result = expenseService.getExpensesForReport(startDate, endDate);
+	            List<BankAccountTransactionReportModel> result = expenseService.getExpensesForReport(startDate, endDate);
 
-            // Assert
-            assertThat(result).allSatisfy(model -> assertThat(model.isCredit()).isFalse());
-        }
-    }
+	            // Assert
+	            assertThat(result)
+	                .hasSize(models.size())
+	                .allSatisfy(model -> assertThat(model.isCredit()).isFalse());
+	        }
+	    }
 
     @Nested
     @DisplayName("deleteByIds Tests")

--- a/apps/backend/src/test/java/com/simpleaccounts/service/impl/RoleModuleRelationServiceImplTest.java
+++ b/apps/backend/src/test/java/com/simpleaccounts/service/impl/RoleModuleRelationServiceImplTest.java
@@ -175,11 +175,11 @@ class RoleModuleRelationServiceImplTest {
             .thenReturn(relations);
 
         // Act
-        List<RoleModuleRelation> result = roleModuleRelationService.getRoleModuleRelationByRoleCode(roleCode);
+	        List<RoleModuleRelation> result = roleModuleRelationService.getRoleModuleRelationByRoleCode(roleCode);
 
-        // Assert
-        assertThat(result).allMatch(r -> r.getRole().getRoleCode().equals(roleCode));
-    }
+	        // Assert
+	        assertThat(result).hasSize(relations.size()).allMatch(r -> r.getRole().getRoleCode().equals(roleCode));
+	    }
 
     @Test
     @DisplayName("Should handle large number of module relations")

--- a/apps/backend/src/test/java/com/simpleaccounts/utils/FileHelperTest.java
+++ b/apps/backend/src/test/java/com/simpleaccounts/utils/FileHelperTest.java
@@ -39,7 +39,7 @@ class FileHelperTest {
 
     @BeforeEach
     void setUp() {
-        fileHelper = new FileHelper("resources/migrationuploadedfiles/");
+        fileHelper = new FileHelper();
     }
 
     @AfterEach


### PR DESCRIPTION
Resolves SonarQube RELIABILITY issues (previously 4 open).\n\nChanges:\n- Fix AssertJ list predicate assertions to avoid vacuous passes (java:S5841).\n- Remove redundant constant @Value injection in FileHelper (java:S6804).\n- Avoid Optional#get() when resolving unitTypeId (java:S3655).\n\nSonarQube now reports 0 unresolved issues impacting RELIABILITY after a fresh analysis upload.