### PR TITLE
fix(redux): update thunk consumers to use correct RTK action pattern

### DIFF
--- a/apps/frontend/src/screens/bank_account/screens/create/screen.js
+++ b/apps/frontend/src/screens/bank_account/screens/create/screen.js
@@ -2,16 +2,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Row,
-	Col,
-	Form,
-	FormGroup,
-	Input,
-	Label,
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Input,
+  Label,
 } from 'reactstrap';
 import Select from 'react-select';
 import { LeavePage, Loader } from 'components';
@@ -24,639 +24,601 @@ import * as createBankAccountActions from './actions';
 import DatePicker from 'react-datepicker';
 import * as CurrencyConvertActions from '../../../currencyConvert/actions';
 import './style.scss';
-import {data}  from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 
-const mapStateToProps = (state) => {
-	return {
-		account_type_list: state.bank_account.account_type_list,
-		currency_list: state.bank_account.currency_list,
-		country_list: state.bank_account.country_list,
-		currency_convert_list: state.common.currency_convert_list,
-	};
+const mapStateToProps = state => {
+  return {
+    account_type_list: state.bank_account.account_type_list,
+    currency_list: state.bank_account.currency_list,
+    country_list: state.bank_account.country_list,
+    currency_convert_list: state.common.currency_convert_list,
+  };
 };
 const customStyles = {
-	control: (base, state) => ({
-		...base,
-		borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		boxShadow: state.isFocused ? null : null,
-		'&:hover': {
-			borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		},
-	}),
+  control: (base, state) => ({
+    ...base,
+    borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    boxShadow: state.isFocused ? null : null,
+    '&:hover': {
+      borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    },
+  }),
 };
 
-const mapDispatchToProps = (dispatch) => {
-	return {
-		commonActions: bindActionCreators(CommonActions, dispatch),
-		currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
-		createBankAccountActions: bindActionCreators(
-			createBankAccountActions,
-			dispatch,
-		),
-	};
+const mapDispatchToProps = dispatch => {
+  return {
+    commonActions: bindActionCreators(CommonActions, dispatch),
+    currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
+    createBankAccountActions: bindActionCreators(createBankAccountActions, dispatch),
+  };
 };
 
-let strings = new LocalizedStrings(data)
+let strings = new LocalizedStrings(data);
 class CreateBankAccount extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			// country_list: [
-			// 	{
-			// 		countryCode: 229,
-			// 		countryDescription: null,
-			// 		countryFullName: 'United Arab Emirates - (null)',
-			// 		countryName: 'United Arab Emirates',
-			// 		createdBy: 0,
-			// 		createdDate: '2020-03-21T05:55:16.000+0000',
-			// 		currencyCode: null,
-			// 		defaltFlag: 'Y',
-			// 		deleteFlag: false,
-			// 		isoAlpha3Code: null,
-			// 		lastUpdateBy: null,
-			// 		lastUpdateDate: null,
-			// 		orderSequence: null,
-			// 		versionNumber: 1,
-			// 	},
-			// 	{
-			// 		countryCode: 101,
-			// 		countryDescription: null,
-			// 		countryFullName: 'India  - (null)',
-			// 		countryName: 'India',
-			// 		createdBy: 0,
-			// 		createdDate: '2020-03-21T05:55:16.000+0000',
-			// 		currencyCode: null,
-			// 		defaltFlag: 'Y',
-			// 		deleteFlag: false,
-			// 		isoAlpha3Code: null,
-			// 		lastUpdateBy: null,
-			// 		lastUpdateDate: null,
-			// 		orderSequence: null,
-			// 		versionNumber: 1,
-			// 	},
-			// ],
-			loading: false,
-			createMore: false,
-			disabled: false,
-			initialVals: {
-				account_name: '',
-				currency: 150,
-				opening_balance: '',
-				account_type: 2,
-				bank_name: '',
-				account_number: '',
-				ifsc_code: '',
-				swift_code: '',
-				countrycode: 229,
-				openingDate: new Date(),
-				account_is_for: '',
-				bankId:'',
-				newBankName:''
-			},
-			BankList: [],
-			currentData: {},
-			language: window['localStorage'].getItem('language'),
-			loadingMsg:"Loading...",
-			disableLeavePage:false, 
-		};
-		this.formRef = React.createRef();
-		this.regExAlpha = /^[a-zA-Z ]+$/;
-		this.regEx = /^[0-9\d]+$/;
-		this.regExBoth = /[a-zA-Z0-9_ ]+$/;
-		this.ifscCode = /[a-zA-Z0-9]+$/;
-		this.swiftRegex = /^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
-		this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
-		this.account_for = [
-			{ label: 'Personal', value: 'Personal' },
-			{ label: 'Corporate', value: 'Corporate' },
-		];
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      // country_list: [
+      // 	{
+      // 		countryCode: 229,
+      // 		countryDescription: null,
+      // 		countryFullName: 'United Arab Emirates - (null)',
+      // 		countryName: 'United Arab Emirates',
+      // 		createdBy: 0,
+      // 		createdDate: '2020-03-21T05:55:16.000+0000',
+      // 		currencyCode: null,
+      // 		defaltFlag: 'Y',
+      // 		deleteFlag: false,
+      // 		isoAlpha3Code: null,
+      // 		lastUpdateBy: null,
+      // 		lastUpdateDate: null,
+      // 		orderSequence: null,
+      // 		versionNumber: 1,
+      // 	},
+      // 	{
+      // 		countryCode: 101,
+      // 		countryDescription: null,
+      // 		countryFullName: 'India  - (null)',
+      // 		countryName: 'India',
+      // 		createdBy: 0,
+      // 		createdDate: '2020-03-21T05:55:16.000+0000',
+      // 		currencyCode: null,
+      // 		defaltFlag: 'Y',
+      // 		deleteFlag: false,
+      // 		isoAlpha3Code: null,
+      // 		lastUpdateBy: null,
+      // 		lastUpdateDate: null,
+      // 		orderSequence: null,
+      // 		versionNumber: 1,
+      // 	},
+      // ],
+      loading: false,
+      createMore: false,
+      disabled: false,
+      initialVals: {
+        account_name: '',
+        currency: 150,
+        opening_balance: '',
+        account_type: 2,
+        bank_name: '',
+        account_number: '',
+        ifsc_code: '',
+        swift_code: '',
+        countrycode: 229,
+        openingDate: new Date(),
+        account_is_for: '',
+        bankId: '',
+        newBankName: '',
+      },
+      BankList: [],
+      currentData: {},
+      language: window['localStorage'].getItem('language'),
+      loadingMsg: 'Loading...',
+      disableLeavePage: false,
+    };
+    this.formRef = React.createRef();
+    this.regExAlpha = /^[a-zA-Z ]+$/;
+    this.regEx = /^[0-9\d]+$/;
+    this.regExBoth = /[a-zA-Z0-9_ ]+$/;
+    this.ifscCode = /[a-zA-Z0-9]+$/;
+    this.swiftRegex = /^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$/;
+    this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
+    this.account_for = [
+      { label: 'Personal', value: 'Personal' },
+      { label: 'Corporate', value: 'Corporate' },
+    ];
+  }
 
-	componentDidMount = () => {
-		this.initializeData();
-		this.props.createBankAccountActions.getBankList()
-            .then((response) => {
-            	this.setState({bankList:response.data
-            });
+  componentDidMount = () => {
+    this.initializeData();
+    this.props.createBankAccountActions.getBankList().then(response => {
+      this.setState({ bankList: response.data });
+    });
+  };
+
+  initializeData = () => {
+    this.props.createBankAccountActions.getAccountTypeList();
+    this.props.commonActions.getCurrencyConversionList().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        this.setState({
+          initValue: {
+            ...this.state.initValue,
+            ...{
+              currency: action.payload ? parseInt(action.payload[0].currencyCode) : '',
+            },
+          },
+        });
+      }
+    });
+    this.props.createBankAccountActions.getCurrencyList().then(response => {
+      this.setState({
+        initValue: {
+          ...this.state.initValue,
+          ...{
+            currency: response.data ? parseInt(response.data[0].currencyCode) : '',
+          },
+          ...{
+            account_is_for: 'Corporate',
+          },
+        },
+      });
+
+      this.formRef.current.setFieldValue('account_is_for', 'Corporate', true);
+    });
+    this.props.createBankAccountActions.getCountryList();
+  };
+
+  validationCheck = value => {
+    const data = {
+      moduleType: 5,
+      name: value,
+    };
+    this.props.createBankAccountActions.checkValidation(data).then(response => {
+      if (response.data === 'Bank Account Already Exists') {
+        this.setState({
+          exist: true,
+        });
+      } else {
+        this.setState({
+          exist: false,
+        });
+      }
+    });
+  };
+
+  handleChange = (e, name) => {
+    this.setState({
+      currentData: _.set(
+        { ...this.state.currentData },
+        e.target.name && e.target.name !== '' ? e.target.name : name,
+        e.target.type === 'checkbox' ? e.target.checked : e.target.value
+      ),
+    });
+  };
+
+  handleSubmit = (data, resetForm) => {
+    this.setState({ disabled: true });
+    const {
+      account_name,
+      currency,
+      opening_balance,
+      account_type,
+      bank_name,
+      account_number,
+      ifsc_code,
+      swift_code,
+      countrycode,
+      account_is_for,
+      openingDate,
+      bankId,
+      newBankName,
+    } = data;
+    let obj = {
+      bankAccountName: account_name,
+      bankAccountCurrency: currency ? currency : '',
+      openingBalance: opening_balance,
+      openingDate: openingDate ? openingDate : null,
+      bankAccountType: account_type ? account_type : '',
+      bankName: bankId && bankId.label ? bankId.label : '',
+      accountNumber: account_number,
+      ifscCode: ifsc_code,
+      swiftCode: swift_code,
+      bankCountry: countrycode ? countrycode : '',
+      personalCorporateAccountInd: account_is_for ? account_is_for : '',
+      newBankName: newBankName,
+      // bankId:bankId ? bankId : "",
+    };
+    this.setState({
+      loading: true,
+      disableLeavePage: true,
+      loadingMsg: 'Creating New Bank Account...',
+    });
+    this.props.createBankAccountActions
+      .createBankAccount(obj)
+      .then(res => {
+        this.setState({ disabled: false });
+        this.setState({ loading: false });
+        this.props.commonActions.tostifyAlert(
+          'success',
+          res.data ? res.data.message : 'New Bank Account Created Successfully.'
+        );
+        if (this.state.createMore) {
+          this.setState({
+            createMore: false,
+            disableLeavePage: false,
           });
-	};
+          this.initializeData();
+          resetForm(this.state.initialVals);
+        } else {
+          this.props.history.push('/admin/banking/bank-account');
+          this.setState({ loading: false });
+        }
+      })
+      .catch(err => {
+        this.setState({ disabled: false });
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err.data ? err.data.message : 'New Bank Account Created Unsuccessfully'
+        );
+      });
+  };
 
-	initializeData = () => {
-		this.props.createBankAccountActions.getAccountTypeList();
-		this.props.commonActions.getCurrencyConversionList().then((response) => {
-			this.setState({
-				initValue: {
-					...this.state.initValue,
-					...{
-						currency: response.data
-							? parseInt(response.data[0].currencyCode)
-							: '',
-					},
-				},
-			});
-		});
-		this.props.createBankAccountActions.getCurrencyList().then((response) => {
-			this.setState({
-				initValue: {
-					...this.state.initValue,
-					...{
-						currency: response.data
-							? parseInt(response.data[0].currencyCode)
-							: '',
-					},
-					...{
-						account_is_for: 'Corporate',
-					},
-				},
-			});
-		
-			this.formRef.current.setFieldValue('account_is_for', 'Corporate', true);
-		});
-		this.props.createBankAccountActions.getCountryList();
-	};
+  render() {
+    strings.setLanguage(this.state.language);
+    const { account_type_list, currency_list, currency_convert_list, country_list } = this.props;
 
-	validationCheck = (value) => {
-		const data = {
-			moduleType: 5,
-			name: value,
-		};
-		this.props.createBankAccountActions
-			.checkValidation(data)
-			.then((response) => {
-				if (response.data === 'Bank Account Already Exists') {
-					this.setState({
-						exist: true,
-					});
-				} else {
-					this.setState({
-						exist: false,
-					});
-				}
-			});
-	};
-
-	handleChange = (e, name) => {
-		this.setState({
-			currentData: _.set(
-				{ ...this.state.currentData },
-				e.target.name && e.target.name !== '' ? e.target.name : name,
-				e.target.type === 'checkbox' ? e.target.checked : e.target.value,
-			),
-		});
-	};
-
-	handleSubmit = (data, resetForm) => {
-		this.setState({ disabled: true });
-		const {
-			account_name,
-			currency,
-			opening_balance,
-			account_type,
-			bank_name,
-			account_number,
-			ifsc_code,
-			swift_code,
-			countrycode,
-			account_is_for,
-			openingDate,
-			bankId,
-			newBankName
-		} = data;
-		let obj = {
-			bankAccountName: account_name,
-			bankAccountCurrency: currency ? currency : '',
-			openingBalance: opening_balance,
-			openingDate: openingDate ? openingDate : null,
-			bankAccountType: account_type ? account_type : '',
-			bankName: bankId && bankId.label ? bankId.label : "",
-			accountNumber: account_number,
-			ifscCode: ifsc_code,
-			swiftCode: swift_code,
-			bankCountry: countrycode ? countrycode : '',
-			personalCorporateAccountInd: account_is_for ? account_is_for : '',
-			newBankName: newBankName,
-			// bankId:bankId ? bankId : "",
-		};
-		this.setState({ loading:true, disableLeavePage:true, loadingMsg:"Creating New Bank Account..."});
-		this.props.createBankAccountActions
-			.createBankAccount(obj)
-			.then((res) => {
-				this.setState({ disabled: false });
-				this.setState({ loading:false});
-				this.props.commonActions.tostifyAlert(
-					'success',
-					res.data ? res.data.message : 'New Bank Account Created Successfully.',
-				);
-				if (this.state.createMore) {
-					this.setState({
-						createMore: false,
-						disableLeavePage:false,
-					});
-					this.initializeData();
-					resetForm(this.state.initialVals);
-				} else {
-					this.props.history.push('/admin/banking/bank-account');
-					this.setState({ loading:false,});
-					
-				}
-			})
-			.catch((err) => {
-				this.setState({ disabled: false });
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err.data? err.data.message: 'New Bank Account Created Unsuccessfully'
-				);
-			});
-	};
-
-
-	render() {
-		strings.setLanguage(this.state.language);
-		const { account_type_list, currency_list,currency_convert_list, country_list } = this.props;
-
-		const { initialVals ,bankList,loading,loadingMsg} = this.state;
-		return (
-			loading ==true? <Loader loadingMsg={loadingMsg}/> :
-			<div>
-			<div className="create-bank-account-screen">
-				<div className="animated fadeIn">
-					<Row>
-						<Col lg={12} className="mx-auto">
-							<Card>
-								<CardHeader>
-									<Row>
-										<Col lg={12}>
-											<div className="h4 mb-0 d-flex align-items-center">
-												<i className="fas fa-university" />
-												<span className="ml-2">{strings.CreateBankAccount}</span>
-											</div>
-										</Col>
-									</Row>
-								</CardHeader>
-								<CardBody>
-								{loading ? (
-										<Row>
-											<Col lg={12}>
-												<Loader />
-											</Col>
-										</Row>
-									) : (
-									<Row>
-										<Col lg={12}>
-											<Formik
-												initialValues={initialVals}
-												ref={this.formRef}
-												onSubmit={(values, { resetForm }) => {
-													this.handleSubmit(values, resetForm);
-												}}
-												validate={(values) => {
-													let errors = {};
-													if (this.state.exist === true) {
-														errors.account_number =
-															'Account number already exists';
-													}
-													if(!values.openingDate){
-														errors.openingDate='Opening date is required';
-													}
-													if(values.bankId.value === 999 && (values.newBankName === null || values.newBankName === '')){
-														errors.newBankName = 'Bank Name is Required';
-													}
-													return errors;
-												}}
-												validationSchema={Yup.object().shape({
-													account_name: Yup.string()
-														.required('Account name is required')
-														.min(2, 'Account name is too short!'),
-														// .max(, 'Account Name Is Too Long!'),
-													opening_balance: Yup.string().required(
-														'Opening balance is required',
-													),
-													openingDate: Yup.date().required(
-														'Opening date is required',
-													),
-													currency: Yup.string().required(
-														'Currency is required',
-													),
-													account_type: Yup.string().required(
-														'Account type is required',
-													),
-													// bank_name: Yup.string()
-													// 	.required('Bank Name is Required')
-													// 	.min(2, 'Bank Name Is Too Short!')
-													// 	.max(30, 'Bank Name Is Too Long!'),
-													bankId: Yup.string().required('Bank name is required') ,
-													account_number: Yup.string()
-														.required('Account number is required')
-														.min(2, 'Account number is too short!')
-														.max(30, 'Account number is too long!'),
-													account_is_for: Yup.string().required(
-														'Account for is required',
-													),
-													// swift_code: Yup.string().required(
-													// 	'Please Enter Valid Swift Code',
-													// ),
-												})}
-											>
-												{(props) => (
-													<Form onSubmit={props.handleSubmit}>
-														<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="account_name">
-																		<span className="text-danger">* </span>
-																		{strings.AccountName}
-																	</Label>
-																	<Input
-																		type="text"
-																		maxLength="100"
-																		id="account_name"
-																		autoComplete="off"
-																		name="account_name"
-																		placeholder={strings.Enter+strings.AccountName}
-																		value={props.values.account_name}
-																		onChange={(option) => {
-																			if (
-																				option.target.value === '' ||
-																				this.regExAlpha.test(
-																					option.target.value,
-																				)
-																			) {
-																				props.handleChange('account_name')(
-																					option,
-																				);
-																			}
-																		}}
-																		className={
-																			props.errors.account_name &&
-																			props.touched.account_name
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.account_name &&
-																		props.touched.account_name && (
-																			<div className="invalid-feedback">
-																				{props.errors.account_name}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="currency">
-																		<span className="text-danger">* </span>
-																		{strings.Currency}
-																	</Label>
-																	<Select
-																		id="currency"
-																		name="currency"
-																		placeholder={strings.Select+strings.Currency}
-																		options={
-																			currency_convert_list
-																				? selectCurrencyFactory.renderOptions(
-																						'currencyName',
-																						'currencyCode',
-																						currency_convert_list,
-																						'Currency',
-																				  )
-																				: []
-																		}
-																		value={
-																			currency_convert_list &&
-																			selectCurrencyFactory
-																				.renderOptions(
-																					'currencyName',
-																					'currencyCode',
-																					currency_convert_list,
-																					'Currency',
-																				)
-																				.find(
-																					(option) =>
-																						option.value ===
-																						+props.values.currency,
-																				)
-																		}
-																		onChange={(option) => {
-																			if (option && option.value) {
-																				props.handleChange('currency')(
-																					option.value,
-																				);
-																			} else {
-																				props.handleChange('currency')('');
-																			}
-																		}}
-																		className={
-																			props.errors.currency &&
-																			props.touched.currency
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.currency &&
-																		props.touched.currency && (
-																			<div className="invalid-feedback">
-																				{props.errors.currency}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="opening_balance">
-																		<span className="text-danger">* </span>
-																		{strings.OpeningBalance}
-																	</Label>
-																	<Input
-																		type="type"
-																		maxLength="14,2"
-																		id="opening_balance"
-																		autoComplete="off"
-																		name="opening_balance"
-																		placeholder={strings.Enter+strings.OpeningBalance}
-																		value={props.values.opening_balance}
-																		onChange={(option) => {
-																			if (
-																				option.target.value === '' ||
-																				this.regDecimal.test(
-																					option.target.value,
-																				)
-																			) {
-																				props.handleChange('opening_balance')(
-																					option,
-																				);
-																			}
-																		}}
-																		className={
-																			props.errors.opening_balance &&
-																			props.touched.opening_balance
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.opening_balance &&
-																		props.touched.opening_balance && (
-																			<div className="invalid-feedback">
-																				{props.errors.opening_balance}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-														</Row>
-														<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="expense_date">
-																		<span className="text-danger">* </span>
-																		{strings.OpeningDate}
-																	</Label>
-																	<DatePicker
-																		id="date"
-																		name="openingDate"
-																		autoComplete="off"
-																		className={`form-control ${
-																			props.errors.openingDate &&
-																			props.touched.openingDate
-																				? 'is-invalid'
-																				: ''
-																		}`}
-																		popperPlacement="bottom-start"
-																		popperModifiers={{
-																			flip: {
-																				behavior: ['bottom'],
-																			},
-																			preventOverflow: {
-																				enabled: false,
-																			},
-																			hide: {
-																				enabled: false,
-																			},
-																		}}
-																		placeholderText={strings.Select+strings.OpeningDate}
-																		selected={props.values.openingDate}
-																		showMonthDropdown
-																		showYearDropdown
-																		dropdownMode="select"
-																		dateFormat="dd-MM-yyyy"
-																		maxDate={new Date()}
-																		onChange={(value) => {
-																			props.handleChange('openingDate')(value);
-																		}}
-																	/>
-																	{props.errors.openingDate &&
-																		props.touched.openingDate && (
-																			<div className="invalid-feedback">
-																				{props.errors.openingDate.includes("nullable()") ? "Opening date is required" :props.errors.openingDate}
-
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="account_type">
-																		<span className="text-danger">* </span>
-																		{strings.AccountType}
-																	</Label>
-																	<Select
-																		id="account_type"
-																		name="account_type"
-																		autoComplete="off"
-																		options={
-																			account_type_list
-																				? selectOptionsFactory.renderOptions(
-																						'name',
-																						'id',
-																						account_type_list,
-																						'Account Type',
-																				  )
-																				: []
-																		}
-																		value={
-																			account_type_list &&
-																			selectOptionsFactory
-																				.renderOptions(
-																					'name',
-																					'id',
-																					account_type_list,
-																					'Account Type',
-																				)
-																				.find(
-																					(option) =>
-																						option.value ===
-																						+props.values.account_type,
-																				)
-																		}
-																		onChange={(option) => {
-																			if (option && option.value) {
-																				props.handleChange('account_type')(
-																					option.value,
-																				);
-																			} else {
-																				props.handleChange('account_type')('');
-																			}
-																		}}
-																		className={
-																			props.errors.account_type &&
-																			props.touched.account_type
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.account_type &&
-																		props.touched.account_type && (
-																			<div className="invalid-feedback">
-																				{props.errors.account_type}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-														</Row>
-														<hr />
-														<Row>
-														<Col md="4">
-                                                                                                <FormGroup>
-                                                                                                <Label htmlFor="select"><span className="text-danger">* </span> {strings.BankName} </Label>
-                                                                                                    <Select
-
-                                                                                                        options={
-                                                                                                            bankList
-                                                                                                                ? selectOptionsFactory.renderOptions(
-                                                                                                                    'bankName',
-                                                                                                                    'bankId',
-                                                                                                                    bankList,
-                                                                                                                    'Bank',
-                                                                                                                )
-                                                                                                                : []
-                                                                                                        }
-                                                                                                        value={props.values.bankId}
-                                                                                                        onChange={(option) => {
-                                                                                                            if (option && option.value) {
-                                                                                                                props.handleChange('bankId')(option);
-                                                                                                            } else {
-                                                                                                                props.handleChange('bankId')('');
-                                                                                                            }
-                                                                                                        }}
-                                                                                                        placeholder={strings.Select+strings.BankName}
-                                                                                                        id="bankId"
-                                                                                                        name="bankId"
-																										autoComplete="off"
-                                                                                                        className={
-                                                                                                            props.errors.bankId &&
-                                                                                                                props.touched.bankId
-                                                                                                                ? 'is-invalid'
-                                                                                                                : ''
-                                                                                                        }
-                                                                                                    />
-                                                                                                    {props.errors.bankId &&
-                                                                                                        props.touched.bankId && (
-                                                                                                            <div className="invalid-feedback">
-                                                                                                                {props.errors.bankId}
-                                                                                                            </div>
-                                                                                                        )}
-                                                                                                </FormGroup>
-                                                                                            </Col>
-															{/* <Col lg={4}>
+    const { initialVals, bankList, loading, loadingMsg } = this.state;
+    return loading == true ? (
+      <Loader loadingMsg={loadingMsg} />
+    ) : (
+      <div>
+        <div className="create-bank-account-screen">
+          <div className="animated fadeIn">
+            <Row>
+              <Col lg={12} className="mx-auto">
+                <Card>
+                  <CardHeader>
+                    <Row>
+                      <Col lg={12}>
+                        <div className="h4 mb-0 d-flex align-items-center">
+                          <i className="fas fa-university" />
+                          <span className="ml-2">{strings.CreateBankAccount}</span>
+                        </div>
+                      </Col>
+                    </Row>
+                  </CardHeader>
+                  <CardBody>
+                    {loading ? (
+                      <Row>
+                        <Col lg={12}>
+                          <Loader />
+                        </Col>
+                      </Row>
+                    ) : (
+                      <Row>
+                        <Col lg={12}>
+                          <Formik
+                            initialValues={initialVals}
+                            ref={this.formRef}
+                            onSubmit={(values, { resetForm }) => {
+                              this.handleSubmit(values, resetForm);
+                            }}
+                            validate={values => {
+                              let errors = {};
+                              if (this.state.exist === true) {
+                                errors.account_number = 'Account number already exists';
+                              }
+                              if (!values.openingDate) {
+                                errors.openingDate = 'Opening date is required';
+                              }
+                              if (
+                                values.bankId.value === 999 &&
+                                (values.newBankName === null || values.newBankName === '')
+                              ) {
+                                errors.newBankName = 'Bank Name is Required';
+                              }
+                              return errors;
+                            }}
+                            validationSchema={Yup.object().shape({
+                              account_name: Yup.string()
+                                .required('Account name is required')
+                                .min(2, 'Account name is too short!'),
+                              // .max(, 'Account Name Is Too Long!'),
+                              opening_balance: Yup.string().required('Opening balance is required'),
+                              openingDate: Yup.date().required('Opening date is required'),
+                              currency: Yup.string().required('Currency is required'),
+                              account_type: Yup.string().required('Account type is required'),
+                              // bank_name: Yup.string()
+                              // 	.required('Bank Name is Required')
+                              // 	.min(2, 'Bank Name Is Too Short!')
+                              // 	.max(30, 'Bank Name Is Too Long!'),
+                              bankId: Yup.string().required('Bank name is required'),
+                              account_number: Yup.string()
+                                .required('Account number is required')
+                                .min(2, 'Account number is too short!')
+                                .max(30, 'Account number is too long!'),
+                              account_is_for: Yup.string().required('Account for is required'),
+                              // swift_code: Yup.string().required(
+                              // 	'Please Enter Valid Swift Code',
+                              // ),
+                            })}
+                          >
+                            {props => (
+                              <Form onSubmit={props.handleSubmit}>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="account_name">
+                                        <span className="text-danger">* </span>
+                                        {strings.AccountName}
+                                      </Label>
+                                      <Input
+                                        type="text"
+                                        maxLength="100"
+                                        id="account_name"
+                                        autoComplete="off"
+                                        name="account_name"
+                                        placeholder={strings.Enter + strings.AccountName}
+                                        value={props.values.account_name}
+                                        onChange={option => {
+                                          if (
+                                            option.target.value === '' ||
+                                            this.regExAlpha.test(option.target.value)
+                                          ) {
+                                            props.handleChange('account_name')(option);
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.account_name && props.touched.account_name
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.account_name && props.touched.account_name && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.account_name}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="currency">
+                                        <span className="text-danger">* </span>
+                                        {strings.Currency}
+                                      </Label>
+                                      <Select
+                                        id="currency"
+                                        name="currency"
+                                        placeholder={strings.Select + strings.Currency}
+                                        options={
+                                          currency_convert_list
+                                            ? selectCurrencyFactory.renderOptions(
+                                                'currencyName',
+                                                'currencyCode',
+                                                currency_convert_list,
+                                                'Currency'
+                                              )
+                                            : []
+                                        }
+                                        value={
+                                          currency_convert_list &&
+                                          selectCurrencyFactory
+                                            .renderOptions(
+                                              'currencyName',
+                                              'currencyCode',
+                                              currency_convert_list,
+                                              'Currency'
+                                            )
+                                            .find(option => option.value === +props.values.currency)
+                                        }
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('currency')(option.value);
+                                          } else {
+                                            props.handleChange('currency')('');
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.currency && props.touched.currency
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.currency && props.touched.currency && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.currency}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="opening_balance">
+                                        <span className="text-danger">* </span>
+                                        {strings.OpeningBalance}
+                                      </Label>
+                                      <Input
+                                        type="type"
+                                        maxLength="14,2"
+                                        id="opening_balance"
+                                        autoComplete="off"
+                                        name="opening_balance"
+                                        placeholder={strings.Enter + strings.OpeningBalance}
+                                        value={props.values.opening_balance}
+                                        onChange={option => {
+                                          if (
+                                            option.target.value === '' ||
+                                            this.regDecimal.test(option.target.value)
+                                          ) {
+                                            props.handleChange('opening_balance')(option);
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.opening_balance &&
+                                          props.touched.opening_balance
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.opening_balance &&
+                                        props.touched.opening_balance && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.opening_balance}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="expense_date">
+                                        <span className="text-danger">* </span>
+                                        {strings.OpeningDate}
+                                      </Label>
+                                      <DatePicker
+                                        id="date"
+                                        name="openingDate"
+                                        autoComplete="off"
+                                        className={`form-control ${
+                                          props.errors.openingDate && props.touched.openingDate
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
+                                        popperPlacement="bottom-start"
+                                        popperModifiers={{
+                                          flip: {
+                                            behavior: ['bottom'],
+                                          },
+                                          preventOverflow: {
+                                            enabled: false,
+                                          },
+                                          hide: {
+                                            enabled: false,
+                                          },
+                                        }}
+                                        placeholderText={strings.Select + strings.OpeningDate}
+                                        selected={props.values.openingDate}
+                                        showMonthDropdown
+                                        showYearDropdown
+                                        dropdownMode="select"
+                                        dateFormat="dd-MM-yyyy"
+                                        maxDate={new Date()}
+                                        onChange={value => {
+                                          props.handleChange('openingDate')(value);
+                                        }}
+                                      />
+                                      {props.errors.openingDate && props.touched.openingDate && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.openingDate.includes('nullable()')
+                                            ? 'Opening date is required'
+                                            : props.errors.openingDate}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="account_type">
+                                        <span className="text-danger">* </span>
+                                        {strings.AccountType}
+                                      </Label>
+                                      <Select
+                                        id="account_type"
+                                        name="account_type"
+                                        autoComplete="off"
+                                        options={
+                                          account_type_list
+                                            ? selectOptionsFactory.renderOptions(
+                                                'name',
+                                                'id',
+                                                account_type_list,
+                                                'Account Type'
+                                              )
+                                            : []
+                                        }
+                                        value={
+                                          account_type_list &&
+                                          selectOptionsFactory
+                                            .renderOptions(
+                                              'name',
+                                              'id',
+                                              account_type_list,
+                                              'Account Type'
+                                            )
+                                            .find(
+                                              option => option.value === +props.values.account_type
+                                            )
+                                        }
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('account_type')(option.value);
+                                          } else {
+                                            props.handleChange('account_type')('');
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.account_type && props.touched.account_type
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.account_type && props.touched.account_type && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.account_type}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <hr />
+                                <Row>
+                                  <Col md="4">
+                                    <FormGroup>
+                                      <Label htmlFor="select">
+                                        <span className="text-danger">* </span>{' '}
+                                        {strings.BankName}{' '}
+                                      </Label>
+                                      <Select
+                                        options={
+                                          bankList
+                                            ? selectOptionsFactory.renderOptions(
+                                                'bankName',
+                                                'bankId',
+                                                bankList,
+                                                'Bank'
+                                              )
+                                            : []
+                                        }
+                                        value={props.values.bankId}
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('bankId')(option);
+                                          } else {
+                                            props.handleChange('bankId')('');
+                                          }
+                                        }}
+                                        placeholder={strings.Select + strings.BankName}
+                                        id="bankId"
+                                        name="bankId"
+                                        autoComplete="off"
+                                        className={
+                                          props.errors.bankId && props.touched.bankId
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.bankId && props.touched.bankId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.bankId}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  {/* <Col lg={4}>
 																<FormGroup className="mb-3">
 																	<Label htmlFor="bank_name">
 																		<span className="text-danger">* </span>{strings.BankName}
@@ -691,110 +653,102 @@ class CreateBankAccount extends React.Component {
 																		)}
 																</FormGroup>
 															</Col> */}
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="account_number">
-																		<span className="text-danger">* </span>
-																		{strings.AccountNumber}
-																	</Label>
-																	<Input
-																		type="text"
-																		maxLength="25"
-																		id="account_number"
-																		autoComplete="Off"
-																		name="account_number"
-																		placeholder={strings.Enter+strings.AccountNumber}
-																		value={props.values.account_number}
-																	    //onBlur={props.handleBlur('account_number')}
-																		onChange={(option) => {
-																			if (
-																				option.target.value === '' ||
-																				this.regEx.test(option.target.value)
-																			) {
-																				props.handleChange('account_number')(
-																					option,
-																				);
-																			}
-																			this.validationCheck(option.target.value);
-																		}}
-																		className={
-																			props.errors.account_number &&
-																			props.touched.account_number
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.account_number &&
-																		props.touched.account_number && (
-																			<div className="invalid-feedback">
-																				{props.errors.account_number}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="countrycode">{strings.Country}</Label>
-																	<Select
-																		styles={customStyles}
-																		id="countrycode"
-																		name="countrycode"
-																		placeholder={strings.Select+strings.Country}
-																		// getOptionValue={(option) =>
-																		// 	option.countrycode
-																		// }
-																		options={
-																			country_list
-																				? selectOptionsFactory.renderOptions(
-																						'countryName',
-																						'countryCode',
-																						country_list,
-																						'Country',
-																				  )
-																				: []
-																		}
-																		onChange={(option) => {
-																			if (option && option.value) {
-																				props.handleChange('countrycode')(
-																					option.value,
-																				);
-																			} else {
-																				props.handleChange('countrycode')('');
-																			}
-																		}}
-																		value={
-																			country_list &&
-																			selectOptionsFactory
-																				.renderOptions(
-																					'countryName',
-																					'countryCode',
-																					country_list,
-																					'Country',
-																				)
-																				.find(
-																					(option) =>
-																						option.value ===
-																						+props.values.countrycode,
-																				)
-																		}
-																		className={
-																			props.errors.countrycode &&
-																			props.touched.countrycode
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.countrycode &&
-																		props.touched.countrycode && (
-																			<div className="invalid-feedback">
-																				{props.errors.countrycode}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-														</Row>
-														<Row>
-															{/* <Col lg={4}>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="account_number">
+                                        <span className="text-danger">* </span>
+                                        {strings.AccountNumber}
+                                      </Label>
+                                      <Input
+                                        type="text"
+                                        maxLength="25"
+                                        id="account_number"
+                                        autoComplete="Off"
+                                        name="account_number"
+                                        placeholder={strings.Enter + strings.AccountNumber}
+                                        value={props.values.account_number}
+                                        //onBlur={props.handleBlur('account_number')}
+                                        onChange={option => {
+                                          if (
+                                            option.target.value === '' ||
+                                            this.regEx.test(option.target.value)
+                                          ) {
+                                            props.handleChange('account_number')(option);
+                                          }
+                                          this.validationCheck(option.target.value);
+                                        }}
+                                        className={
+                                          props.errors.account_number &&
+                                          props.touched.account_number
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.account_number &&
+                                        props.touched.account_number && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.account_number}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="countrycode">{strings.Country}</Label>
+                                      <Select
+                                        styles={customStyles}
+                                        id="countrycode"
+                                        name="countrycode"
+                                        placeholder={strings.Select + strings.Country}
+                                        // getOptionValue={(option) =>
+                                        // 	option.countrycode
+                                        // }
+                                        options={
+                                          country_list
+                                            ? selectOptionsFactory.renderOptions(
+                                                'countryName',
+                                                'countryCode',
+                                                country_list,
+                                                'Country'
+                                              )
+                                            : []
+                                        }
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('countrycode')(option.value);
+                                          } else {
+                                            props.handleChange('countrycode')('');
+                                          }
+                                        }}
+                                        value={
+                                          country_list &&
+                                          selectOptionsFactory
+                                            .renderOptions(
+                                              'countryName',
+                                              'countryCode',
+                                              country_list,
+                                              'Country'
+                                            )
+                                            .find(
+                                              option => option.value === +props.values.countrycode
+                                            )
+                                        }
+                                        className={
+                                          props.errors.countrycode && props.touched.countrycode
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.countrycode && props.touched.countrycode && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.countrycode}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  {/* <Col lg={4}>
 																<FormGroup className="mb-3">
 																	<Label htmlFor="ifsc_code">
 																		IFSC Code
@@ -850,7 +804,7 @@ class CreateBankAccount extends React.Component {
 																<FormGroup className="mb-3">
 																	<Label htmlFor="swift_code">
 																		{/* <span className="text-danger">* </span> */}
-															{/* 	Swift Code
+                                  {/* 	Swift Code
 																		<i
 																			id="SwiftCodeToolTip"
 																			className="fa fa-question-circle ml-1"
@@ -885,173 +839,162 @@ class CreateBankAccount extends React.Component {
 																		)}
 																</FormGroup>
 															</Col> */}
-														</Row>
-														<Row>
-															{props.values.bankId.value === 999 && (
-																<Col lg={4}>
-																	<FormGroup className="mb-3">
-																	<Label>
-																		<span className="text-danger">* </span>
-																		{strings.AddNewBank}
-																	</Label>
-																	<Input
-																		type="text"
-																		maxLength="25"
-																		id="newBankName"
-																		name="newBankName"
-																		placeholder={`${strings.Enter} ${strings.New} ${strings.BankName}`}
-																		value={props.values.AddNewBank}
-																		onChange={props.handleChange('newBankName')}
-																		className={
-																		props.errors.newBankName && props.touched.newBankName ? 'is-invalid' : ''
-																		}
-																	/>
-																	{props.errors.newBankName && props.touched.newBankName && (
-																		<div className="invalid-feedback">
-																		{props.errors.newBankName}
-																		</div>
-																	)}
-																	</FormGroup>
-																</Col>
-															)}
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="account_is_for">
-																		<span className="text-danger">* </span>
-																		{strings.Accountisfor}
-																	</Label>
-																	<Select
-																		id="account_is_for"
-																		name="account_is_for"
-																		options={
-																			this.account_for
-																				? selectOptionsFactory.renderOptions(
-																						'label',
-																						'value',
-																						this.account_for,
-																						'Account is for',
-																				  )
-																				: []
-																		}
-																		value={
-																			this.account_for &&
-																			selectOptionsFactory
-																				.renderOptions(
-																					'label',
-																					'value',
-																					this.account_for,
-																					'Account is for',
-																				)
-																				.find(
-																					(option) =>
-																						option.value ===
-																						props.values.account_is_for,
-																				)
-																		}
-																		onChange={(option) => {
-																			if (option && option.value) {
-																				props.handleChange('account_is_for')(
-																					option.value,
-																				);
-																			} else {
-																				props.handleChange('account_is_for')(
-																					'',
-																				);
-																			}
-																		}}
-																		className={
-																			props.errors.account_is_for &&
-																			props.touched.account_is_for
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.account_is_for &&
-																		props.touched.account_is_for && (
-																			<div className="invalid-feedback">
-																				{props.errors.account_is_for}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-														</Row>
-														<Row>
-															<Col lg={12}>
-																<FormGroup className="text-right mt-5 form-action-btn">
-																	<Button
-																		type="submit"
-																		name="submit"
-																		color="primary"
-																		className="btn-square mr-3"
-																		disabled={this.state.disabled}
-																		onClick={() => {
-																			//  added validation popup  msg                                                                
-																			props.handleBlur();
-																			if(props.errors &&  Object.keys(props.errors).length != 0)
-																			this.props.commonActions.fillManDatoryDetails();
-																		}}
-																	>
-																		<i className="fa fa-dot-circle-o"></i>{' '}
-																		{this.state.disabled
-																			? 'Creating...'
-																			: strings.Create}
-																	</Button>
-																	<Button
-																		type="button"
-																		name="button"
-																		color="primary"
-																		className="btn-square mr-3"
-																		disabled={this.state.disabled}
-																		onClick={() => { 
-																			//  added validation popup  msg                                                                
-																			props.handleBlur();
-																			if(props.errors &&  Object.keys(props.errors).length != 0)
-																			this.props.commonActions.fillManDatoryDetails();
-																			this.setState(
-																				{ createMore: true },
-																				() => {
-																					props.handleSubmit();
-																				},
-																			);
-																		}}
-																	>
-																		<i className="fa fa-refresh"></i>
-																		{this.state.disabled
-																			? ' Creating...'
-																			: strings.CreateandMore}
-																	</Button>
-																	<Button
-																		type="button"
-																		name="button"
-																		color="secondary"
-																		className="btn-square"
-																		onClick={() => {
-																			this.props.history.push(
-																				'/admin/banking/bank-account',
-																			);
-																		}}
-																	>
-																		<i className="fa fa-ban"></i> {strings.Cancel}
-																	</Button>
-																</FormGroup>
-															</Col>
-														</Row>
-													</Form>
-												)}
-											</Formik>
-										</Col>
-									</Row>
-									)}
-								</CardBody>
-							</Card>
-						</Col>
-					</Row>
-				</div>
-			</div>
-			{this.state.disableLeavePage ?"":<LeavePage/>}
-			</div>
-		);
-	}
+                                </Row>
+                                <Row>
+                                  {props.values.bankId.value === 999 && (
+                                    <Col lg={4}>
+                                      <FormGroup className="mb-3">
+                                        <Label>
+                                          <span className="text-danger">* </span>
+                                          {strings.AddNewBank}
+                                        </Label>
+                                        <Input
+                                          type="text"
+                                          maxLength="25"
+                                          id="newBankName"
+                                          name="newBankName"
+                                          placeholder={`${strings.Enter} ${strings.New} ${strings.BankName}`}
+                                          value={props.values.AddNewBank}
+                                          onChange={props.handleChange('newBankName')}
+                                          className={
+                                            props.errors.newBankName && props.touched.newBankName
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                        />
+                                        {props.errors.newBankName && props.touched.newBankName && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.newBankName}
+                                          </div>
+                                        )}
+                                      </FormGroup>
+                                    </Col>
+                                  )}
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="account_is_for">
+                                        <span className="text-danger">* </span>
+                                        {strings.Accountisfor}
+                                      </Label>
+                                      <Select
+                                        id="account_is_for"
+                                        name="account_is_for"
+                                        options={
+                                          this.account_for
+                                            ? selectOptionsFactory.renderOptions(
+                                                'label',
+                                                'value',
+                                                this.account_for,
+                                                'Account is for'
+                                              )
+                                            : []
+                                        }
+                                        value={
+                                          this.account_for &&
+                                          selectOptionsFactory
+                                            .renderOptions(
+                                              'label',
+                                              'value',
+                                              this.account_for,
+                                              'Account is for'
+                                            )
+                                            .find(
+                                              option => option.value === props.values.account_is_for
+                                            )
+                                        }
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('account_is_for')(option.value);
+                                          } else {
+                                            props.handleChange('account_is_for')('');
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.account_is_for &&
+                                          props.touched.account_is_for
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.account_is_for &&
+                                        props.touched.account_is_for && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.account_is_for}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={12}>
+                                    <FormGroup className="text-right mt-5 form-action-btn">
+                                      <Button
+                                        type="submit"
+                                        name="submit"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        disabled={this.state.disabled}
+                                        onClick={() => {
+                                          //  added validation popup  msg
+                                          props.handleBlur();
+                                          if (props.errors && Object.keys(props.errors).length != 0)
+                                            this.props.commonActions.fillManDatoryDetails();
+                                        }}
+                                      >
+                                        <i className="fa fa-dot-circle-o"></i>{' '}
+                                        {this.state.disabled ? 'Creating...' : strings.Create}
+                                      </Button>
+                                      <Button
+                                        type="button"
+                                        name="button"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        disabled={this.state.disabled}
+                                        onClick={() => {
+                                          //  added validation popup  msg
+                                          props.handleBlur();
+                                          if (props.errors && Object.keys(props.errors).length != 0)
+                                            this.props.commonActions.fillManDatoryDetails();
+                                          this.setState({ createMore: true }, () => {
+                                            props.handleSubmit();
+                                          });
+                                        }}
+                                      >
+                                        <i className="fa fa-refresh"></i>
+                                        {this.state.disabled
+                                          ? ' Creating...'
+                                          : strings.CreateandMore}
+                                      </Button>
+                                      <Button
+                                        type="button"
+                                        name="button"
+                                        color="secondary"
+                                        className="btn-square"
+                                        onClick={() => {
+                                          this.props.history.push('/admin/banking/bank-account');
+                                        }}
+                                      >
+                                        <i className="fa fa-ban"></i> {strings.Cancel}
+                                      </Button>
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                              </Form>
+                            )}
+                          </Formik>
+                        </Col>
+                      </Row>
+                    )}
+                  </CardBody>
+                </Card>
+              </Col>
+            </Row>
+          </div>
+        </div>
+        {this.state.disableLeavePage ? '' : <LeavePage />}
+      </div>
+    );
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateBankAccount);

--- a/apps/frontend/src/screens/bank_account/screens/transactions/screen.js
+++ b/apps/frontend/src/screens/bank_account/screens/transactions/screen.js
@@ -1,6 +1,6 @@
-import React from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import {
   Card,
   CardHeader,
@@ -16,46 +16,40 @@ import {
   DropdownToggle,
   DropdownMenu,
   DropdownItem,
-} from "reactstrap";
-import Select from "react-select";
-import { selectOptionsFactory } from "utils";
-import BootstrapTable from "react-bootstrap-table-next";
-import DatePicker from "react-datepicker";
-import { Loader, ConfirmDeleteModal } from "components";
-import "react-toastify/dist/ReactToastify.css";
-import "bootstrap/dist/css/bootstrap.min.css";
-import "react-bootstrap-table-next/dist/react-bootstrap-table2.min.css";
-import paginationFactory from "react-bootstrap-table2-paginator";
-import "bootstrap-daterangepicker/daterangepicker.css";
-import * as TransactionsActions from "./actions";
-import * as detailBankAccountActions from "./../detail/actions";
-import { CommonActions } from "services/global";
-import { ExplainTrasactionDetail } from "./sections";
-import "./style.scss";
-import { data } from "../../../Language/index";
-import LocalizedStrings from "react-localization";
-import * as transactionDetailActions from "../transactions/screens/detail/actions";
-import { Suspense, lazy } from "react";
-import Getbyid from "./sections/transactiondetails";
+} from 'reactstrap';
+import Select from 'react-select';
+import { selectOptionsFactory } from 'utils';
+import BootstrapTable from 'react-bootstrap-table-next';
+import DatePicker from 'react-datepicker';
+import { Loader, ConfirmDeleteModal } from 'components';
+import 'react-toastify/dist/ReactToastify.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
+import paginationFactory from 'react-bootstrap-table2-paginator';
+import 'bootstrap-daterangepicker/daterangepicker.css';
+import * as TransactionsActions from './actions';
+import * as detailBankAccountActions from './../detail/actions';
+import { CommonActions } from 'services/global';
+import { ExplainTrasactionDetail } from './sections';
+import './style.scss';
+import { data } from '../../../Language/index';
+import LocalizedStrings from 'react-localization';
+import * as transactionDetailActions from '../transactions/screens/detail/actions';
+import { Suspense, lazy } from 'react';
+import Getbyid from './sections/transactiondetails';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     bank_transaction_list: state.bank_account.bank_transaction_list,
     transaction_type_list: state.bank_account.transaction_type_list,
     universal_currency_list: state.common.universal_currency_list,
   };
 };
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     transactionsActions: bindActionCreators(TransactionsActions, dispatch),
-    detailBankAccountActions: bindActionCreators(
-      detailBankAccountActions,
-      dispatch
-    ),
-    transactionDetailActions: bindActionCreators(
-      transactionDetailActions,
-      dispatch
-    ),
+    detailBankAccountActions: bindActionCreators(detailBankAccountActions, dispatch),
+    transactionDetailActions: bindActionCreators(transactionDetailActions, dispatch),
     commonActions: bindActionCreators(CommonActions, dispatch),
   };
 };
@@ -66,53 +60,53 @@ class BankTransactions extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      language: window["localStorage"].getItem("language"),
+      language: window['localStorage'].getItem('language'),
       loading: true,
       openDeleteModal: false,
       typeOptions: [
-        { value: "Withdrawal", label: "Withdrawal" },
-        { value: "Deposit", label: "Deposit" },
+        { value: 'Withdrawal', label: 'Withdrawal' },
+        { value: 'Deposit', label: 'Deposit' },
       ],
       statusOptions: [
-        { value: "All", label: "All" },
-        { value: "Matched", label: "Matched" },
-        { value: "Manually Added", label: "Manually Added" },
-        { value: "Categorized", label: "Categorized" },
-        { value: "Reconciled", label: "Reconciled" },
-        { value: "Unreconciled", label: "Unreconciled" },
+        { value: 'All', label: 'All' },
+        { value: 'Matched', label: 'Matched' },
+        { value: 'Manually Added', label: 'Manually Added' },
+        { value: 'Categorized', label: 'Categorized' },
+        { value: 'Reconciled', label: 'Reconciled' },
+        { value: 'Unreconciled', label: 'Unreconciled' },
       ],
       actionButtons: {},
       filterData: {
-        transactionDate: "",
-        chartOfAccountId: "",
+        transactionDate: '',
+        chartOfAccountId: '',
       },
-      selectedData: "",
-      selectedreconcileRrefId: "",
-      id: "",
+      selectedData: '',
+      selectedreconcileRrefId: '',
+      id: '',
       dialog: null,
       selectedRowData: {},
       sidebarOpen: false,
       csvData: [],
       view: false,
       selectedRow: null,
-      transactionId: "",
+      transactionId: '',
       openExplainTransactionModal: false,
       rowId: null,
       show: false,
-      bankId: "",
-      openingBalance: "",
-      closingBalance: "",
-      currentBalance: "",
-      bankAccountCurrencySymbol: "",
-      bankAccountCurrencyIsoCode: "",
-      accounName: "",
+      bankId: '',
+      openingBalance: '',
+      closingBalance: '',
+      currentBalance: '',
+      bankAccountCurrencySymbol: '',
+      bankAccountCurrencyIsoCode: '',
+      accounName: '',
       expanded: false,
       page: 1,
-      activeTab: new Array(3).fill("all"),
-      transactionType: "all",
+      activeTab: new Array(3).fill('all'),
+      transactionType: 'all',
       nonexpand: [],
       selected_id_list: [],
-      transation_data: "",
+      transation_data: '',
       res: [],
       showExpandedRow: true,
     };
@@ -125,8 +119,8 @@ class BankTransactions extends React.Component {
     };
 
     this.selectRowProp = {
-      mode: "checkbox",
-      bgColor: "rgba(0,0,0, 0.05)",
+      mode: 'checkbox',
+      bgColor: 'rgba(0,0,0, 0.05)',
       clickToSelect: true,
       onSelectAll: this.onSelectAll,
     };
@@ -136,10 +130,8 @@ class BankTransactions extends React.Component {
   getnewbackdetils = () => {
     if (this.props.location.state && this.props.location.state.bankAccountId) {
       this.props.detailBankAccountActions
-        .getBankAccountByID(
-          this.props.location.state.bankAccountId
-        )
-        .then((res) => {
+        .getBankAccountByID(this.props.location.state.bankAccountId)
+        .then(res => {
           this.setState({
             bankAccountCurrencySymbol: res.bankAccountCurrencySymbol,
             bankAccountCurrencyIsoCode: res.bankAccountCurrencyIsoCode,
@@ -150,14 +142,14 @@ class BankTransactions extends React.Component {
             transactionCount: res.transactionCount,
           });
         })
-        .catch((err) => {
+        .catch(err => {
           this.props.commonActions.tostifyAlert(
-            "error",
-            err && err.data ? err.data.message : "Something Went Wrong"
+            'error',
+            err && err.data ? err.data.message : 'Something Went Wrong'
           );
-          this.props.history.push("/admin/banking/bank-account");
+          this.props.history.push('/admin/banking/bank-account');
         });
-      this.toggle(0, "all");
+      this.toggle(0, 'all');
       //.this.initializeData();
       this.props.transactionsActions.getTransactionTypeList();
       this.initializeData();
@@ -167,10 +159,8 @@ class BankTransactions extends React.Component {
   componentDidMount = () => {
     if (this.props.location.state && this.props.location.state.bankAccountId) {
       this.props.detailBankAccountActions
-        .getBankAccountByID(
-          this.props.location.state.bankAccountId
-        )
-        .then((res) => {
+        .getBankAccountByID(this.props.location.state.bankAccountId)
+        .then(res => {
           this.setState({
             bankAccountCurrencySymbol: res.bankAccountCurrencySymbol,
             bankAccountCurrencyIsoCode: res.bankAccountCurrencyIsoCode,
@@ -181,18 +171,19 @@ class BankTransactions extends React.Component {
             transactionCount: res.transactionCount,
           });
         })
-        .catch((err) => {
+        .catch(err => {
           this.props.commonActions.tostifyAlert(
-            "error",
-            err && err.data ? err.data.message : "Something Went Wrong"
+            'error',
+            err && err.data ? err.data.message : 'Something Went Wrong'
           );
-          this.props.history.push("/admin/banking/bank-account");
+          this.props.history.push('/admin/banking/bank-account');
         });
-      this.toggle(0, "all");
+      this.toggle(0, 'all');
       //.this.initializeData();
-      this.props.commonActions.getCompanyDetails().then((res) => {
-        if (res.status === 200) {
-          const isRegisteredVat = res.data.isRegisteredVat;
+      this.props.commonActions.getCompanyDetails().then(action => {
+        // Redux Toolkit thunks return action objects
+        if (action && action.type && action.type.includes('fulfilled')) {
+          const isRegisteredVat = action.payload.isRegisteredVat;
 
           this.props.history.replace({
             pathname: this.props.location.pathname,
@@ -203,7 +194,7 @@ class BankTransactions extends React.Component {
           });
 
           this.setState({
-            companyDetails: res.data,
+            companyDetails: action.payload,
             isRegisteredVat: isRegisteredVat,
           });
         }
@@ -228,34 +219,34 @@ class BankTransactions extends React.Component {
       };
       this.props.transactionsActions
         .getTransactionList(postData)
-        .then((res) => {
+        .then(res => {
           const array = [];
           if (res.status === 200) {
             this.setState({
               loading: false,
               transation_data: res.data.data,
             });
-            res.data.data.map((item) => {
-              if (item.creationMode === "POTENTIAL_DUPLICATE") {
+            res.data.data.map(item => {
+              if (item.creationMode === 'POTENTIAL_DUPLICATE') {
                 array.push(item.id);
               }
               this.setState({ nonexpand: array });
             });
           }
         })
-        .catch((err) => {
+        .catch(err => {
           this.props.commonActions.tostifyAlert(
-            "error",
-            err && err.data ? err.data.message : "Something Went Wrong"
+            'error',
+            err && err.data ? err.data.message : 'Something Went Wrong'
           );
           this.setState({ loading: false });
         });
     } else {
-      this.props.history.push("/admin/banking/bank-account");
+      this.props.history.push('/admin/banking/bank-account');
     }
   };
 
-  toggleActionButton = (row) => {
+  toggleActionButton = row => {
     let temp = Object.assign({}, this.state.actionButtons);
     if (temp[parseInt(row, 10)]) {
       temp[parseInt(row, 10)] = false;
@@ -271,11 +262,7 @@ class BankTransactions extends React.Component {
     return (
       <label
         className="mb-0 my-link"
-        onClick={() =>
-          this.props.history.push(
-            "/admin/banking/bank-account/transaction/detail"
-          )
-        }
+        onClick={() => this.props.history.push('/admin/banking/bank-account/transaction/detail')}
       >
         {row.reference_number}
       </label>
@@ -283,29 +270,29 @@ class BankTransactions extends React.Component {
   };
 
   renderTransactionStatus = (cell, row) => {
-    let classname = "";
-    if (row.status === "Explained") {
-      classname = "badge-success";
-    } else if (row.status === "Unexplained") {
-      classname = "badge-danger";
+    let classname = '';
+    if (row.status === 'Explained') {
+      classname = 'badge-success';
+    } else if (row.status === 'Unexplained') {
+      classname = 'badge-danger';
     } else {
-      classname = "badge-primary";
+      classname = 'badge-primary';
     }
     return <span className={`badge ${classname} mb-0`}>{row.status}</span>;
   };
 
   renderreconcileRrefId = (cell, row) => {
-    let classname = "";
-    let value = "";
-    if (row.status === "Explained") {
-      classname = "badge-success";
-      value = "Withdrawal";
-    } else if (row.status === "Unexplained") {
-      classname = "badge-danger";
-      value = "Deposit";
+    let classname = '';
+    let value = '';
+    if (row.status === 'Explained') {
+      classname = 'badge-success';
+      value = 'Withdrawal';
+    } else if (row.status === 'Unexplained') {
+      classname = 'badge-danger';
+      value = 'Deposit';
     } else {
-      classname = "badge-primary";
-      value = "Tax Claim";
+      classname = 'badge-primary';
+      value = 'Tax Claim';
     }
     return <span className={`badge ${classname} mb-0`}>{value}</span>;
   };
@@ -313,43 +300,43 @@ class BankTransactions extends React.Component {
   renderDepositAmount = (cell, row, rowIndex, extraData) => {
     return row.depositeAmount >= 0
       ? row.currencyIsoCode +
-      " " +
-      row.depositeAmount.toLocaleString(navigator.language, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })
-      : "";
+          ' ' +
+          row.depositeAmount.toLocaleString(navigator.language, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })
+      : '';
   };
   renderWithdrawalAmount = (cell, row, rowIndex, extraData) => {
     return row.withdrawalAmount >= 0
       ? row.currencyIsoCode +
-      " " +
-      row.withdrawalAmount.toLocaleString(navigator.language, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })
-      : "";
+          ' ' +
+          row.withdrawalAmount.toLocaleString(navigator.language, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })
+      : '';
   };
   renderRunningAmount = (cell, row) => {
     return row.runningAmount >= 0
       ? row.currencyIsoCode +
-      " " +
-      row.runningAmount.toLocaleString(navigator.language, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })
-      : "";
+          ' ' +
+          row.runningAmount.toLocaleString(navigator.language, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })
+      : '';
   };
 
   renderDueAmount = (cell, row, rowIndex, extraData) => {
     return row.dueAmount >= 0
       ? row.currencyIsoCode +
-      " " +
-      row.dueAmount.toLocaleString(navigator.language, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })
-      : "";
+          ' ' +
+          row.dueAmount.toLocaleString(navigator.language, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })
+      : '';
   };
 
   test(row) {
@@ -374,7 +361,7 @@ class BankTransactions extends React.Component {
     );
   };
 
-  onSizePerPageList = (sizePerPage) => {
+  onSizePerPageList = sizePerPage => {
     if (this.options.sizePerPage !== sizePerPage) {
       this.options.sizePerPage = sizePerPage;
       this.initializeData();
@@ -394,7 +381,7 @@ class BankTransactions extends React.Component {
 
   handleChange = (val, name, reconcile, row, label) => {
     if (!reconcile) {
-      this.setState((prevState) => ({
+      this.setState(prevState => ({
         filterData: {
           ...prevState.filterData,
           [name]: val,
@@ -411,14 +398,13 @@ class BankTransactions extends React.Component {
     this.initializeData();
   };
 
-  closeTransaction = (id) => {
+  closeTransaction = id => {
     const message1 = (
       <text>
         <b>Delete Transaction?</b>
       </text>
     );
-    const message =
-      "This Transaction will be deleted permanently and cannot be recovered.";
+    const message = 'This Transaction will be deleted permanently and cannot be recovered.';
     this.setState({
       dialog: (
         <ConfirmDeleteModal
@@ -432,22 +418,16 @@ class BankTransactions extends React.Component {
     });
   };
 
-  removeTransaction = (id) => {
+  removeTransaction = id => {
     this.removeDialog();
     this.props.transactionsActions
       .deleteTransactionById(id)
-      .then((res) => {
-        this.props.commonActions.tostifyAlert(
-          "success",
-          "Transaction Deleted Successfully"
-        );
+      .then(res => {
+        this.props.commonActions.tostifyAlert('success', 'Transaction Deleted Successfully');
         this.initializeData();
       })
-      .catch((err) => {
-        this.props.commonActions.tostifyAlert(
-          "error",
-          err && err.data ? err.data.message : null
-        );
+      .catch(err => {
+        this.props.commonActions.tostifyAlert('error', err && err.data ? err.data.message : null);
       });
   };
 
@@ -461,12 +441,10 @@ class BankTransactions extends React.Component {
     if (this.state.csvData.length === 0) {
       let obj = {
         paginationDisable: true,
-        id: this.props.location.state
-          ? this.props.location.state.bankAccountId
-          : "",
+        id: this.props.location.state ? this.props.location.state.bankAccountId : '',
         transactionType: this.state.transactionType,
       };
-      this.props.transactionsActions.getTransactionList(obj).then((res) => {
+      this.props.transactionsActions.getTransactionList(obj).then(res => {
         if (res.status === 200) {
           this.setState({ csvData: res.data.data, view: true }, () => {
             setTimeout(() => {
@@ -484,8 +462,8 @@ class BankTransactions extends React.Component {
     this.setState(
       {
         filterData: {
-          transactionDate: "",
-          chartOfAccountId: "",
+          transactionDate: '',
+          chartOfAccountId: '',
         },
       },
       () => {
@@ -494,7 +472,7 @@ class BankTransactions extends React.Component {
     );
   };
 
-  openExplainTransactionModal = (row) => {
+  openExplainTransactionModal = row => {
     this.setState(
       {
         selectedData: row,
@@ -507,7 +485,7 @@ class BankTransactions extends React.Component {
     );
   };
 
-  closeExplainTransactionModal = (res) => {
+  closeExplainTransactionModal = res => {
     this.initializeData();
     const array = [];
     this.setState(() => ({
@@ -535,13 +513,13 @@ class BankTransactions extends React.Component {
     );
   };
 
-  onRowSelect = (row) => {
+  onRowSelect = row => {
     let tempList = [];
     if (row) {
       tempList = Object.assign([], this.state.selected_id_list);
       tempList.push(row);
     } else {
-      this.state.selected_id_list.map((item) => {
+      this.state.selected_id_list.map(item => {
         if (item !== row) {
           tempList.push(item);
         }
@@ -560,18 +538,18 @@ class BankTransactions extends React.Component {
           .changeTransaction(obj)
           .then(() => {
             this.props.commonActions.tostifyAlert(
-              "success",
-              "Transaction status changed successfully"
+              'success',
+              'Transaction status changed successfully'
             );
             this.initializeData();
             this.setState({
               selected_id_list: [],
             });
           })
-          .catch((err) => {
+          .catch(err => {
             this.props.commonActions.tostifyAlert(
-              "error",
-              err && err.data ? err.data.message : "Something Went Wrong"
+              'error',
+              err && err.data ? err.data.message : 'Something Went Wrong'
             );
           });
       }
@@ -579,32 +557,28 @@ class BankTransactions extends React.Component {
   };
 
   statusFormatter = (cell, row, extraData) => {
-    if (row.explinationStatusEnum === "FULL") {
+    if (row.explinationStatusEnum === 'FULL') {
       return <div className="label-info">Explained</div>;
-    } else if (row.explinationStatusEnum === "RECONCILED") {
+    } else if (row.explinationStatusEnum === 'RECONCILED') {
       return <div className="label-success">Reconciled</div>;
-    } else if (row.explinationStatusEnum === "PARTIAL") {
+    } else if (row.explinationStatusEnum === 'PARTIAL') {
       return <div className="label-PartiallyPaid">Partially Explained</div>;
     } else if (
-      row.explinationStatusEnum === "NOT_EXPLAIN" &&
-      row.creationMode !== "POTENTIAL_DUPLICATE"
+      row.explinationStatusEnum === 'NOT_EXPLAIN' &&
+      row.creationMode !== 'POTENTIAL_DUPLICATE'
     ) {
       return <div className="label-danger">Not Explained</div>;
-    } else if (row.creationMode === "POTENTIAL_DUPLICATE") {
+    } else if (row.creationMode === 'POTENTIAL_DUPLICATE') {
       return (
         <div>
           <ButtonDropdown
             isOpen={this.state.actionButtons[row.id]}
-            toggle={(e) => {
+            toggle={e => {
               e.preventDefault();
               this.toggleActionButton(row.id);
             }}
           >
-            <DropdownToggle
-              size="sm"
-              color="primary"
-              className="btn-brand icon"
-            >
+            <DropdownToggle size="sm" color="primary" className="btn-brand icon">
               {this.state.actionButtons[row.id] === true ? (
                 <i className="fas fa-chevron-up" />
               ) : (
@@ -635,7 +609,7 @@ class BankTransactions extends React.Component {
     }
   };
 
-  getbyid = (row) => {
+  getbyid = row => {
     return (
       <>
         <>
@@ -643,7 +617,7 @@ class BankTransactions extends React.Component {
             this.state.response?.data?.map((i, inx) => {
               return (
                 <ExplainTrasactionDetail
-                  closeExplainTransactionModal={(e) => {
+                  closeExplainTransactionModal={e => {
                     this.closeExplainTransactionModal(e);
                   }}
                   bankId={this.props.location.state.bankAccountId}
@@ -656,9 +630,9 @@ class BankTransactions extends React.Component {
         </>
         <>
           {row.explanationIds.length > 0 ||
-            (row.explinationStatusEnum === "PARTIAL" && (
+            (row.explinationStatusEnum === 'PARTIAL' && (
               <ExplainTrasactionDetail
-                closeExplainTransactionModal={(e) => {
+                closeExplainTransactionModal={e => {
                   this.closeExplainTransactionModal(e);
                 }}
                 bankId={this.props.location.state.bankAccountId}
@@ -674,62 +648,50 @@ class BankTransactions extends React.Component {
 
   render() {
     strings.setLanguage(this.state.language);
-    const {
-      loading,
-      statusOptions,
-      filterData,
-      dialog,
-      csvData,
-      view,
-      nonexpand,
-      expanded,
-    } = this.state;
-    const {
-      bank_transaction_list,
-      transaction_type_list,
-      universal_currency_list,
-    } = this.props;
+    const { loading, statusOptions, filterData, dialog, csvData, view, nonexpand, expanded } =
+      this.state;
+    const { bank_transaction_list, transaction_type_list, universal_currency_list } = this.props;
     const columns = [
       {
-        dataField: "transactionDate",
-        text: "Date",
+        dataField: 'transactionDate',
+        text: 'Date',
       },
       {
-        dataField: "description",
-        text: "Description",
+        dataField: 'description',
+        text: 'Description',
       },
       {
-        dataField: "depositeAmount",
-        text: "Deposit Amount",
+        dataField: 'depositeAmount',
+        text: 'Deposit Amount',
         formatter: this.renderDepositAmount,
         formatExtraData: universal_currency_list,
       },
       {
-        dataField: "withdrawalAmount",
-        text: "Withdrawal Amount",
+        dataField: 'withdrawalAmount',
+        text: 'Withdrawal Amount',
         formatter: this.renderWithdrawalAmount,
         formatExtraData: universal_currency_list,
       },
       {
-        dataField: "dueAmount",
-        text: "Due Amount",
+        dataField: 'dueAmount',
+        text: 'Due Amount',
         formatter: this.renderDueAmount,
         formatExtraData: universal_currency_list,
       },
       {
-        dataField: "explinationStatusEnum",
-        text: "Status",
+        dataField: 'explinationStatusEnum',
+        text: 'Status',
         formatter: this.statusFormatter,
         formatExtraData: this.state.actionButtons,
       },
     ];
     const expandRow = {
       onlyOneExpanding: true,
-      renderer: (row) => (
+      renderer: row => (
         <Getbyid
           row={row}
           getbankdetails={this.getnewbackdetils}
-          closeExplainTransactionModal={(e) => {
+          closeExplainTransactionModal={e => {
             this.closeExplainTransactionModal(e);
           }}
           bankAccountId={this.props.location.state.bankAccountId}
@@ -745,12 +707,12 @@ class BankTransactions extends React.Component {
     return (
       <div className="bank-transaction-screen transaction">
         <div className="animated fadeIn">
-          <Card className={this.state.sidebarOpen ? `main-table-panel` : ""}>
+          <Card className={this.state.sidebarOpen ? `main-table-panel` : ''}>
             <CardHeader>
               <Row>
                 <Col>
                   <div className="h4 mb-0 d-flex align-items-center">
-                  <i className="fas fa-university" />
+                    <i className="fas fa-university" />
                     <span className="ml-2">{strings.BankTransactions}</span>
                   </div>
                 </Col>
@@ -758,7 +720,7 @@ class BankTransactions extends React.Component {
                   <Button
                     title="Back"
                     onClick={() => {
-                      this.props.history.push("/admin/banking/bank-account");
+                      this.props.history.push('/admin/banking/bank-account');
                     }}
                     className=" pull-right"
                   >
@@ -789,17 +751,14 @@ class BankTransactions extends React.Component {
                           <h3>
                             {this.state.bankAccountCurrencyIsoCode} &nbsp;
                             {this.state.currentBalance
-                              ? this.state.currentBalance.toLocaleString(
-                                navigator.language,
-                                {
+                              ? this.state.currentBalance.toLocaleString(navigator.language, {
                                   minimumFractionDigits: 2,
                                   maximumFractionDigits: 2,
-                                }
-                              )
-                              : " " +
-                              ZERO.toLocaleString(navigator.language, {
-                                minimumFractionDigits: 2,
-                              })}
+                                })
+                              : ' ' +
+                                ZERO.toLocaleString(navigator.language, {
+                                  minimumFractionDigits: 2,
+                                })}
                           </h3>
                         </Col>
                         <Col lg={3}>
@@ -808,17 +767,14 @@ class BankTransactions extends React.Component {
                           <h3>
                             {this.state.bankAccountCurrencyIsoCode} &nbsp;
                             {this.state.closingBalance
-                              ? this.state.closingBalance.toLocaleString(
-                                navigator.language,
-                                {
+                              ? this.state.closingBalance.toLocaleString(navigator.language, {
                                   minimumFractionDigits: 2,
                                   maximumFractionDigits: 2,
-                                }
-                              )
-                              : " " +
-                              ZERO.toLocaleString(navigator.language, {
-                                minimumFractionDigits: 2,
-                              })}
+                                })
+                              : ' ' +
+                                ZERO.toLocaleString(navigator.language, {
+                                  minimumFractionDigits: 2,
+                                })}
                           </h3>
                         </Col>
                         <Col lg={3}>
@@ -826,17 +782,14 @@ class BankTransactions extends React.Component {
                           <h3>
                             {this.state.bankAccountCurrencyIsoCode} &nbsp;
                             {this.state.openingBalance
-                              ? this.state.openingBalance.toLocaleString(
-                                navigator.language,
-                                {
+                              ? this.state.openingBalance.toLocaleString(navigator.language, {
                                   minimumFractionDigits: 2,
                                   maximumFractionDigits: 2,
-                                }
-                              )
-                              : " " +
-                              ZERO.toLocaleString(navigator.language, {
-                                minimumFractionDigits: 2,
-                              })}
+                                })
+                              : ' ' +
+                                ZERO.toLocaleString(navigator.language, {
+                                  minimumFractionDigits: 2,
+                                })}
                           </h3>
                         </Col>
                       </Row>
@@ -866,17 +819,13 @@ class BankTransactions extends React.Component {
                               color="info"
                               className="btn-square mr-1"
                               onClick={() =>
-                                this.props.history.push(
-                                  "/admin/banking/upload-statement",
-                                  {
-                                    bankAccountId:
-                                      this.props.location.state &&
-                                        this.props.location.state.bankAccountId
-                                        ? this.props.location.state
-                                          .bankAccountId
-                                        : "",
-                                  }
-                                )
+                                this.props.history.push('/admin/banking/upload-statement', {
+                                  bankAccountId:
+                                    this.props.location.state &&
+                                    this.props.location.state.bankAccountId
+                                      ? this.props.location.state.bankAccountId
+                                      : '',
+                                })
                               }
                             >
                               <i className="fa glyphicon glyphicon-export fa-upload mr-1" />
@@ -884,23 +833,19 @@ class BankTransactions extends React.Component {
                             </Button>
                             &nbsp; &nbsp; &nbsp;
                             {this.state.transactionCount > 0 ? (
-                              ""
+                              ''
                             ) : (
                               <Button
                                 color="success"
                                 className="btn-square mr-1"
                                 onClick={() =>
-                                  this.props.history.push(
-                                    "/admin/banking/bank-account/detail",
-                                    {
-                                      bankAccountId:
-                                        this.props.location.state &&
-                                          this.props.location.state.bankAccountId
-                                          ? this.props.location.state
-                                            .bankAccountId
-                                          : "",
-                                    }
-                                  )
+                                  this.props.history.push('/admin/banking/bank-account/detail', {
+                                    bankAccountId:
+                                      this.props.location.state &&
+                                      this.props.location.state.bankAccountId
+                                        ? this.props.location.state.bankAccountId
+                                        : '',
+                                  })
                                 }
                               >
                                 <i className="fas fa-edit mr-1" />
@@ -913,14 +858,13 @@ class BankTransactions extends React.Component {
                               className="btn-square mr-1"
                               onClick={() =>
                                 this.props.history.push(
-                                  "/admin/banking/bank-account/transaction/reconcile",
+                                  '/admin/banking/bank-account/transaction/reconcile',
                                   {
                                     bankAccountId:
                                       this.props.location.state &&
-                                        this.props.location.state.bankAccountId
-                                        ? this.props.location.state
-                                          .bankAccountId
-                                        : "",
+                                      this.props.location.state.bankAccountId
+                                        ? this.props.location.state.bankAccountId
+                                        : '',
                                   }
                                 )
                               }
@@ -1013,9 +957,9 @@ class BankTransactions extends React.Component {
                       <Nav tabs className="pull-left">
                         <NavItem>
                           <NavLink
-                            active={this.state.activeTab[0] === "all"}
+                            active={this.state.activeTab[0] === 'all'}
                             onClick={() => {
-                              this.toggle(0, "all");
+                              this.toggle(0, 'all');
                             }}
                           >
                             {strings.All}
@@ -1023,9 +967,9 @@ class BankTransactions extends React.Component {
                         </NavItem>
                         <NavItem>
                           <NavLink
-                            active={this.state.activeTab[0] === "not_explain"}
+                            active={this.state.activeTab[0] === 'not_explain'}
                             onClick={() => {
-                              this.toggle(0, "not_explain");
+                              this.toggle(0, 'not_explain');
                             }}
                           >
                             {strings.NotExplained}
@@ -1033,11 +977,9 @@ class BankTransactions extends React.Component {
                         </NavItem>
                         <NavItem>
                           <NavLink
-                            active={
-                              this.state.activeTab[0] === "potential_duplicate"
-                            }
+                            active={this.state.activeTab[0] === 'potential_duplicate'}
                             onClick={() => {
-                              this.toggle(0, "potential_duplicate");
+                              this.toggle(0, 'potential_duplicate');
                             }}
                           >
                             {strings.PotentialDuplicate}
@@ -1049,15 +991,14 @@ class BankTransactions extends React.Component {
                         className="btn-square pull-right"
                         onClick={() =>
                           this.props.history.push(
-                            "/admin/banking/bank-account/transaction/create",
+                            '/admin/banking/bank-account/transaction/create',
                             {
                               bankAccountId:
-                                this.props.location.state &&
-                                  this.props.location.state.bankAccountId
+                                this.props.location.state && this.props.location.state.bankAccountId
                                   ? this.props.location.state.bankAccountId
-                                  : "",
+                                  : '',
                               currency: this.props.location.state.currency,
-                              isRegisteredVat: this.props.location.state.isRegisteredVat
+                              isRegisteredVat: this.props.location.state.isRegisteredVat,
                             }
                           )
                         }
@@ -1070,11 +1011,7 @@ class BankTransactions extends React.Component {
                       <BootstrapTable
                         id="myTable"
                         keyField="id"
-                        data={
-                          bank_transaction_list.data
-                            ? bank_transaction_list.data
-                            : []
-                        }
+                        data={bank_transaction_list.data ? bank_transaction_list.data : []}
                         columns={columns}
                         expandRow={expandRow}
                         noDataIndication="There are no records to display."

--- a/apps/frontend/src/screens/bank_account/screens/transactions/screens/create/screen.js
+++ b/apps/frontend/src/screens/bank_account/screens/transactions/screens/create/screen.js
@@ -1,6 +1,6 @@
-import React from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import {
   Card,
   CardHeader,
@@ -12,31 +12,31 @@ import {
   FormGroup,
   Input,
   Label,
-} from "reactstrap";
-import Select from "react-select";
-import DatePicker from "react-datepicker";
-import { Formik, Field } from "formik";
-import * as Yup from "yup";
-import { CommonActions } from "services/global";
+} from 'reactstrap';
+import Select from 'react-select';
+import DatePicker from 'react-datepicker';
+import { Formik, Field } from 'formik';
+import * as Yup from 'yup';
+import { CommonActions } from 'services/global';
 import dayjs from '@/utils/date';
-import * as transactionCreateActions from "./actions";
-import * as transactionActions from "../../actions";
-import * as detailBankAccountActions from "../../../detail/actions";
-import * as AllPayrollActions from "../../../../../payroll_run/actions";
-import * as CurrencyConvertActions from "../../../../../currencyConvert/actions";
-import "react-datepicker/dist/react-datepicker.css";
-import "./style.scss";
-import { data } from "../../../../../Language/index";
-import LocalizedStrings from "react-localization";
-import { selectOptionsFactory, selectCurrencyFactory } from "utils";
-import Switch from "react-switch";
-import { LeavePage, Loader } from "components";
-import { Checkbox } from "@material-ui/core";
-import { defaultState } from "./helpers/defaultstate";
-import { calculateVAT } from "./helpers/calculateVat";
-import { amountFormat } from "./helpers/amountformater";
+import * as transactionCreateActions from './actions';
+import * as transactionActions from '../../actions';
+import * as detailBankAccountActions from '../../../detail/actions';
+import * as AllPayrollActions from '../../../../../payroll_run/actions';
+import * as CurrencyConvertActions from '../../../../../currencyConvert/actions';
+import 'react-datepicker/dist/react-datepicker.css';
+import './style.scss';
+import { data } from '../../../../../Language/index';
+import LocalizedStrings from 'react-localization';
+import { selectOptionsFactory, selectCurrencyFactory } from 'utils';
+import Switch from 'react-switch';
+import { LeavePage, Loader } from 'components';
+import { Checkbox } from '@material-ui/core';
+import { defaultState } from './helpers/defaultstate';
+import { calculateVAT } from './helpers/calculateVat';
+import { amountFormat } from './helpers/amountformater';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     transaction_category_list: state.bank_account.transaction_category_list,
     transaction_type_list: state.bank_account.transaction_type_list,
@@ -52,32 +52,23 @@ const mapStateToProps = (state) => {
     UnPaidPayrolls_List: state.bank_account.UnPaidPayrolls_List,
   };
 };
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     transactionActions: bindActionCreators(transactionActions, dispatch),
     allPayrollActions: bindActionCreators(AllPayrollActions, dispatch),
-    transactionCreateActions: bindActionCreators(
-      transactionCreateActions,
-      dispatch
-    ),
-    currencyConvertActions: bindActionCreators(
-      CurrencyConvertActions,
-      dispatch
-    ),
+    transactionCreateActions: bindActionCreators(transactionCreateActions, dispatch),
+    currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
     commonActions: bindActionCreators(CommonActions, dispatch),
-    detailBankAccountActions: bindActionCreators(
-      detailBankAccountActions,
-      dispatch
-    ),
+    detailBankAccountActions: bindActionCreators(detailBankAccountActions, dispatch),
   };
 };
 const customStyles = {
   control: (base, state) => ({
     ...base,
-    borderColor: state.isFocused ? "#2064d8" : "#c7c7c7",
+    borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
     boxShadow: state.isFocused ? null : null,
-    "&:hover": {
-      borderColor: state.isFocused ? "#2064d8" : "#c7c7c7",
+    '&:hover': {
+      borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
     },
   }),
 };
@@ -86,17 +77,20 @@ let strings = new LocalizedStrings(data);
 class CreateBankTransaction extends React.Component {
   constructor(props) {
     super(props);
-    this.state = defaultState(this.props.location.state?.currency, this.props.location.state?.isRegisteredVat);
+    this.state = defaultState(
+      this.props.location.state?.currency,
+      this.props.location.state?.isRegisteredVat
+    );
 
     this.file_size = 1024000;
     this.supported_format = [
-      "image/png",
-      "image/jpeg",
-      "text/plain",
-      "application/pdf",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      'image/png',
+      'image/jpeg',
+      'text/plain',
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     ];
     this.regEx = /^\d+$/;
     this.regExBoth = /[a-zA-Z0-9]+$/;
@@ -107,16 +101,15 @@ class CreateBankTransaction extends React.Component {
   componentDidMount = () => {
     this.props.transactionActions.getUnPaidPayrollsList();
     this.initializeData();
-    this.props.transactionActions
-      .getCOACList()
-      .then((response) => {
-        this.setState({ COACList: response.data });
-      });
+    this.props.transactionActions.getCOACList().then(response => {
+      this.setState({ COACList: response.data });
+    });
     this.getCorporateTaxList();
 
-    this.props.commonActions.getCompanyDetails().then((res) => {
-      if (res.status === 200) {
-        const isRegisteredVat = res.data.isRegisteredVat;
+    this.props.commonActions.getCompanyDetails().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        const isRegisteredVat = action.payload.isRegisteredVat;
 
         this.props.history.replace({
           pathname: this.props.location.pathname,
@@ -127,7 +120,7 @@ class CreateBankTransaction extends React.Component {
         });
 
         this.setState({
-          companyDetails: res.data,
+          companyDetails: action.payload,
           isRegisteredVat: isRegisteredVat,
         });
       }
@@ -136,29 +129,25 @@ class CreateBankTransaction extends React.Component {
 
   initializeData = () => {
     this.getCompanyCurrency();
-    this.props.commonActions
-      .getCurrencyConversionList()
-      .then((response) => {
-        // Capture response data to avoid stale closure
-        const responseData = response.data;
-        const currencyCode = responseData?.[0]?.currencyCode;
-        
-        this.setState((prevState) => ({
-          initValue: {
-            ...prevState.initValue,
-            ...{
-              currency: currencyCode ? parseInt(currencyCode) : "",
-            },
+    this.props.commonActions.getCurrencyConversionList().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (!(action && action.type && action.type.includes('fulfilled'))) return;
+      // Capture payload data to avoid stale closure
+      const responseData = action.payload;
+      const currencyCode = responseData?.[0]?.currencyCode;
+
+      this.setState(prevState => ({
+        initValue: {
+          ...prevState.initValue,
+          ...{
+            currency: currencyCode ? parseInt(currencyCode) : '',
           },
-        }));
-        if (currencyCode) {
-          this.formRef.current.setFieldValue(
-            "currency",
-            currencyCode,
-            true
-          );
-        }
-      });
+        },
+      }));
+      if (currencyCode) {
+        this.formRef.current.setFieldValue('currency', currencyCode, true);
+      }
+    });
 
     const paginationData = {
       pageNo: '',
@@ -171,15 +160,14 @@ class CreateBankTransaction extends React.Component {
     };
     const postData = { ...paginationData, ...sortingData };
 
-    this.props.transactionCreateActions.getAllPayrollList(postData)
-      .then((res) => {
-        this.setState(
-          {
-            payrolldata: res.data
-          },
-          () => { }
-        );
-      })
+    this.props.transactionCreateActions.getAllPayrollList(postData).then(res => {
+      this.setState(
+        {
+          payrolldata: res.data,
+        },
+        () => {}
+      );
+    });
 
     if (this.props.location.state && this.props.location.state.bankAccountId) {
       // Capture bankAccountId to avoid stale closure
@@ -187,24 +175,22 @@ class CreateBankTransaction extends React.Component {
       this.setState({ id: bankAccountId });
       this.props.detailBankAccountActions
         .getBankAccountByID(bankAccountId)
-        .then((res) => {
+        .then(res => {
           this.setState(
             {
-              date: res.openingDate
-                ? dayjs(res.openingDate).format("MM/DD/YYYY")
-                : "",
+              date: res.openingDate ? dayjs(res.openingDate).format('MM/DD/YYYY') : '',
               reconciledDate: res.lastReconcileDate
-                ? dayjs(res.lastReconcileDate).format("MM/DD/YYYY")
-                : "",
-              bankCurrency: res.bankAccountCurrency ? res : "",
+                ? dayjs(res.lastReconcileDate).format('MM/DD/YYYY')
+                : '',
+              bankCurrency: res.bankAccountCurrency ? res : '',
             },
-            () => { }
+            () => {}
           );
         })
-        .catch((err) => {
+        .catch(err => {
           this.props.commonActions.tostifyAlert(
-            "error",
-            err && err.data ? err.data.message : "Something Went Wrong"
+            'error',
+            err && err.data ? err.data.message : 'Something Went Wrong'
           );
         });
     }
@@ -215,50 +201,54 @@ class CreateBankTransaction extends React.Component {
     let reader = new FileReader();
     let file = e.target.files[0];
     if (file) {
-      reader.onloadend = () => { };
+      reader.onloadend = () => {};
       reader.readAsDataURL(file);
-      props.setFieldValue("attachment", file, true);
+      props.setFieldValue('attachment', file, true);
     }
   };
 
-  getVatReportListForBank = (id) => {
-    this.props.transactionCreateActions
-      .getVatReportListForBank(id)
-      .then((res) => {
-        this.setState({ VATlist: res.data });
-      });
+  getVatReportListForBank = id => {
+    this.props.transactionCreateActions.getVatReportListForBank(id).then(res => {
+      this.setState({ VATlist: res.data });
+    });
   };
   getCorporateTaxList = () => {
-    this.props.transactionActions
-      .getCorporateTaxList()
-      .then((res) => {
-        if (res.status === 200) {
-          let list = [];
-          res.data = res.data && res.data.data.length > 0 ? res.data.data.filter(obj => obj.status === 'Filed') : [];
-          res.data && res.data.length > 0 && res.data.map((obj, index) => {
-            var label = dayjs(obj.startDate).format('DD-MM-YYYY') + ' To ' + dayjs(obj.endDate).format('DD-MM-YYYY')
+    this.props.transactionActions.getCorporateTaxList().then(res => {
+      if (res.status === 200) {
+        let list = [];
+        res.data =
+          res.data && res.data.data.length > 0
+            ? res.data.data.filter(obj => obj.status === 'Filed')
+            : [];
+        res.data &&
+          res.data.length > 0 &&
+          res.data.map((obj, index) => {
+            var label =
+              dayjs(obj.startDate).format('DD-MM-YYYY') +
+              ' To ' +
+              dayjs(obj.endDate).format('DD-MM-YYYY');
             var value = index;
-            list.push({ 'label': label, 'value': value })
-          })
-          this.setState({ corporateTaxList: res.data, ct_taxPeriodList: list });
-        }
-      });
+            list.push({ label: label, value: value });
+          });
+        this.setState({ corporateTaxList: res.data, ct_taxPeriodList: list });
+      }
+    });
   };
-  setCTValues = (value) => {
-    const { corporateTaxList } = this.state
+  setCTValues = value => {
+    const { corporateTaxList } = this.state;
     const report = corporateTaxList ? corporateTaxList.find((obj, index) => index === value) : '';
-    this.formRef.current.setFieldValue("transactionAmount", report.balanceDue, true);
-    this.formRef.current.setFieldValue("balanceDue", report.balanceDue, true);
-    this.formRef.current.setFieldValue("totalAmount", report.taxAmount, true);
-    this.formRef.current.setFieldValue("transactionDate", new Date(report.taxFiledOn), true);
-  }
+    this.formRef.current.setFieldValue('transactionAmount', report.balanceDue, true);
+    this.formRef.current.setFieldValue('balanceDue', report.balanceDue, true);
+    this.formRef.current.setFieldValue('totalAmount', report.taxAmount, true);
+    this.formRef.current.setFieldValue('transactionDate', new Date(report.taxFiledOn), true);
+  };
 
   handleSubmit = (data, resetForm) => {
     this.setState({ disabled: true, loading: true, disableLeavePage: true });
     let bankAccountId =
       this.props.location.state && this.props.location.state.bankAccountId
         ? this.props.location.state.bankAccountId
-        : "";
+        : '';
     let {
       transactionDate,
       description,
@@ -282,18 +272,15 @@ class CreateBankTransaction extends React.Component {
       exchangeRateFromList,
     } = data;
     let formData = new FormData();
-    if (coaCategoryId && (coaCategoryId.value === 10 || coaCategoryId.label === "Expense")) {
+    if (coaCategoryId && (coaCategoryId.value === 10 || coaCategoryId.label === 'Expense')) {
       const list = calculateVAT(transactionAmount, vatId.value, exclusiveVat);
-      transactionAmount = list.transactionAmount
+      transactionAmount = list.transactionAmount;
       this.setState({
         transactionVatAmount: list.transactionVatAmount,
         transactionExpenseAmount: list.transactionExpenseAmount,
-      })
+      });
     }
-    if (
-      coaCategoryId.label === "Sales" ||
-      coaCategoryId.label === "Supplier Invoice"
-    ) {
+    if (coaCategoryId.label === 'Sales' || coaCategoryId.label === 'Supplier Invoice') {
       var result = invoiceIdList.map((o, index) => ({
         id: o.value,
         remainingInvoiceAmount: 0,
@@ -301,197 +288,157 @@ class CreateBankTransaction extends React.Component {
         exchangeRate: exchangeRate,
       }));
 
+      formData.append('explainParamListStr', invoiceIdList ? JSON.stringify(result) : '');
       formData.append(
-        "explainParamListStr",
-        invoiceIdList ? JSON.stringify(result) : ""
-      );
-      formData.append(
-        "explainedInvoiceListString",
+        'explainedInvoiceListString',
         invoiceIdList
           ? JSON.stringify(
-            invoiceIdList.map((i) => {
-              return {
-                invoiceId: i.value,
-                invoiceAmount: i.dueAmount,
-                convertedInvoiceAmount: i.convertedInvoiceAmount,
-                explainedAmount: i.explainedAmount,
-                exchangeRate: i.exchangeRate,
-                partiallyPaid: i.pp,
-                nonConvertedInvoiceAmount: i.explainedAmount / i.exchangeRate,
-                convertedToBaseCurrencyAmount:
-                  i.convertedToBaseCurrencyAmount,
-              };
-            })
-          )
+              invoiceIdList.map(i => {
+                return {
+                  invoiceId: i.value,
+                  invoiceAmount: i.dueAmount,
+                  convertedInvoiceAmount: i.convertedInvoiceAmount,
+                  explainedAmount: i.explainedAmount,
+                  exchangeRate: i.exchangeRate,
+                  partiallyPaid: i.pp,
+                  nonConvertedInvoiceAmount: i.explainedAmount / i.exchangeRate,
+                  convertedToBaseCurrencyAmount: i.convertedToBaseCurrencyAmount,
+                };
+              })
+            )
           : []
       );
       formData.append(
-        "exchangeGainOrLossId",
-        this.setexcessorshortamount().data
-          ? 103
-          : this.setexcessorshortamount().data > 0
-            ? 79
-            : 0
+        'exchangeGainOrLossId',
+        this.setexcessorshortamount().data ? 103 : this.setexcessorshortamount().data > 0 ? 79 : 0
       );
-      formData.append("exchangeGainOrLoss", this.setexcessorshortamount().data);
+      formData.append('exchangeGainOrLoss', this.setexcessorshortamount().data);
     }
     if (
       payrollListIds &&
       expenseCategory.value &&
-      expenseCategory.label === "Salaries and Employee Wages"
+      expenseCategory.label === 'Salaries and Employee Wages'
     ) {
-      var result1 = payrollListIds.map((o) => ({
+      var result1 = payrollListIds.map(o => ({
         payrollId: o.value,
       }));
     }
 
-    formData.append("expenseType", this.state.expenseType);
-    formData.append("bankId ", bankAccountId ? bankAccountId : "");
-    formData.append("date", transactionDate ? transactionDate : "");
-    formData.append("description", description ? description : "");
-    formData.append("amount", transactionAmount ? transactionAmount : "");
+    formData.append('expenseType', this.state.expenseType);
+    formData.append('bankId ', bankAccountId ? bankAccountId : '');
+    formData.append('date', transactionDate ? transactionDate : '');
+    formData.append('description', description ? description : '');
+    formData.append('amount', transactionAmount ? transactionAmount : '');
     formData.append(
-      "coaCategoryId",
+      'coaCategoryId',
       coaCategoryId
         ? coaCategoryId.value && coaCategoryId.value == 100
           ? 10
           : coaCategoryId.value
-        : ""
+        : ''
     );
 
-    formData.append("exchangeRate", exchangeRate);
+    formData.append('exchangeRate', exchangeRate);
 
     if (transactionCategoryId) {
-      formData.append(
-        "transactionCategoryId",
-        transactionCategoryId.value || ""
-      );
+      formData.append('transactionCategoryId', transactionCategoryId.value || '');
     }
-    if (expenseCategory && coaCategoryId.label === "Expense") {
-      formData.append(
-        "expenseCategory",
-        expenseCategory.value || ""
-      );
+    if (expenseCategory && coaCategoryId.label === 'Expense') {
+      formData.append('expenseCategory', expenseCategory.value || '');
     }
-    if (
-      (vatId && coaCategoryId.value === 10) ||
-      (vatId && coaCategoryId.label === "Expense")
-    ) {
-      formData.append("vatId", vatId.value || "");
+    if ((vatId && coaCategoryId.value === 10) || (vatId && coaCategoryId.label === 'Expense')) {
+      formData.append('vatId', vatId.value || '');
       formData.append(
-        "transactionVatAmount",
-        this.state.transactionVatAmount ? this.state.transactionVatAmount : ""
+        'transactionVatAmount',
+        this.state.transactionVatAmount ? this.state.transactionVatAmount : ''
       );
       formData.append(
-        "transactionExpenseAmount",
-        this.state.transactionExpenseAmount
-          ? this.state.transactionExpenseAmount
-          : ""
+        'transactionExpenseAmount',
+        this.state.transactionExpenseAmount ? this.state.transactionExpenseAmount : ''
       );
-      formData.append("currencyName", currencyName ? currencyName : "");
-      formData.append("bankGenerated", true);
-      formData.append("isReverseChargeEnabled", isReverseChargeEnabled);
-      formData.append("exclusiveVat", exclusiveVat);
-      formData.append(
-        "convertedAmount",
-        this.expenceconvert(transactionAmount)
-      );
+      formData.append('currencyName', currencyName ? currencyName : '');
+      formData.append('bankGenerated', true);
+      formData.append('isReverseChargeEnabled', isReverseChargeEnabled);
+      formData.append('exclusiveVat', exclusiveVat);
+      formData.append('convertedAmount', this.expenceconvert(transactionAmount));
     }
     if (
-      (currencyCode && coaCategoryId.label === "Expense") ||
-      coaCategoryId.label === "Sales" ||
-      coaCategoryId.label === "Supplier Invoice"
+      (currencyCode && coaCategoryId.label === 'Expense') ||
+      coaCategoryId.label === 'Sales' ||
+      coaCategoryId.label === 'Supplier Invoice'
     ) {
-      formData.append(
-        "currencyCode",
-        currencyCode.value ? currencyCode.value : currencyCode
-      );
+      formData.append('currencyCode', currencyCode.value ? currencyCode.value : currencyCode);
     }
     if (
-      (customerId &&
-        coaCategoryId.value &&
-        coaCategoryId.label === "Expenses") ||
-      (customerId && coaCategoryId.value && coaCategoryId.label === "Sales")
+      (customerId && coaCategoryId.value && coaCategoryId.label === 'Expenses') ||
+      (customerId && coaCategoryId.value && coaCategoryId.label === 'Sales')
     ) {
-      formData.append("customerId", customerId ? customerId.value : "");
+      formData.append('customerId', customerId ? customerId.value : '');
     }
-    if (vendorId && coaCategoryId.value && coaCategoryId.label === "Expenses") {
-      formData.append("vendorId", vendorId ? vendorId.value : "");
+    if (vendorId && coaCategoryId.value && coaCategoryId.label === 'Expenses') {
+      formData.append('vendorId', vendorId ? vendorId.value : '');
     }
 
-    if (vendorId && coaCategoryId.label === "Supplier Invoice") {
-      formData.append("vendorId", vendorId.value ? vendorId.value : vendorId);
+    if (vendorId && coaCategoryId.label === 'Supplier Invoice') {
+      formData.append('vendorId', vendorId.value ? vendorId.value : vendorId);
     }
-    if (vendorId && coaCategoryId.value && coaCategoryId.label === "Expenses") {
-      formData.append("vatId", vatId ? vatId.value : "");
+    if (vendorId && coaCategoryId.value && coaCategoryId.label === 'Expenses') {
+      formData.append('vatId', vatId ? vatId.value : '');
     }
     if (employeeId) {
-      formData.append("employeeId", employeeId ? employeeId.value : "");
+      formData.append('employeeId', employeeId ? employeeId.value : '');
     }
 
-    formData.append("reference", reference ? reference : "");
+    formData.append('reference', reference ? reference : '');
     if (this.uploadFile?.files?.[0]) {
-      formData.append("attachmentFile", this.uploadFile?.files?.[0]);
+      formData.append('attachmentFile', this.uploadFile?.files?.[0]);
     }
     if (
       payrollListIds &&
       expenseCategory.value &&
-      expenseCategory.label === "Salaries and Employee Wages"
+      expenseCategory.label === 'Salaries and Employee Wages'
     ) {
-      formData.append(
-        "payrollListIds",
-        payrollListIds ? JSON.stringify(result1) : ""
-      );
+      formData.append('payrollListIds', payrollListIds ? JSON.stringify(result1) : '');
     }
-    if (
-      coaCategoryId.label === "VAT Payment" ||
-      coaCategoryId.label === "VAT Claim"
-    ) {
+    if (coaCategoryId.label === 'VAT Payment' || coaCategoryId.label === 'VAT Claim') {
       const info = {
-        ...this.state.VATlist.find((i) => i.id === VATReportId.value),
+        ...this.state.VATlist.find(i => i.id === VATReportId.value),
       };
       delete info.taxFiledOn;
 
-      formData.append(
-        "explainedVatPaymentListString",
-        info ? JSON.stringify([info]) : ""
-      );
+      formData.append('explainedVatPaymentListString', info ? JSON.stringify([info]) : '');
     }
-    if (coaCategoryId.label === "Corporate Tax Payment") {
+    if (coaCategoryId.label === 'Corporate Tax Payment') {
       const report = {
-        ...this.state.corporateTaxList.find((obj, index) => index === this.state.ct_taxPeriod.value),
+        ...this.state.corporateTaxList.find(
+          (obj, index) => index === this.state.ct_taxPeriod.value
+        ),
       };
-      formData.append(
-        "explainedCorporateTaxListString",
-        report ? JSON.stringify([report]) : ""
-      );
+      formData.append('explainedCorporateTaxListString', report ? JSON.stringify([report]) : '');
     }
     this.props.transactionCreateActions
       .createTransaction(formData)
-      .then((res) => {
+      .then(res => {
         if (res.status === 200) {
           resetForm();
-          this.props.commonActions.tostifyAlert(
-            "success",
-            "New Transaction Created Successfully."
-          );
+          this.props.commonActions.tostifyAlert('success', 'New Transaction Created Successfully.');
           if (this.state.createMore) {
             this.setState({
               createMore: false,
               disabled: false,
             });
           } else {
-            this.props.history.push("/admin/banking/bank-account/transaction", {
+            this.props.history.push('/admin/banking/bank-account/transaction', {
               bankAccountId,
               currency: this.props.location.state?.currency,
             });
           }
         }
       })
-      .catch((err) => {
+      .catch(err => {
         this.props.commonActions.tostifyAlert(
-          "error",
-          err && err.data ? err.data.message : "Something Went Wrong"
+          'error',
+          err && err.data ? err.data.message : 'Something Went Wrong'
         );
         this.setState({
           disabled: false,
@@ -501,7 +448,7 @@ class CreateBankTransaction extends React.Component {
       });
   };
 
-  setValue = (value) => {
+  setValue = value => {
     this.setState({
       transactionCategoryList: [],
     });
@@ -509,47 +456,32 @@ class CreateBankTransaction extends React.Component {
 
   totalAmount(option) {
     let totalInvoiceAmount = 0;
-    if (option && option != "") {
-      option.map((row) => {
+    if (option && option != '') {
+      option.map(row => {
         let listData = row.amount;
         totalInvoiceAmount += listData;
       });
 
-      const amount = option.reduce(
-        (totalAmount, invoice) => totalAmount + invoice.amount,
-        0
-      );
+      const amount = option.reduce((totalAmount, invoice) => totalAmount + invoice.amount, 0);
 
-      this.setState(
-        { totalAmount: amount, totalInvoiceAmount: totalInvoiceAmount },
-        () => { }
-      );
+      this.setState({ totalAmount: amount, totalInvoiceAmount: totalInvoiceAmount }, () => {});
     } else {
-      this.setState(
-        { totalAmount: 0, totalInvoiceAmount: totalInvoiceAmount },
-        () => { }
-      );
+      this.setState({ totalAmount: 0, totalInvoiceAmount: totalInvoiceAmount }, () => {});
     }
   }
 
   getExpensesCategoriesList = () => {
     this.props.transactionActions.getExpensesCategoriesList();
-    this.props.transactionActions.getCurrencyList().then((response) => {
+    this.props.transactionActions.getCurrencyList().then(response => {
       this.setState({
         initValue: {
           ...this.state.initValue,
           ...{
-            currencyCode: response.data
-              ? parseInt(response.data[0].currencyCode)
-              : "",
+            currencyCode: response.data ? parseInt(response.data[0].currencyCode) : '',
           },
         },
       });
-      this.formRef.current.setFieldValue(
-        "currency",
-        response.data[0].currencyCode,
-        true
-      );
+      this.formRef.current.setFieldValue('currency', response.data[0].currencyCode, true);
     });
     this.props.transactionActions.getUserForDropdown();
     this.props.transactionActions.getVatList();
@@ -557,19 +489,16 @@ class CreateBankTransaction extends React.Component {
 
   getVendorList = () => {
     this.props.transactionActions.getVendorList(
-      this.props.location.state.bankAccountId
-        ? this.props.location.state.bankAccountId
-        : ""
+      this.props.location.state.bankAccountId ? this.props.location.state.bankAccountId : ''
     );
   };
   getSuggestionInvoicesFotCust = (option, amount) => {
     const data = {
       amount: amount,
       id: option,
-      currency:
-        this.state?.bankCurrency?.bankAccountCurrency
-          ? this.state?.bankCurrency?.bankAccountCurrency
-          : 0,
+      currency: this.state?.bankCurrency?.bankAccountCurrency
+        ? this.state?.bankCurrency?.bankAccountCurrency
+        : 0,
       bankId: this.props.location.state.bankAccountId,
     };
     this.props.transactionActions.getCustomerInvoiceList(data);
@@ -579,21 +508,20 @@ class CreateBankTransaction extends React.Component {
     const data = {
       amount: amount,
       id: option,
-      currency:
-        this.state.bankCurrency?.bankAccountCurrency
-          ? this.state.bankCurrency?.bankAccountCurrency
-          : 0,
+      currency: this.state.bankCurrency?.bankAccountCurrency
+        ? this.state.bankCurrency?.bankAccountCurrency
+        : 0,
       bankId: this.props.location.state.bankAccountId,
     };
     this.props.transactionActions.getVendorInvoiceList(data);
     if (invoice_list === null) {
-      this.formRef.current.setFieldValue("curreancyname", "", true);
-      this.formRef.current.setFieldValue("exchangeRate", "", true);
-      this.formRef.current.setFieldValue("currencyCode", "", true);
+      this.formRef.current.setFieldValue('curreancyname', '', true);
+      this.formRef.current.setFieldValue('exchangeRate', '', true);
+      this.formRef.current.setFieldValue('currencyCode', '', true);
     }
   };
 
-  invoiceIdList = (option) => {
+  invoiceIdList = option => {
     this.setState({
       initValue: {
         ...this.state.initValue,
@@ -602,31 +530,24 @@ class CreateBankTransaction extends React.Component {
         },
       },
     });
-    this.formRef.current.setFieldValue("invoiceIdList", option, true);
+    this.formRef.current.setFieldValue('invoiceIdList', option, true);
   };
   getInvoiceCurrency = (opt, props) => {
     const { customer_invoice_list } = this.props;
 
-    const customerinvoice = customer_invoice_list.data.filter(
-      (item) => item.value === opt.value
-    );
+    const customerinvoice = customer_invoice_list.data.filter(item => item.value === opt.value);
     this.setState(
       {
         invoiceCurrency: customerinvoice?.[0].currencyCode,
         invCurrency: customerinvoice?.[0],
       },
       () => {
-        this.formRef.current.setFieldValue(
-          "currencyCode",
-          customerinvoice?.[0].currencyCode,
-          true
-        );
+        this.formRef.current.setFieldValue('currencyCode', customerinvoice?.[0].currencyCode, true);
 
         this.setCurrency(customerinvoice?.[0].currencyCode);
         // this.setExchange(this.state.bankCurrency.bankAccountCurrency);
       }
     );
-
   };
 
   getVendorInvoiceCurrency = (opt, props) => {
@@ -642,19 +563,14 @@ class CreateBankTransaction extends React.Component {
         // 	props.values.customerId,
         // 	props.values.transactionAmount,
         // )
-        this.formRef.current.setFieldValue(
-          "currencyCode",
-          opt?.[0].currencyCode,
-          true
-        );
+        this.formRef.current.setFieldValue('currencyCode', opt?.[0].currencyCode, true);
 
         this.setCurrency(opt?.[0].currencyCode);
         //this.setExchange(this.state.bankCurrency.bankAccountCurrency);
       }
     );
-
   };
-  payrollList = (option) => {
+  payrollList = option => {
     this.setState({
       initValue: {
         ...this.state.initValue,
@@ -663,49 +579,48 @@ class CreateBankTransaction extends React.Component {
         },
       },
     });
-    this.formRef.current.setFieldValue("payrollListIds", option, true);
+    this.formRef.current.setFieldValue('payrollListIds', option, true);
   };
 
-  getPayrollAmount = (option) => {
-    const amounts = option && option.map((i) => {
-      const startIndex = i.label.indexOf("(");
-      const endIndex = i.label.indexOf(")");
-      const amountString = i.label.slice(startIndex + 1, endIndex);
-      const amount = parseFloat(amountString);
-      return amount;
-    });
+  getPayrollAmount = option => {
+    const amounts =
+      option &&
+      option.map(i => {
+        const startIndex = i.label.indexOf('(');
+        const endIndex = i.label.indexOf(')');
+        const amountString = i.label.slice(startIndex + 1, endIndex);
+        const amount = parseFloat(amountString);
+        return amount;
+      });
     const totalAmount = amounts && amounts.reduce((sum, amount) => sum + amount, 0);
-    this.formRef.current.setFieldValue("transactionAmount", totalAmount)
-  }
+    this.formRef.current.setFieldValue('transactionAmount', totalAmount);
+  };
 
   getPayrollList = (UnPaidPayrolls_List, props) => {
     return (
       <Col lg={3}>
         <FormGroup className="mb-3">
-          <Label htmlFor="payrollListIds"><span className="text-danger">* </span>{strings.Payroll}</Label>
+          <Label htmlFor="payrollListIds">
+            <span className="text-danger">* </span>
+            {strings.Payroll}
+          </Label>
           <Select
             style={customStyles}
             isMulti
-            options={
-              UnPaidPayrolls_List && UnPaidPayrolls_List
-                ? UnPaidPayrolls_List
-                : []
-            }
+            options={UnPaidPayrolls_List && UnPaidPayrolls_List ? UnPaidPayrolls_List : []}
             placeholder={strings.Select + strings.Payroll}
             id="payrollListIds"
-            onChange={(option) => {
-
-              this.state.selectedPayrollListBank = []
-              props.handleChange("payrollListIds")(option);
+            onChange={option => {
+              this.state.selectedPayrollListBank = [];
+              props.handleChange('payrollListIds')(option);
               this.payrollList(option);
               this.getPayrollAmount(option);
-              (!option && this.formRef.current.setFieldValue("transactionAmount", ""))
+              !option && this.formRef.current.setFieldValue('transactionAmount', '');
               // let selectedPayroll1 = []
               if (option) {
-                option.map((i) => {
-
-                  const selectedPayroll = this.state.payrolldata.find((el) => el.id === i.value)
-                  this.state.selectedPayrollListBank.push(selectedPayroll)
+                option.map(i => {
+                  const selectedPayroll = this.state.payrolldata.find(el => el.id === i.value);
+                  this.state.selectedPayrollListBank.push(selectedPayroll);
                   const uniqueArray = [];
                   const seenIds = new Set();
                   for (const obj of this.state.selectedPayrollListBank) {
@@ -714,131 +629,105 @@ class CreateBankTransaction extends React.Component {
                       seenIds.add(obj.id);
                     }
                   }
-                })
+                });
               }
             }}
-            className={
-              props.errors.vatId &&
-                props.touched.vatId
-                ? "is-invalid"
-                : ""
-            }
+            className={props.errors.vatId && props.touched.vatId ? 'is-invalid' : ''}
           />
-          {props.errors.vatId &&
-            props.touched.vatId && (
-              <div className="invalid-feedback">
-                {props.errors.vatId}
-              </div>
-            )}
+          {props.errors.vatId && props.touched.vatId && (
+            <div className="invalid-feedback">{props.errors.vatId}</div>
+          )}
         </FormGroup>
       </Col>
     );
   };
 
-  getCompanyCurrency = (basecurrency) => {
+  getCompanyCurrency = basecurrency => {
     this.props.currencyConvertActions
       .getCompanyCurrency()
-      .then((res) => {
+      .then(res => {
         if (res.status === 200) {
           this.setState({ basecurrency: res.data });
         }
       })
-      .catch((err) => {
+      .catch(err => {
         this.props.commonActions.tostifyAlert(
-          "error",
-          err && err.data ? err.data.message : "Something Went Wrong"
+          'error',
+          err && err.data ? err.data.message : 'Something Went Wrong'
         );
         this.setState({ loading: false });
       });
   };
 
-  setExchange = (value) => {
+  setExchange = value => {
     let exchange;
-    let result = this.props.currency_convert_list.filter((obj) => {
+    let result = this.props.currency_convert_list.filter(obj => {
       return obj.currencyCode === value;
     });
-    if (
-      this.state.invoiceCurrency === this.state.bankCurrency.bankAccountCurrency
-    ) {
+    if (this.state.invoiceCurrency === this.state.bankCurrency.bankAccountCurrency) {
       exchange = 1;
-    } else if (
-      this.state.invoiceCurrency !== this.state.bankCurrency.bankAccountCurrency
-    ) {
+    } else if (this.state.invoiceCurrency !== this.state.bankCurrency.bankAccountCurrency) {
       if (this.state.invoiceCurrency !== this.state.basecurrency.currencyCode) {
         exchange = result[0].exchangeRate;
       } else {
         exchange = 1 / result[0].exchangeRate;
       }
     }
-    this.formRef.current.setFieldValue("exchangeRate", exchange, true);
+    this.formRef.current.setFieldValue('exchangeRate', exchange, true);
   };
   getExchangeRate = () => {
-    let result = this.props.currency_convert_list.filter((obj) => {
+    let result = this.props.currency_convert_list.filter(obj => {
       return obj.currencyCode === this.state?.bankCurrency?.bankAccountCurrency;
     });
     if (result[0]) {
-      this.formRef.current.setFieldValue(
-        "exchangeRate",
-        result[0].exchangeRate,
-        true
-      );
-      this.formRef.current.setFieldValue(
-        "currencyName",
-        result[0].currencyName,
-        true
-      );
+      this.formRef.current.setFieldValue('exchangeRate', result[0].exchangeRate, true);
+      this.formRef.current.setFieldValue('currencyName', result[0].currencyName, true);
     }
   };
-  getVatListByIds = (vatIds) => {
+  getVatListByIds = vatIds => {
     const { vat_list } = this.props;
-    const finalarr = vat_list.filter((i) => vatIds.includes(i.id));
+    const finalarr = vat_list.filter(i => vatIds.includes(i.id));
     return finalarr;
   };
 
-  getVatListByIds = (vatIds) => {
+  getVatListByIds = vatIds => {
     const { vat_list } = this.props;
-    const finalarr = vat_list.filter((i) => vatIds.includes(i.id));
+    const finalarr = vat_list.filter(i => vatIds.includes(i.id));
 
     return finalarr;
   };
 
-  setCurrency = (value) => {
-    let result = this.props.currency_convert_list.find((obj) => {
+  setCurrency = value => {
+    let result = this.props.currency_convert_list.find(obj => {
       return obj.currencyCode === value;
     });
-    this.formRef.current.setFieldValue(
-      "curreancyname",
-      result.currencyIsoCode,
-      true
-    );
+    this.formRef.current.setFieldValue('curreancyname', result.currencyIsoCode, true);
   };
 
   setcustomexchnage = (customerinvoice, exrate) => {
     let exchange;
     let convertor =
-      this.state.bankCurrency.bankAccountCurrency ===
-        this.state.basecurrency.currencyCode
+      this.state.bankCurrency.bankAccountCurrency === this.state.basecurrency.currencyCode
         ? customerinvoice
         : this.state.bankCurrency.bankAccountCurrency;
-    let result = this.props.currency_convert_list.filter((obj) => {
+    let result = this.props.currency_convert_list.filter(obj => {
       return obj.currencyCode === convertor;
     });
     const ex = exrate || result[0].exchangeRate;
-    this.formRef.current.setFieldValue("exchangeRate", ex, true);
+    this.formRef.current.setFieldValue('exchangeRate', ex, true);
     if (customerinvoice === this.state.bankCurrency.bankAccountCurrency) {
       exchange = 1;
     } else {
-      if (this.state.basecurrency.currencyCode === customerinvoice)
-        exchange = 1 / ex;
+      if (this.state.basecurrency.currencyCode === customerinvoice) exchange = 1 / ex;
       else exchange = ex;
     }
-    this.formRef.current.setFieldValue("exchangeRateFromList", ex, true);
+    this.formRef.current.setFieldValue('exchangeRateFromList', ex, true);
 
     return exchange;
   };
 
-  expenceconvert = (amount) => {
-    let result = this.props.currency_convert_list.filter((obj) => {
+  expenceconvert = amount => {
+    let result = this.props.currency_convert_list.filter(obj => {
       return obj.currencyCode === this.state.bankCurrency.bankAccountCurrency;
     });
     const exchange = result[0].exchangeRate;
@@ -846,10 +735,10 @@ class CreateBankTransaction extends React.Component {
     return amount * exchange;
   };
 
-  basecurrencyconvertor = (customerinvoice) => {
+  basecurrencyconvertor = customerinvoice => {
     let exchange;
     if (customerinvoice !== this.state.basecurrency.currencyCode) {
-      let result = this.props.currency_convert_list.filter((obj) => {
+      let result = this.props.currency_convert_list.filter(obj => {
         return obj.currencyCode === customerinvoice;
       });
       exchange = result[0].exchangeRate;
@@ -862,8 +751,7 @@ class CreateBankTransaction extends React.Component {
 
   setexchnagedamount = (option, amount, exrate) => {
     if (option?.length > 0) {
-      const transactionAmount =
-        amount || this.formRef.current.state.values.transactionAmount;
+      const transactionAmount = amount || this.formRef.current.state.values.transactionAmount;
       const invoicelist = [...option];
       let remainingcredit = transactionAmount;
       const finaldata = invoicelist?.map((i, ind) => {
@@ -897,10 +785,10 @@ class CreateBankTransaction extends React.Component {
         };
       });
 
-      this.formRef.current.setFieldValue("invoiceIdList", finaldata);
+      this.formRef.current.setFieldValue('invoiceIdList', finaldata);
       return finaldata;
     } else {
-      this.formRef.current.setFieldValue("invoiceIdList", []);
+      this.formRef.current.setFieldValue('invoiceIdList', []);
       return [];
     }
   };
@@ -910,29 +798,21 @@ class CreateBankTransaction extends React.Component {
     local2[indexofinvoce].pp = value;
     let finaldata = [...local2];
     //how many are clicked
-    const howManyAreClicked = finaldata.reduce(
-      (a, c, i) => a + (c.pp ? 1 : 0),
-      0
-    );
-    const transactionAmount =
-      this.formRef.current.state.values.transactionAmount;
-    const total = finaldata.reduce(
-      (accu, curr, index) => accu + curr.convertedInvoiceAmount,
-      0
-    );
+    const howManyAreClicked = finaldata.reduce((a, c, i) => a + (c.pp ? 1 : 0), 0);
+    const transactionAmount = this.formRef.current.state.values.transactionAmount;
+    const total = finaldata.reduce((accu, curr, index) => accu + curr.convertedInvoiceAmount, 0);
     const shortAmount = transactionAmount - total;
     let remainingcredit = transactionAmount;
     let updatedfinaldata = [];
     let temp = finaldata.reduce(
-      (a, c, i) =>
-        c.convertedInvoiceAmount >= transactionAmount ? a + 1 : a + 0,
+      (a, c, i) => (c.convertedInvoiceAmount >= transactionAmount ? a + 1 : a + 0),
       0
     );
     let amountislessthanallinvoice = temp === finaldata.length;
     let tempdata;
     if (amountislessthanallinvoice) {
       if (value) {
-        tempdata = finaldata.map((i) => {
+        tempdata = finaldata.map(i => {
           const basecurrency = this.basecurrencyconvertor(i.currencyCode);
           return {
             ...i,
@@ -945,22 +825,21 @@ class CreateBankTransaction extends React.Component {
           };
         });
       } else {
-        const temp = finaldata.map((i) => {
+        const temp = finaldata.map(i => {
           return { ...i, pp: value };
         });
         tempdata = this.setexchnagedamount(temp);
       }
       finaldata = [...tempdata];
-      if (transactionAmount > 0 && transactionAmount !== "")
-        this.formRef.current.setFieldValue("invoiceIdList", finaldata);
+      if (transactionAmount > 0 && transactionAmount !== '')
+        this.formRef.current.setFieldValue('invoiceIdList', finaldata);
     } else {
       let currentshort = shortAmount;
       finaldata.map((i, inx) => {
         const local = { ...i };
 
         if (i.pp) {
-          let iio =
-            local.convertedInvoiceAmount + currentshort / howManyAreClicked;
+          let iio = local.convertedInvoiceAmount + currentshort / howManyAreClicked;
           if (iio < 0) {
             local.explainedAmount = 0;
           } else {
@@ -971,23 +850,21 @@ class CreateBankTransaction extends React.Component {
         }
         updatedfinaldata.push(local);
       });
-      let updatedfinaldata2 = updatedfinaldata.map((i) => {
+      let updatedfinaldata2 = updatedfinaldata.map(i => {
         const basecurrency = this.basecurrencyconvertor(i.currencyCode);
         return {
           ...i,
-          convertedToBaseCurrencyAmount: (
-            i.explainedAmount * basecurrency
-          )?.toFixed(2),
+          convertedToBaseCurrencyAmount: (i.explainedAmount * basecurrency)?.toFixed(2),
         };
       });
-      this.formRef.current.setFieldValue("invoiceIdList", updatedfinaldata2);
+      this.formRef.current.setFieldValue('invoiceIdList', updatedfinaldata2);
     }
   };
 
-  getCurrency = (opt) => {
+  getCurrency = opt => {
     let supplier_currencyCode = 0;
 
-    this.props.vendor_list.map((item) => {
+    this.props.vendor_list.map(item => {
       if (item.label.contactId == opt) {
         this.setState({
           supplier_currency: item.label.currency.currencyCode,
@@ -1007,13 +884,12 @@ class CreateBankTransaction extends React.Component {
     }
   };
 
-  getTransactionCategoryList = (type) => {
+  getTransactionCategoryList = type => {
     function getParentLabel(array, id, parentId) {
       return array.some(
-        (o) =>
+        o =>
           o.label === id ||
-          (o.options &&
-            (parentId = getParentLabel(o.options, id, o.label)) !== null)
+          (o.options && (parentId = getParentLabel(o.options, id, o.label)) !== null)
       )
         ? parentId
         : null;
@@ -1027,25 +903,27 @@ class CreateBankTransaction extends React.Component {
     this.setValue(null);
     try {
       this.props.transactionCreateActions
-        .getTransactionCategoryListForExplain(
-          type.value,
-          this.props.location.state.bankAccountId
-        )
-        .then((res) => {
+        .getTransactionCategoryListForExplain(type.value, this.props.location.state.bankAccountId)
+        .then(res => {
           if (res.status === 200) {
-            let categoryList = res.data.categoriesList && res.data.categoriesList.map((category) => {
-              let newcategory = category.label;
-              let newOption = category.options;
-              if (category.label === 'Other Current Liability') {
-                newOption = category.options.filter(obj => obj.label !== 'Payroll Liability')
-              }
-              return { label: newcategory, options: newOption }
-            })
+            let categoryList =
+              res.data.categoriesList &&
+              res.data.categoriesList.map(category => {
+                let newcategory = category.label;
+                let newOption = category.options;
+                if (category.label === 'Other Current Liability') {
+                  newOption = category.options.filter(obj => obj.label !== 'Payroll Liability');
+                }
+                return { label: newcategory, options: newOption };
+              });
             this.setState(
               {
-                transactionCategoryList: { categoriesList: categoryList, dataList: res.data.dataList },
+                transactionCategoryList: {
+                  categoriesList: categoryList,
+                  dataList: res.data.dataList,
+                },
               },
-              () => { }
+              () => {}
             );
           }
         });
@@ -1053,20 +931,18 @@ class CreateBankTransaction extends React.Component {
       console.log(err);
     }
   };
-  getMoneyPaidToUserlist = (option) => {
+  getMoneyPaidToUserlist = option => {
     try {
-      this.props.transactionActions
-        .getMoneyCategoryList(option.value)
-        .then((res) => {
-          if (res.status === 200) {
-            this.setState(
-              {
-                moneyCategoryList: res.data,
-              },
-              () => { }
-            );
-          }
-        });
+      this.props.transactionActions.getMoneyCategoryList(option.value).then(res => {
+        if (res.status === 200) {
+          this.setState(
+            {
+              moneyCategoryList: res.data,
+            },
+            () => {}
+          );
+        }
+      });
     } catch (err) {
       console.log(err);
     }
@@ -1076,40 +952,35 @@ class CreateBankTransaction extends React.Component {
     const data = {
       amount: amount,
       id: option.value,
-      currency:
-        this.state?.bankCurrency?.bankAccountCurrency
-          ? this.state?.bankCurrency?.bankAccountCurrency
-          : 0,
+      currency: this.state?.bankCurrency?.bankAccountCurrency
+        ? this.state?.bankCurrency?.bankAccountCurrency
+        : 0,
       bankId: this.props.location.state.bankAccountId,
     };
     this.props.transactionActions.getCustomerInvoiceList(data);
     if (invoice_list === null) {
-      this.formRef.current.setFieldValue("curreancyname", "", true);
-      this.formRef.current.setFieldValue("exchangeRate", "", true);
-      this.formRef.current.setFieldValue("currencyCode", "", true);
+      this.formRef.current.setFieldValue('curreancyname', '', true);
+      this.formRef.current.setFieldValue('exchangeRate', '', true);
+      this.formRef.current.setFieldValue('currencyCode', '', true);
     }
   };
 
   setexcessorshortamount = () => {
-    const totalexpainedamount =
-      this.formRef.current.state.values?.invoiceIdList?.reduce(
-        (accu, curr, index) => accu + curr.explainedAmount,
-        0
-      );
+    const totalexpainedamount = this.formRef.current.state.values?.invoiceIdList?.reduce(
+      (accu, curr, index) => accu + curr.explainedAmount,
+      0
+    );
 
-    const totalconvetedamount =
-      this.formRef.current.state.values?.invoiceIdList?.reduce(
-        (accu, curr, index) => accu + curr.convertedInvoiceAmount,
-        0
-      );
+    const totalconvetedamount = this.formRef.current.state.values?.invoiceIdList?.reduce(
+      (accu, curr, index) => accu + curr.convertedInvoiceAmount,
+      0
+    );
 
-    const transactionAmount =
-      this.formRef.current.state.values.transactionAmount;
-    const isppselected =
-      this.formRef.current.state.values?.invoiceIdList?.reduce(
-        (a, c, i) => a + (c.pp ? 1 : 0),
-        0
-      );
+    const transactionAmount = this.formRef.current.state.values.transactionAmount;
+    const isppselected = this.formRef.current.state.values?.invoiceIdList?.reduce(
+      (a, c, i) => a + (c.pp ? 1 : 0),
+      0
+    );
 
     let final = 0;
     const totalshort = totalexpainedamount - totalconvetedamount;
@@ -1121,21 +992,21 @@ class CreateBankTransaction extends React.Component {
       final = transactionAmount - totalconvetedamount;
     }
     return {
-      value: ` ${this.state.bankCurrency.bankAccountCurrencyIsoCode
-        } ${final.toLocaleString(navigator.language, {
+      value: ` ${this.state.bankCurrency.bankAccountCurrencyIsoCode} ${final.toLocaleString(
+        navigator.language,
+        {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
-        })} `,
+        }
+      )} `,
       data: final?.toFixed(2),
     };
   };
   expense_categories_list_generate = () => {
     const categoriesList = [...this.props.expense_categories_list];
     const grouped = [];
-    categoriesList.map((i) => {
-      const category = grouped.findIndex(
-        (g) => g.label === i.transactionCategoryDescription
-      );
+    categoriesList.map(i => {
+      const category = grouped.findIndex(g => g.label === i.transactionCategoryDescription);
       if (category > -1) {
         grouped[category].options = [
           ...grouped[category].options,
@@ -1177,7 +1048,7 @@ class CreateBankTransaction extends React.Component {
     } = this.props;
     let tmpSupplier_list = [];
 
-    vendor_list.map((item) => {
+    vendor_list.map(item => {
       let obj = { label: item.label.contactName, value: item.value };
 
       tmpSupplier_list.push(obj);
@@ -1194,9 +1065,7 @@ class CreateBankTransaction extends React.Component {
                     <Col lg={12}>
                       <div className="h4 mb-0 d-flex align-items-center">
                         <i className="icon-doc" />
-                        <span className="ml-2">
-                          {strings.CreateBankTransaction}
-                        </span>
+                        <span className="ml-2">{strings.CreateBankTransaction}</span>
                       </div>
                     </Col>
                   </Row>
@@ -1210,7 +1079,7 @@ class CreateBankTransaction extends React.Component {
                         onSubmit={(values, { resetForm }) => {
                           this.handleSubmit(values, resetForm);
                         }}
-                        validate={(values) => {
+                        validate={values => {
                           let errors = {};
                           const totalexpaled = values?.invoiceIdList.reduce(
                             (a, c) => a + c.explainedAmount,
@@ -1218,143 +1087,122 @@ class CreateBankTransaction extends React.Component {
                           );
 
                           if (
-                            values.coaCategoryId === "VAT Payment" ||
-                            values.coaCategoryId === "VAT Claim"
+                            values.coaCategoryId === 'VAT Payment' ||
+                            values.coaCategoryId === 'VAT Claim'
                           ) {
-                            if (
-                              values?.transactionAmount > values?.vatDueAmount
-                            )
+                            if (values?.transactionAmount > values?.vatDueAmount)
                               errors.transactionAmount = `Amount cannot be greater than Due amount`;
 
                             const info = this.state.VATlist.find(
-                              (i) => i.id === values.VATReportId.value
+                              i => i.id === values.VATReportId.value
                             );
 
                             if (
                               dayjs(values.transactionDate).diff(
                                 new Date(info.taxFiledOn),
-                                "seconds"
+                                'seconds'
                               ) < 0
                             ) {
                               errors.transactionDate =
-                                "The transaction date cannot be before the Date of Filing.";
+                                'The transaction date cannot be before the Date of Filing.';
                             }
                           }
 
-                          const date = dayjs(values.transactionDate).format(
-                            "MM/DD/YYYY"
-                          );
+                          const date = dayjs(values.transactionDate).format('MM/DD/YYYY');
                           const date1 = new Date(date);
                           const date2 = new Date(this.state.date);
 
                           if (
                             values.coaCategoryId &&
-                            this.props.location.state?.currency === "AED" &&
-                            (values.coaCategoryId.label === "VAT Payment" ||
-                              values.coaCategoryId.label === "VAT Claim")
+                            this.props.location.state?.currency === 'AED' &&
+                            (values.coaCategoryId.label === 'VAT Payment' ||
+                              values.coaCategoryId.label === 'VAT Claim')
                           ) {
-                            if (
-                              !values.VATReportId ||
-                              values.VATReportId === ""
-                            ) {
-                              errors.VATReportId = "Please Select Vat Report Number";
+                            if (!values.VATReportId || values.VATReportId === '') {
+                              errors.VATReportId = 'Please Select Vat Report Number';
                             }
                           }
 
                           if (
-                            values.coaCategoryId.label !== "Expense" &&
-                            values.coaCategoryId.label !== "Supplier Invoice" &&
-                            values.coaCategoryId.label !== "Sales" &&
-                            values.coaCategoryId.label !== "VAT Payment" &&
-                            values.coaCategoryId.label !== "VAT Claim" &&
-                            values.coaCategoryId.label !== "Corporate Tax Payment"
+                            values.coaCategoryId.label !== 'Expense' &&
+                            values.coaCategoryId.label !== 'Supplier Invoice' &&
+                            values.coaCategoryId.label !== 'Sales' &&
+                            values.coaCategoryId.label !== 'VAT Payment' &&
+                            values.coaCategoryId.label !== 'VAT Claim' &&
+                            values.coaCategoryId.label !== 'Corporate Tax Payment'
                           ) {
                             if (
                               !values.transactionCategoryId ||
-                              values.transactionCategoryId === ""
+                              values.transactionCategoryId === ''
                             ) {
-                              errors.transactionCategoryId =
-                                "Category is required";
+                              errors.transactionCategoryId = 'Category is required';
                             }
                             if (
                               (values.coaCategoryId.value === 12 ||
                                 values.coaCategoryId.value === 6) &&
                               !values.employeeId
                             ) {
-                              errors.employeeId = "User is Required";
+                              errors.employeeId = 'User is Required';
                             }
                           }
-                          if (
-                            values.coaCategoryId.label === "Expense" &&
-                            !values.expenseCategory
-                          ) {
-                            errors.expenseCategory =
-                              "Expense Category is Required";
+                          if (values.coaCategoryId.label === 'Expense' && !values.expenseCategory) {
+                            errors.expenseCategory = 'Expense Category is Required';
                           }
                           if (
-                            values.vatId === "" &&
-                            values.coaCategoryId.label === "Expense" &&
+                            values.vatId === '' &&
+                            values.coaCategoryId.label === 'Expense' &&
                             values.expenseCategory.value !== 34
                           ) {
-                            errors.vatId = "Please select vat";
+                            errors.vatId = 'Please select vat';
                           }
                           if (
-                            (values.payrollListIds === "" || !values.payrollListIds || values.payrollListIds?.length === 0) &&
-                            values.coaCategoryId.label === "Expense" &&
+                            (values.payrollListIds === '' ||
+                              !values.payrollListIds ||
+                              values.payrollListIds?.length === 0) &&
+                            values.coaCategoryId.label === 'Expense' &&
                             values.expenseCategory.value == 34
                           ) {
-                            errors.vatId = "Payroll is Required";
+                            errors.vatId = 'Payroll is Required';
                           }
                           if (
                             values.coaCategoryId.value === 2 ||
                             values.coaCategoryId.value === 100
                           ) {
-                            if (
-                              !values.vendorId.value &&
-                              values.coaCategoryId.value === 100
-                            ) {
-                              errors.vendorId = "Please select the Vendor";
+                            if (!values.vendorId.value && values.coaCategoryId.value === 100) {
+                              errors.vendorId = 'Please select the Vendor';
                             }
-                            if (
-                              !values.customerId.value &&
-                              values.coaCategoryId.value === 2
-                            ) {
-                              errors.customerId = "Please select the Customer";
+                            if (!values.customerId.value && values.coaCategoryId.value === 2) {
+                              errors.customerId = 'Please select the Customer';
                             }
                             if (values.invoiceIdList.length === 0) {
-                              errors.invoiceIdList = "Please Select Invoice";
+                              errors.invoiceIdList = 'Please Select Invoice';
                             } else {
                               let isExplainAmountZero = false;
-                              values.invoiceIdList.map((i) => {
+                              values.invoiceIdList.map(i => {
                                 if (i.explainedAmount === 0) {
                                   isExplainAmountZero = true;
                                 }
                               });
 
                               if (isExplainAmountZero) {
-                                errors.invoiceIdList =
-                                  "Expain Amount Cannot Be Zero";
+                                errors.invoiceIdList = 'Expain Amount Cannot Be Zero';
                               }
 
-                              values.invoiceIdList.map((ii) => {
+                              values.invoiceIdList.map(ii => {
                                 if (
-                                  this.state.bankCurrency
-                                    .bankAccountCurrency !==
-                                  this.state.basecurrency.currencyCode &&
-                                  this.state.basecurrency.currencyCode !==
-                                  ii.currencyCode &&
-                                  this.state.bankCurrency
-                                    .bankAccountCurrency !== ii.currencyCode
+                                  this.state.bankCurrency.bankAccountCurrency !==
+                                    this.state.basecurrency.currencyCode &&
+                                  this.state.basecurrency.currencyCode !== ii.currencyCode &&
+                                  this.state.bankCurrency.bankAccountCurrency !== ii.currencyCode
                                 )
                                   errors.invoiceIdList =
-                                    "Invoices created in another FCY cannot be processed by this foreign currency bank account.";
+                                    'Invoices created in another FCY cannot be processed by this foreign currency bank account.';
                               });
 
                               if (
                                 values.transactionAmount > totalexpaled &&
-                                this.state?.bankCurrency
-                                  ?.bankAccountCurrency ===
-                                values?.invoiceIdList?.[0]?.currencyCode
+                                this.state?.bankCurrency?.bankAccountCurrency ===
+                                  values?.invoiceIdList?.[0]?.currencyCode
                               ) {
                                 errors.transactionAmount = `The transaction amount cannot be greater than the invoice amount.`;
                               }
@@ -1364,135 +1212,128 @@ class CreateBankTransaction extends React.Component {
                               );
                               if (
                                 values.transactionAmount < totalexpaled &&
-                                this.state?.bankCurrency
-                                  ?.bankAccountCurrency ===
-                                values?.invoiceIdList?.[0]?.currencyCode &&
+                                this.state?.bankCurrency?.bankAccountCurrency ===
+                                  values?.invoiceIdList?.[0]?.currencyCode &&
                                 isppselected === 0
                               ) {
                                 errors.transactionAmount = `The transaction amount is less than the invoice amount. To partially pay the invoice, please select the checkbox `;
                               }
                             }
 
-                            if (
-                              date1 < date2 ||
-                              date1 < new Date(this.state.reconciledDate)
-                            ) {
+                            if (date1 < date2 || date1 < new Date(this.state.reconciledDate)) {
                               errors.transactionDate =
-                                "Transaction Date cannot be before Bank Account Opening Date or after Current Date.";
+                                'Transaction Date cannot be before Bank Account Opening Date or after Current Date.';
+                            }
+
+                            if (values.coaCategoryId.label === 'Expense' && !values.currencyCode) {
+                              errors.currencyCode = ' Currency is Required';
                             }
 
                             if (
-                              values.coaCategoryId.label === "Expense" &&
-                              !values.currencyCode
-                            ) {
-                              errors.currencyCode = " Currency is Required";
-                            }
-
-                            if (
-                              this.state.totalInvoiceAmount === "" &&
+                              this.state.totalInvoiceAmount === '' &&
                               this.state.totalInvoiceAmount === 0
                             ) {
                               errors.transactionAmount = `Enter Amount`;
                             }
-                            values.invoiceIdList.map((i1) => {
+                            values.invoiceIdList.map(i1 => {
                               const transactionDate = dayjs(values.transactionDate);
                               const invoiceDate = dayjs(i1.invoiceDate);
 
-                              console.log(transactionDate.format("MM/DD/YYYY") + '-' + invoiceDate.format("MM/DD/YYYY"));
-                              
+                              console.log(
+                                transactionDate.format('MM/DD/YYYY') +
+                                  '-' +
+                                  invoiceDate.format('MM/DD/YYYY')
+                              );
+
                               if (transactionDate.diff(invoiceDate) < 0) {
-                                  errors.transactionDate = 'Transaction date cannot be before Invoice date';
+                                errors.transactionDate =
+                                  'Transaction date cannot be before Invoice date';
                               }
                             });
                           }
-                          if (values.coaCategoryId?.label === "Corporate Tax Payment") {
+                          if (values.coaCategoryId?.label === 'Corporate Tax Payment') {
                             if (!values.transactionAmount)
                               errors.transactionAmount = strings.AmountIsRequired;
                             if (!values.ct_taxPeriod)
-                              errors.ct_taxPeriod = strings.TaxPeriodIsRequired
-                            if (values.balanceDue && values.transactionAmount && parseFloat(values.balanceDue) < parseFloat(values.transactionAmount))
-                              errors.transactionAmount = strings.AmountShouldBeLessThanOrEqualToTheBalanceDue;
+                              errors.ct_taxPeriod = strings.TaxPeriodIsRequired;
+                            if (
+                              values.balanceDue &&
+                              values.transactionAmount &&
+                              parseFloat(values.balanceDue) < parseFloat(values.transactionAmount)
+                            )
+                              errors.transactionAmount =
+                                strings.AmountShouldBeLessThanOrEqualToTheBalanceDue;
                           }
-                          if (values.coaCategoryId && values.coaCategoryId?.label === "Expense") {
-                            if (values.expenseCategory && values.expenseCategory.value === 34 && values.payrollListIds && values.payrollListIds?.length > 0) {
-                              const sumOfPayrollAmounts = values.payrollListIds.reduce((sum, item) => {
-                                let num = parseFloat(item.label.match(/\d+\.\d+/)[0]);
-                                return sum + num;
-                              }, 0);
+                          if (values.coaCategoryId && values.coaCategoryId?.label === 'Expense') {
+                            if (
+                              values.expenseCategory &&
+                              values.expenseCategory.value === 34 &&
+                              values.payrollListIds &&
+                              values.payrollListIds?.length > 0
+                            ) {
+                              const sumOfPayrollAmounts = values.payrollListIds.reduce(
+                                (sum, item) => {
+                                  let num = parseFloat(item.label.match(/\d+\.\d+/)[0]);
+                                  return sum + num;
+                                },
+                                0
+                              );
                               if (values.transactionAmount > sumOfPayrollAmounts) {
-                                errors.transactionAmount = 'Transaction amount cannot be greater than payroll amount.';
+                                errors.transactionAmount =
+                                  'Transaction amount cannot be greater than payroll amount.';
                               }
                             }
                           }
                           if (!values.transactionDate) {
-                            errors.transactionDate = "Transaction Date is Required";
+                            errors.transactionDate = 'Transaction Date is Required';
                           }
                           if (values.transactionDate) {
-                            this.state.selectedPayrollListBank.forEach((payrollItem) => {
+                            this.state.selectedPayrollListBank.forEach(payrollItem => {
                               const payrollDate = dayjs(payrollItem.runDate).startOf('day');
                               const transactionDate = dayjs(values.transactionDate).startOf('day');
 
                               if (transactionDate.isBefore(payrollDate)) {
-                                errors.transactionDate = "Transaction Date cannot be earlier than the payroll approval date.";
+                                errors.transactionDate =
+                                  'Transaction Date cannot be earlier than the payroll approval date.';
                               }
                             });
                           }
                           return errors;
                         }}
                         validationSchema={Yup.object().shape({
-                          transactionDate: Yup.date().required(
-                            "Transaction Date is Required"
-                          ),
+                          transactionDate: Yup.date().required('Transaction Date is Required'),
                           reference: Yup.string().max(20),
                           transactionAmount: Yup.string()
-                            .required("Amount is Required")
+                            .required('Amount is Required')
                             .test(
-                              "transactionAmount",
-                              "Transaction Amount Must Be Greater Than 0",
-                              (value) => value > 0
+                              'transactionAmount',
+                              'Transaction Amount Must Be Greater Than 0',
+                              value => value > 0
                             ),
-                          coaCategoryId: Yup.string().required(
-                            "Transaction Type is Required"
-                          ),
+                          coaCategoryId: Yup.string().required('Transaction Type is Required'),
                           attachment: Yup.mixed()
-                            .test(
-                              "fileType",
-                              "*Unsupported File Format",
-                              (value) => {
-                                if (value) {
-                                  this.setState({
-                                    fileName: value.name,
-                                  });
-                                }
-                                if (
-                                  !value ||
-                                  this.supported_format.includes(
-                                    value.type
-                                  )
-                                ) {
-                                  return true;
-                                } else {
-                                  return false;
-                                }
+                            .test('fileType', '*Unsupported File Format', value => {
+                              if (value) {
+                                this.setState({
+                                  fileName: value.name,
+                                });
                               }
-                            )
-                            .test(
-                              "fileSize",
-                              "*File Size is too large",
-                              (value) => {
-                                if (
-                                  !value ||
-                                  value.size <= this.file_size
-                                ) {
-                                  return true;
-                                } else {
-                                  return false;
-                                }
+                              if (!value || this.supported_format.includes(value.type)) {
+                                return true;
+                              } else {
+                                return false;
                               }
-                            ),
+                            })
+                            .test('fileSize', '*File Size is too large', value => {
+                              if (!value || value.size <= this.file_size) {
+                                return true;
+                              } else {
+                                return false;
+                              }
+                            }),
                         })}
                       >
-                        {(props) => (
+                        {props => (
                           <Form onSubmit={props.handleSubmit}>
                             <Row>
                               <Col lg={3}>
@@ -1504,74 +1345,60 @@ class CreateBankTransaction extends React.Component {
                                   <Select
                                     options={categoriesList}
                                     value={props.values.coaCategoryId}
-                                    onChange={(option) => {
+                                    onChange={option => {
                                       if (option && option.value) {
                                         this.getExchangeRate();
-                                        props.handleChange("coaCategoryId")(
-                                          option
-                                        );
+                                        props.handleChange('coaCategoryId')(option);
                                       } else {
-                                        props.handleChange("coaCategoryId")("");
+                                        props.handleChange('coaCategoryId')('');
                                       }
 
                                       if (
-                                        option.label !== "Expense" &&
-                                        option.label !== "Supplier Invoice" &&
-                                        option.label !== "VAT Payment" &&
-                                        option.label !== "VAT Claim" &&
-                                        option.label !== "Corporate Tax Payment"
+                                        option.label !== 'Expense' &&
+                                        option.label !== 'Supplier Invoice' &&
+                                        option.label !== 'VAT Payment' &&
+                                        option.label !== 'VAT Claim' &&
+                                        option.label !== 'Corporate Tax Payment'
                                       ) {
                                         this.getTransactionCategoryList(option);
-                                      }
-                                      else if (option.label === "Expense") {
-                                        props.handleChange("currencyCode")(
-                                          this.state.bankCurrency
-                                            .bankAccountCurrency
+                                      } else if (option.label === 'Expense') {
+                                        props.handleChange('currencyCode')(
+                                          this.state.bankCurrency.bankAccountCurrency
                                         );
                                         this.getExpensesCategoriesList();
-                                      }
-                                      else if (option.label === "Supplier Invoice") {
+                                      } else if (option.label === 'Supplier Invoice') {
                                         this.getVendorList();
-                                      }
-                                      else if (option.label === "VAT Payment") {
+                                      } else if (option.label === 'VAT Payment') {
                                         this.getVatReportListForBank(1);
-                                        props.handleChange("VATReportId")("");
-                                        props.handleChange("vatDueAmount")("");
-                                        props.handleChange("vatAmountpc")("");
-                                      }
-                                      else if (option.label === "VAT Claim") {
+                                        props.handleChange('VATReportId')('');
+                                        props.handleChange('vatDueAmount')('');
+                                        props.handleChange('vatAmountpc')('');
+                                      } else if (option.label === 'VAT Claim') {
                                         this.getVatReportListForBank(2);
-                                        props.handleChange("VATReportId")("");
-                                        props.handleChange("vatDueAmount")("");
+                                        props.handleChange('VATReportId')('');
+                                        props.handleChange('vatDueAmount')('');
 
-                                        props.handleChange("vatAmountpc")("");
-                                      }
-                                      else if (option.label === "Corporate Tax Payment") {
+                                        props.handleChange('vatAmountpc')('');
+                                      } else if (option.label === 'Corporate Tax Payment') {
                                         this.getCorporateTaxList();
                                       }
 
-                                      this.totalAmount("");
+                                      this.totalAmount('');
                                     }}
-                                    placeholder={
-                                      strings.Select +
-                                      " " +
-                                      strings.TransactionType
-                                    }
+                                    placeholder={strings.Select + ' ' + strings.TransactionType}
                                     id="coaCategoryId"
                                     name="coaCategoryId"
                                     className={
-                                      props.errors.coaCategoryId &&
-                                        props.touched.coaCategoryId
-                                        ? "is-invalid"
-                                        : ""
+                                      props.errors.coaCategoryId && props.touched.coaCategoryId
+                                        ? 'is-invalid'
+                                        : ''
                                     }
                                   />
-                                  {props.errors.coaCategoryId &&
-                                    props.touched.coaCategoryId && (
-                                      <div className="invalid-feedback">
-                                        {props.errors.coaCategoryId}
-                                      </div>
-                                    )}
+                                  {props.errors.coaCategoryId && props.touched.coaCategoryId && (
+                                    <div className="invalid-feedback">
+                                      {props.errors.coaCategoryId}
+                                    </div>
+                                  )}
                                 </FormGroup>
                               </Col>
                               <Col lg={3}>
@@ -1591,14 +1418,15 @@ class CreateBankTransaction extends React.Component {
                                     dropdownMode="select"
                                     value={props.values.transactionDate}
                                     selected={props.values.transactionDate}
-                                    onBlur={props.handleBlur("transactionDate")}
-                                    onChange={(value) => {
-                                      props.handleChange("transactionDate")(value);
+                                    onBlur={props.handleBlur('transactionDate')}
+                                    onChange={value => {
+                                      props.handleChange('transactionDate')(value);
                                     }}
-                                    className={`form-control ${props.errors.transactionDate &&
-                                      props.touched.transactionDate
-                                      ? "is-invalid"
-                                      : ""}`}
+                                    className={`form-control ${
+                                      props.errors.transactionDate && props.touched.transactionDate
+                                        ? 'is-invalid'
+                                        : ''
+                                    }`}
                                   />
                                   {props.errors.transactionDate &&
                                     props.touched.transactionDate && (
@@ -1618,23 +1446,20 @@ class CreateBankTransaction extends React.Component {
                                     type="number"
                                     min="0"
                                     maxLength="100"
-                                    disabled={
-                                      props.values.coaCategoryId?.label ===
-                                      "VAT Claim"
-                                    }
+                                    disabled={props.values.coaCategoryId?.label === 'VAT Claim'}
                                     id="transactionAmount"
                                     name="transactionAmount"
-                                    placeholder={props.values.coaCategoryId?.label === "Corporate Tax Payment" ? strings.Enter + strings.Amount : strings.Amount}
-                                    onChange={(option) => {
+                                    placeholder={
+                                      props.values.coaCategoryId?.label === 'Corporate Tax Payment'
+                                        ? strings.Enter + strings.Amount
+                                        : strings.Amount
+                                    }
+                                    onChange={option => {
                                       if (
-                                        option.target.value === "" ||
-                                        this.regDecimal.test(
-                                          option.target.value
-                                        )
+                                        option.target.value === '' ||
+                                        this.regDecimal.test(option.target.value)
                                       ) {
-                                        props.handleChange("transactionAmount")(
-                                          option
-                                        );
+                                        props.handleChange('transactionAmount')(option);
                                         this.setexchnagedamount(
                                           props.values.invoiceIdList,
                                           option.target.value,
@@ -1645,9 +1470,9 @@ class CreateBankTransaction extends React.Component {
                                     value={props.values.transactionAmount}
                                     className={
                                       props.errors.transactionAmount &&
-                                        props.touched.transactionAmount
-                                        ? "is-invalid"
-                                        : ""
+                                      props.touched.transactionAmount
+                                        ? 'is-invalid'
+                                        : ''
                                     }
                                   />
                                   {props.errors.transactionAmount &&
@@ -1659,114 +1484,96 @@ class CreateBankTransaction extends React.Component {
                                 </FormGroup>
                               </Col>
 
-                              {props.values.coaCategoryId?.label ===
-                                "VAT Payment" && (
-                                  <Col lg={3}>
-                                    <FormGroup className="mb-3">
-                                      <Label htmlFor="dueAmount">
-                                        <span className="text-danger">* </span>
-                                        Balance Due
-                                      </Label>
-                                      <Input
-                                        type="number"
-                                        min="0"
-                                        disabled
-                                        maxLength="100"
-                                        id="vatDueAmount"
-                                        name="vatDueAmount"
-                                        placeholder="Balance Due"
-                                        onChange={(option) => {
-                                          if (
-                                            option.target.value === "" ||
-                                            this.regDecimal.test(
-                                              option.target.value
-                                            )
-                                          ) {
-                                            props.handleChange("vatDueAmount")(
-                                              option
-                                            );
-                                          }
-                                        }}
-                                        value={props.values.vatDueAmount}
-                                        className={
-                                          props.errors.vatDueAmount &&
-                                            props.touched.vatDueAmount
-                                            ? "is-invalid"
-                                            : ""
+                              {props.values.coaCategoryId?.label === 'VAT Payment' && (
+                                <Col lg={3}>
+                                  <FormGroup className="mb-3">
+                                    <Label htmlFor="dueAmount">
+                                      <span className="text-danger">* </span>
+                                      Balance Due
+                                    </Label>
+                                    <Input
+                                      type="number"
+                                      min="0"
+                                      disabled
+                                      maxLength="100"
+                                      id="vatDueAmount"
+                                      name="vatDueAmount"
+                                      placeholder="Balance Due"
+                                      onChange={option => {
+                                        if (
+                                          option.target.value === '' ||
+                                          this.regDecimal.test(option.target.value)
+                                        ) {
+                                          props.handleChange('vatDueAmount')(option);
                                         }
-                                      />
-                                      {props.errors.vatDueAmount &&
-                                        props.touched.vatDueAmount && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.vatDueAmount}
-                                          </div>
-                                        )}
-                                    </FormGroup>
-                                  </Col>
-                                )}
-                              {(props.values.coaCategoryId?.label ===
-                                "VAT Claim" ||
-                                props.values.coaCategoryId?.label ===
-                                "VAT Payment") && (
-                                  <Col lg={3}>
-                                    <FormGroup className="mb-3">
-                                      <Label htmlFor="vatAmountpc">
-                                        <span className="text-danger">* </span>
-                                        {props.values.coaCategoryId?.label ===
-                                          "VAT Claim"
-                                          ? "Total VAT Reclaimable"
-                                          : "Total VAT Payable"}
-                                      </Label>
-                                      <Input
-                                        type="number"
-                                        min="0"
-                                        disabled
-                                        maxLength="100"
-                                        id="vatAmountpc"
-                                        name="vatAmountpc"
-                                        placeholder={
-                                          props.values.coaCategoryId?.label ===
-                                            "VAT Claim"
-                                            ? "Total VAT Reclaimable"
-                                            : "Total VAT Payable"
+                                      }}
+                                      value={props.values.vatDueAmount}
+                                      className={
+                                        props.errors.vatDueAmount && props.touched.vatDueAmount
+                                          ? 'is-invalid'
+                                          : ''
+                                      }
+                                    />
+                                    {props.errors.vatDueAmount && props.touched.vatDueAmount && (
+                                      <div className="invalid-feedback">
+                                        {props.errors.vatDueAmount}
+                                      </div>
+                                    )}
+                                  </FormGroup>
+                                </Col>
+                              )}
+                              {(props.values.coaCategoryId?.label === 'VAT Claim' ||
+                                props.values.coaCategoryId?.label === 'VAT Payment') && (
+                                <Col lg={3}>
+                                  <FormGroup className="mb-3">
+                                    <Label htmlFor="vatAmountpc">
+                                      <span className="text-danger">* </span>
+                                      {props.values.coaCategoryId?.label === 'VAT Claim'
+                                        ? 'Total VAT Reclaimable'
+                                        : 'Total VAT Payable'}
+                                    </Label>
+                                    <Input
+                                      type="number"
+                                      min="0"
+                                      disabled
+                                      maxLength="100"
+                                      id="vatAmountpc"
+                                      name="vatAmountpc"
+                                      placeholder={
+                                        props.values.coaCategoryId?.label === 'VAT Claim'
+                                          ? 'Total VAT Reclaimable'
+                                          : 'Total VAT Payable'
+                                      }
+                                      onChange={option => {
+                                        if (
+                                          option.target.value === '' ||
+                                          this.regDecimal.test(option.target.value)
+                                        ) {
+                                          props.handleChange('vatAmountpc')(option);
                                         }
-                                        onChange={(option) => {
-                                          if (
-                                            option.target.value === "" ||
-                                            this.regDecimal.test(
-                                              option.target.value
-                                            )
-                                          ) {
-                                            props.handleChange("vatAmountpc")(
-                                              option
-                                            );
-                                          }
-                                        }}
-                                        value={props.values.vatAmountpc}
-                                        className={
-                                          props.errors.vatAmountpc &&
-                                            props.touched.vatAmountpc
-                                            ? "is-invalid"
-                                            : ""
-                                        }
-                                      />
-                                      {props.errors.vatAmountpc &&
-                                        props.touched.vatAmountpc && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.vatAmountpc}
-                                          </div>
-                                        )}
-                                    </FormGroup>
-                                  </Col>
-                                )}
+                                      }}
+                                      value={props.values.vatAmountpc}
+                                      className={
+                                        props.errors.vatAmountpc && props.touched.vatAmountpc
+                                          ? 'is-invalid'
+                                          : ''
+                                      }
+                                    />
+                                    {props.errors.vatAmountpc && props.touched.vatAmountpc && (
+                                      <div className="invalid-feedback">
+                                        {props.errors.vatAmountpc}
+                                      </div>
+                                    )}
+                                  </FormGroup>
+                                </Col>
+                              )}
                             </Row>
                             <hr />
-                            {props.values.coaCategoryId?.label === "Corporate Tax Payment" && (
+                            {props.values.coaCategoryId?.label === 'Corporate Tax Payment' && (
                               <Row className="mb-3">
                                 <Col lg={3} className=" pull-right ">
                                   <Label>
-                                    <span className="text-danger">* </span>{' '}
-                                    {strings.TaxPeriod}
+                                    <span className="text-danger">* </span> {strings.TaxPeriod}
                                   </Label>
                                   <Select
                                     options={ct_taxPeriodList}
@@ -1774,29 +1581,28 @@ class CreateBankTransaction extends React.Component {
                                     name="ct_taxPeriod"
                                     value={this.state.ct_taxPeriod}
                                     placeholder={strings.Select + strings.TaxPeriod}
-                                    onChange={(option) => {
+                                    onChange={option => {
                                       this.setState({ ct_taxPeriod: option });
                                       props.handleChange('ct_taxPeriod')(option);
-                                      this.setCTValues(option.value)
+                                      this.setCTValues(option.value);
                                     }}
                                     className={
-                                      props.errors.ct_taxPeriod &&
-                                        props.touched.ct_taxPeriod
+                                      props.errors.ct_taxPeriod && props.touched.ct_taxPeriod
                                         ? 'is-invalid'
                                         : ''
                                     }
                                   />
-                                  {props.errors.ct_taxPeriod &&
-                                    props.touched.ct_taxPeriod && (
-                                      <div className="invalid-feedback">
-                                        {props.errors.ct_taxPeriod}
-                                      </div>
-                                    )}
+                                  {props.errors.ct_taxPeriod && props.touched.ct_taxPeriod && (
+                                    <div className="invalid-feedback">
+                                      {props.errors.ct_taxPeriod}
+                                    </div>
+                                  )}
                                 </Col>
                                 <Col lg={3}>
                                   <FormGroup className="mb-3">
                                     <Label htmlFor="totalAmount">
-                                      <span className="text-danger">* </span> {strings.TotalCorporateTaxAmount}
+                                      <span className="text-danger">* </span>{' '}
+                                      {strings.TotalCorporateTaxAmount}
                                     </Label>
                                     <Input
                                       type="number"
@@ -1805,71 +1611,66 @@ class CreateBankTransaction extends React.Component {
                                       name="totalAmount"
                                       placeholder={strings.Enter + strings.TotalCorporateTaxAmount}
                                       value={props.values.totalAmount}
-                                      onChange={(option) => {
+                                      onChange={option => {
                                         if (
-                                          option.target.value === '' ||
-                                          this.regDecimal.test(option.target.value),
-                                          props.handleChange('totalAmount')(option)
+                                          (option.target.value === '' ||
+                                            this.regDecimal.test(option.target.value),
+                                          props.handleChange('totalAmount')(option))
                                         ) {
                                           props.handleChange('totalAmount')(option);
                                         }
                                       }}
                                       className={
-                                        props.errors.totalAmount &&
-                                          props.touched.totalAmount
+                                        props.errors.totalAmount && props.touched.totalAmount
                                           ? 'is-invalid'
                                           : ''
                                       }
                                     />
-                                    {props.errors.totalAmount &&
-                                      props.touched.totalAmount && (
-                                        <div className="invalid-feedback">
-                                          {props.errors.totalAmount}
-                                        </div>
-                                      )}
+                                    {props.errors.totalAmount && props.touched.totalAmount && (
+                                      <div className="invalid-feedback">
+                                        {props.errors.totalAmount}
+                                      </div>
+                                    )}
                                   </FormGroup>
                                 </Col>
                                 <Col lg={3}>
                                   <FormGroup className="mb-3">
                                     <Label htmlFor="project">
-                                      <span className="text-danger">* </span>{' '}
-                                      Balance Due
+                                      <span className="text-danger">* </span> Balance Due
                                     </Label>
                                     <Input
                                       disabled
                                       type="number"
-                                      placeholder='Enter Balance Amount'
+                                      placeholder="Enter Balance Amount"
                                       id="balanceDue"
                                       name="balanceDue"
                                       value={props.values.balanceDue}
-                                      onChange={(option) => {
+                                      onChange={option => {
                                         if (
-                                          option.target.value === '' ||
-                                          this.regDecimal.test(option.target.value),
-                                          props.handleChange('balanceDue')(option)
+                                          (option.target.value === '' ||
+                                            this.regDecimal.test(option.target.value),
+                                          props.handleChange('balanceDue')(option))
                                         ) {
                                           props.handleChange('balanceDue')(option);
                                         }
                                       }}
                                       className={
-                                        props.errors.balanceDue &&
-                                          props.touched.balanceDue
+                                        props.errors.balanceDue && props.touched.balanceDue
                                           ? 'is-invalid'
                                           : ''
                                       }
                                     />
-                                    {props.errors.balanceDue &&
-                                      props.touched.balanceDue && (
-                                        <div className="invalid-feedback">
-                                          {props.errors.balanceDue}
-                                        </div>
-                                      )}
+                                    {props.errors.balanceDue && props.touched.balanceDue && (
+                                      <div className="invalid-feedback">
+                                        {props.errors.balanceDue}
+                                      </div>
+                                    )}
                                   </FormGroup>
                                 </Col>
                               </Row>
                             )}
                             {props.values.coaCategoryId &&
-                              props.values.coaCategoryId?.label === "Expense" && (
+                              props.values.coaCategoryId?.label === 'Expense' && (
                                 <Row>
                                   <Col lg={3}>
                                     <FormGroup className="mb-3">
@@ -1885,16 +1686,16 @@ class CreateBankTransaction extends React.Component {
                                             ? this.expense_categories_list_generate()
                                             : []
                                         }
-                                        onChange={(option) => {
-                                          props.handleChange("expenseCategory")(option,);
+                                        onChange={option => {
+                                          props.handleChange('expenseCategory')(option);
                                         }}
                                         id="expenseCategory"
                                         name="expenseCategory"
                                         className={
                                           props.errors.expenseCategory &&
-                                            props.touched.expenseCategory
-                                            ? "is-invalid"
-                                            : ""
+                                          props.touched.expenseCategory
+                                            ? 'is-invalid'
+                                            : ''
                                         }
                                       />
                                       {props.errors.expenseCategory &&
@@ -1908,21 +1709,15 @@ class CreateBankTransaction extends React.Component {
                                   {props.values.expenseCategory &&
                                     props.values.expenseCategory.value &&
                                     props.values.expenseCategory.value == 34 &&
-                                    this.getPayrollList(
-                                      UnPaidPayrolls_List,
-                                      props
-                                    )}
+                                    this.getPayrollList(UnPaidPayrolls_List, props)}
                                   {props.values.coaCategoryId &&
-                                    props.values.coaCategoryId?.label ===
-                                    "Expense" &&
+                                    props.values.coaCategoryId?.label === 'Expense' &&
                                     props.values.expenseCategory &&
-                                    props.values.expenseCategory.value !==
-                                    34 && this.state.isRegisteredVat && (
+                                    props.values.expenseCategory.value !== 34 &&
+                                    this.state.isRegisteredVat && (
                                       <Col lg={3}>
                                         <FormGroup className="mb-3">
-                                          <span className="text-danger">
-                                            *{" "}
-                                          </span>
+                                          <span className="text-danger">* </span>
                                           <Label htmlFor="vatId">VAT</Label>
                                           <Select
                                             style={customStyles}
@@ -1930,81 +1725,64 @@ class CreateBankTransaction extends React.Component {
                                             options={
                                               vat_list
                                                 ? selectOptionsFactory.renderOptions(
-                                                  "name",
-                                                  "id",
-                                                  this.getVatListByIds(
-                                                    this.state
-                                                      .isReverseChargeEnabled
-                                                      ? [1, 2]
-                                                      : [1, 2, 3, 4]
-                                                  ),
-                                                  "Tax"
-                                                )
+                                                    'name',
+                                                    'id',
+                                                    this.getVatListByIds(
+                                                      this.state.isReverseChargeEnabled
+                                                        ? [1, 2]
+                                                        : [1, 2, 3, 4]
+                                                    ),
+                                                    'Tax'
+                                                  )
                                                 : []
                                             }
-                                            onChange={(option) => {
+                                            onChange={option => {
                                               if (option && option.value) {
-                                                props.handleChange("vatId")(
-                                                  option
-                                                );
+                                                props.handleChange('vatId')(option);
                                               } else {
-                                                props.handleChange("vatId")("");
+                                                props.handleChange('vatId')('');
                                               }
                                             }}
-                                            placeholder={strings.Select + " VAT"}
+                                            placeholder={strings.Select + ' VAT'}
                                             id="vatId"
                                             name="vatId"
                                             className={
-                                              props.errors.vatId &&
-                                                props.touched.vatId
-                                                ? "is-invalid"
-                                                : ""
+                                              props.errors.vatId && props.touched.vatId
+                                                ? 'is-invalid'
+                                                : ''
                                             }
                                           />
-                                          {props.errors.vatId &&
-                                            props.touched.vatId && (
-                                              <div className="invalid-feedback">
-                                                {props.errors.vatId}
-                                              </div>
-                                            )}
+                                          {props.errors.vatId && props.touched.vatId && (
+                                            <div className="invalid-feedback">
+                                              {props.errors.vatId}
+                                            </div>
+                                          )}
                                         </FormGroup>
                                       </Col>
                                     )}
                                   {props.values.coaCategoryId &&
-                                    props.values.coaCategoryId?.label ===
-                                    "Expense" &&
+                                    props.values.coaCategoryId?.label === 'Expense' &&
                                     props.values.expenseCategory &&
-                                    props.values.expenseCategory.value !==
-                                    34 && (
+                                    props.values.expenseCategory.value !== 34 && (
                                       <Col className="mb-6" lg={6}>
                                         <Label htmlFor="inline-radio3">
                                           <span className="text-danger">* </span>
                                           {strings.ExpenseType}
                                         </Label>
-                                        <div style={{ display: "flex" }}>
+                                        <div style={{ display: 'flex' }}>
                                           {this.state.expenseType === false ? (
-                                            <span
-                                              style={{ color: "#0069d9" }}
-                                              className="mr-4"
-                                            >
+                                            <span style={{ color: '#0069d9' }} className="mr-4">
                                               <b>{strings.NonClaimable}</b>
                                             </span>
                                           ) : (
-                                            <span className="mr-4">
-                                              {strings.NonClaimable}
-                                            </span>
+                                            <span className="mr-4">{strings.NonClaimable}</span>
                                           )}
 
                                           <Switch
                                             checked={this.state.expenseType}
-                                            onChange={(expenseType) => {
-                                              props.handleChange("expenseType")(
-                                                expenseType
-                                              );
-                                              this.setState(
-                                                { expenseType },
-                                                () => { }
-                                              );
+                                            onChange={expenseType => {
+                                              props.handleChange('expenseType')(expenseType);
+                                              this.setState({ expenseType }, () => {});
                                             }}
                                             onColor="#2064d8"
                                             onHandleColor="#2693e6"
@@ -2019,16 +1797,11 @@ class CreateBankTransaction extends React.Component {
                                           />
 
                                           {this.state.expenseType === true ? (
-                                            <span
-                                              style={{ color: "#0069d9" }}
-                                              className="ml-4"
-                                            >
+                                            <span style={{ color: '#0069d9' }} className="ml-4">
                                               <b>{strings.Claimable}</b>
                                             </span>
                                           ) : (
-                                            <span className="ml-4">
-                                              {strings.Claimable}
-                                            </span>
+                                            <span className="ml-4">{strings.Claimable}</span>
                                           )}
                                         </div>
                                       </Col>
@@ -2036,48 +1809,33 @@ class CreateBankTransaction extends React.Component {
                                 </Row>
                               )}
                             {props.values.coaCategoryId &&
-                              props.values.coaCategoryId?.label === "Expense" &&
+                              props.values.coaCategoryId?.label === 'Expense' &&
                               props.values?.vatId?.value === 1 && (
                                 <Row>
                                   <Col lg={3}></Col>
                                   {props.values.expenseCategory &&
                                     props.values.expenseCategory.value &&
                                     props.values.expenseCategory.value == 34 &&
-                                    this.getPayrollList(
-                                      UnPaidPayrolls_List,
-                                      props
-                                    )}
+                                    this.getPayrollList(UnPaidPayrolls_List, props)}
                                   {props.values.coaCategoryId &&
-                                    props.values.coaCategoryId?.label ===
-                                    "Expense" &&
+                                    props.values.coaCategoryId?.label === 'Expense' &&
                                     props.values.expenseCategory &&
-                                    props.values.expenseCategory.value !==
-                                    34 && (
+                                    props.values.expenseCategory.value !== 34 && (
                                       <Col lg={3}>
-                                        <div style={{ display: "flex" }}>
+                                        <div style={{ display: 'flex' }}>
                                           {!this.state.exclusiveVat ? (
-                                            <span
-                                              style={{ color: "#0069d9" }}
-                                              className="mr-4"
-                                            >
+                                            <span style={{ color: '#0069d9' }} className="mr-4">
                                               <b>{strings.InclusiveVAT}</b>
                                             </span>
                                           ) : (
-                                            <span className="mr-4">
-                                              {strings.InclusiveVAT}
-                                            </span>
+                                            <span className="mr-4">{strings.InclusiveVAT}</span>
                                           )}
 
                                           <Switch
                                             checked={this.state.exclusiveVat}
-                                            onChange={(exclusiveVat) => {
-                                              props.handleChange(
-                                                "exclusiveVat"
-                                              )(exclusiveVat);
-                                              this.setState(
-                                                { exclusiveVat },
-                                                () => { }
-                                              );
+                                            onChange={exclusiveVat => {
+                                              props.handleChange('exclusiveVat')(exclusiveVat);
+                                              this.setState({ exclusiveVat }, () => {});
                                             }}
                                             onColor="#2064d8"
                                             onHandleColor="#2693e6"
@@ -2092,16 +1850,11 @@ class CreateBankTransaction extends React.Component {
                                           />
 
                                           {this.state.exclusiveVat ? (
-                                            <span
-                                              style={{ color: "#0069d9" }}
-                                              className="ml-4"
-                                            >
+                                            <span style={{ color: '#0069d9' }} className="ml-4">
                                               <b>{strings.ExclusiveVAT}</b>
                                             </span>
                                           ) : (
-                                            <span className="ml-4">
-                                              {strings.ExclusiveVAT}
-                                            </span>
+                                            <span className="ml-4">{strings.ExclusiveVAT}</span>
                                           )}
                                         </div>
                                       </Col>
@@ -2111,26 +1864,24 @@ class CreateBankTransaction extends React.Component {
                               )}
                             <Row>
                               {props.values.coaCategoryId &&
-                                props.values.coaCategoryId?.label ===
-                                "Expense" &&
+                                props.values.coaCategoryId?.label === 'Expense' &&
                                 props.values.expenseCategory &&
-                                props.values.expenseCategory.value !==
-                                34 && (
+                                props.values.expenseCategory.value !== 34 && (
                                   <Col>
                                     <Checkbox
                                       id="isReverseChargeEnabled"
                                       checked={this.state.isReverseChargeEnabled}
-                                      onChange={(option) => {
+                                      onChange={option => {
                                         this.setState({
                                           isReverseChargeEnabled:
                                             !this.state.isReverseChargeEnabled,
                                           exclusiveVat: false,
                                         });
 
-                                        props.handleChange("vatId")("");
-                                        props.handleChange(
-                                          "isReverseChargeEnabled"
-                                        )(!props.values.isReverseChargeEnabled);
+                                        props.handleChange('vatId')('');
+                                        props.handleChange('isReverseChargeEnabled')(
+                                          !props.values.isReverseChargeEnabled
+                                        );
                                       }}
                                     />
                                     <Label>{strings.IsReverseCharge}</Label>
@@ -2138,8 +1889,7 @@ class CreateBankTransaction extends React.Component {
                                 )}
                             </Row>
                             {props.values.coaCategoryId &&
-                              props.values.coaCategoryId?.label ===
-                              "Supplier Invoice" && (
+                              props.values.coaCategoryId?.label === 'Supplier Invoice' && (
                                 <Row>
                                   <Col lg={3}>
                                     <FormGroup className="mb-3">
@@ -2151,23 +1901,19 @@ class CreateBankTransaction extends React.Component {
                                         options={
                                           tmpSupplier_list
                                             ? selectOptionsFactory.renderOptions(
-                                              "label",
-                                              "value",
-                                              tmpSupplier_list,
-                                              "Supplier Name"
-                                            )
+                                                'label',
+                                                'value',
+                                                tmpSupplier_list,
+                                                'Supplier Name'
+                                              )
                                             : []
                                         }
-                                        onChange={(option) => {
+                                        onChange={option => {
                                           if (option && option.value) {
-                                            props.handleChange("vendorId")(
-                                              option
-                                            );
-                                            props.handleChange("invoiceIdList")(
-                                              []
-                                            );
+                                            props.handleChange('vendorId')(option);
+                                            props.handleChange('invoiceIdList')([]);
                                           } else {
-                                            props.handleChange("vendorId")("");
+                                            props.handleChange('vendorId')('');
                                           }
 
                                           this.getSuggestionInvoicesFotVend(
@@ -2175,58 +1921,57 @@ class CreateBankTransaction extends React.Component {
                                             props.values.transactionAmount
                                           );
                                         }}
-                                        placeholder={strings.Select + " Vendor"}
+                                        placeholder={strings.Select + ' Vendor'}
                                         id="vendorId"
                                         name="vendorId"
                                         className={
-                                          props.errors.vendorId &&
-                                            props.touched.vendorId
-                                            ? "is-invalid"
-                                            : ""
+                                          props.errors.vendorId && props.touched.vendorId
+                                            ? 'is-invalid'
+                                            : ''
                                         }
                                       />
 
-                                      {props.errors.vendorId &&
-                                        props.touched.vendorId && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.vendorId}
-                                          </div>
-                                        )}
+                                      {props.errors.vendorId && props.touched.vendorId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.vendorId}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                   {props.values.coaCategoryId &&
-                                    props.values.coaCategoryId?.label ===
-                                    "Supplier Invoice" && (
+                                    props.values.coaCategoryId?.label === 'Supplier Invoice' && (
                                       <Col lg={3}>
                                         <FormGroup className="mb-3">
                                           <Label htmlFor="invoiceIdList">
-                                            <span className="text-danger">
-                                              *{" "}
-                                            </span>
+                                            <span className="text-danger">* </span>
                                             Invoice
                                           </Label>
                                           <Select
                                             style={customStyles}
                                             isMulti
                                             options={
-                                              vendor_invoice_list
-                                                ? vendor_invoice_list.data
-                                                : []
+                                              vendor_invoice_list ? vendor_invoice_list.data : []
                                             }
-                                            onChange={(selectedOptions) => {
-                                              if (!selectedOptions || selectedOptions.length === 0) {
-
-                                                props.setFieldValue("transactionAmount", 0);
-                                                props.setFieldValue("invoiceIdList", []);
+                                            onChange={selectedOptions => {
+                                              if (
+                                                !selectedOptions ||
+                                                selectedOptions.length === 0
+                                              ) {
+                                                props.setFieldValue('transactionAmount', 0);
+                                                props.setFieldValue('invoiceIdList', []);
                                                 return;
                                               }
 
                                               const totalDueAmount = selectedOptions.reduce(
-                                                (acc, selectedOption) => acc + (selectedOption.dueAmount || 0),
+                                                (acc, selectedOption) =>
+                                                  acc + (selectedOption.dueAmount || 0),
                                                 0
                                               );
 
-                                              props.setFieldValue("transactionAmount", totalDueAmount);
+                                              props.setFieldValue(
+                                                'transactionAmount',
+                                                totalDueAmount
+                                              );
 
                                               this.setexchnagedamount(selectedOptions);
                                               this.totalAmount(selectedOptions);
@@ -2238,16 +1983,14 @@ class CreateBankTransaction extends React.Component {
                                               }
                                             }}
                                             value={props.values.invoiceIdList}
-                                            placeholder={
-                                              strings.Select + " Invoice"
-                                            }
+                                            placeholder={strings.Select + ' Invoice'}
                                             id="invoiceIdList"
                                             name="invoiceIdList"
                                             className={
                                               props.errors.invoiceIdList &&
-                                                props.touched.invoiceIdList
-                                                ? "is-invalid"
-                                                : ""
+                                              props.touched.invoiceIdList
+                                                ? 'is-invalid'
+                                                : ''
                                             }
                                           />
                                           {props.errors.invoiceIdList &&
@@ -2266,18 +2009,16 @@ class CreateBankTransaction extends React.Component {
                                                 className={
                                                   this.state.initValue.invoiceIdList.reduce(
                                                     (totalAmount, invoice) =>
-                                                      totalAmount +
-                                                      invoice.amount,
+                                                      totalAmount + invoice.amount,
                                                     0
-                                                  ) >
-                                                    this.state.initValue.amount
-                                                    ? "is-invalid"
-                                                    : ""
+                                                  ) > this.state.initValue.amount
+                                                    ? 'is-invalid'
+                                                    : ''
                                                 }
                                               >
                                                 <div className="invalid-feedback">
-                                                  Total Invoice Amount Is More
-                                                  Than The Transaction Amount
+                                                  Total Invoice Amount Is More Than The Transaction
+                                                  Amount
                                                 </div>
                                               </div>
                                             )}
@@ -2287,11 +2028,11 @@ class CreateBankTransaction extends React.Component {
                                 </Row>
                               )}
                             {transactionCategoryList.categoriesList &&
-                              props.values.coaCategoryId?.label !== "VAT Payment" &&
-                              props.values.coaCategoryId?.label !== "VAT Claim" &&
-                              props.values.coaCategoryId?.label !== "Expense" &&
-                              props.values.coaCategoryId?.label !== "Supplier Invoice" &&
-                              props.values.coaCategoryId?.label !== "Sales" && (
+                              props.values.coaCategoryId?.label !== 'VAT Payment' &&
+                              props.values.coaCategoryId?.label !== 'VAT Claim' &&
+                              props.values.coaCategoryId?.label !== 'Expense' &&
+                              props.values.coaCategoryId?.label !== 'Supplier Invoice' &&
+                              props.values.coaCategoryId?.label !== 'Sales' && (
                                 <Row>
                                   <Col lg={3}>
                                     <FormGroup className="mb-3">
@@ -2302,9 +2043,7 @@ class CreateBankTransaction extends React.Component {
                                       <Select
                                         style={customStyles}
                                         // className="select-default-width"
-                                        placeholder={
-                                          strings.Select + " Category"
-                                        }
+                                        placeholder={strings.Select + ' Category'}
                                         options={
                                           transactionCategoryList
                                             ? transactionCategoryList.categoriesList
@@ -2313,84 +2052,61 @@ class CreateBankTransaction extends React.Component {
                                         value={
                                           transactionCategoryList
                                             ? props.values.transactionCategoryId
-                                            : ""
+                                            : ''
                                         }
                                         id="transactionCategoryId"
-                                        onChange={(option) => {
+                                        onChange={option => {
                                           if (option && option.value) {
-                                            props.handleChange(
-                                              "transactionCategoryId"
-                                            )(option);
+                                            props.handleChange('transactionCategoryId')(option);
                                           } else {
-                                            props.handleChange(
-                                              "transactionCategoryId"
-                                            )("");
+                                            props.handleChange('transactionCategoryId')('');
                                           }
                                           if (
-                                            option.label !== "Salaries and Employee Wages" &&
-                                            option.label !== "Owners Drawing" &&
-                                            option.label !== "Dividend" &&
-                                            option.label !== "Owners Current Account" &&
-                                            option.label !== "Share Premium" &&
-                                            option.label !== "Employee Advance" &&
-                                            option.label !== "Employee Reimbursements" &&
-                                            option.label !== "Director Loan Account" &&
-                                            option.label !== "Owners Equity"
+                                            option.label !== 'Salaries and Employee Wages' &&
+                                            option.label !== 'Owners Drawing' &&
+                                            option.label !== 'Dividend' &&
+                                            option.label !== 'Owners Current Account' &&
+                                            option.label !== 'Share Premium' &&
+                                            option.label !== 'Employee Advance' &&
+                                            option.label !== 'Employee Reimbursements' &&
+                                            option.label !== 'Director Loan Account' &&
+                                            option.label !== 'Owners Equity'
                                           ) {
                                           }
-                                          if (
-                                            option.label ===
-                                            "Salaries and Employee Wages"
-                                          ) {
+                                          if (option.label === 'Salaries and Employee Wages') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label === "Owners Drawing"
-                                          ) {
+                                          if (option.label === 'Owners Drawing') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (option.label === "Dividend") {
+                                          if (option.label === 'Dividend') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label ===
-                                            "Owners Current Account"
-                                          ) {
+                                          if (option.label === 'Owners Current Account') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label === "Share Premium"
-                                          ) {
+                                          if (option.label === 'Share Premium') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label === "Employee Advance"
-                                          ) {
+                                          if (option.label === 'Employee Advance') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label ===
-                                            "Employee Reimbursements"
-                                          ) {
+                                          if (option.label === 'Employee Reimbursements') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label ===
-                                            "Director Loan Account"
-                                          ) {
+                                          if (option.label === 'Director Loan Account') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
-                                          if (
-                                            option.label === "Owners Equity"
-                                          ) {
+                                          if (option.label === 'Owners Equity') {
                                             this.getMoneyPaidToUserlist(option);
                                           }
                                         }}
-                                        className={`${props.errors.transactionCategoryId &&
+                                        className={`${
+                                          props.errors.transactionCategoryId &&
                                           props.touched.transactionCategoryId
-                                          ? "is-invalid"
-                                          : ""
-                                          }`}
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
                                       />
                                       {props.errors.transactionCategoryId &&
                                         props.touched.transactionCategoryId && (
@@ -2414,30 +2130,23 @@ class CreateBankTransaction extends React.Component {
                                       <Select
                                         style={customStyles}
                                         //className="select-default-width"
-                                        options={
-                                          moneyCategoryList
-                                            ? moneyCategoryList
-                                            : []
-                                        }
+                                        options={moneyCategoryList ? moneyCategoryList : []}
                                         id="employeeId"
                                         value={props.values.employeeId}
-                                        onChange={(option) => {
-                                          props.handleChange("employeeId")(
-                                            option
-                                          );
+                                        onChange={option => {
+                                          props.handleChange('employeeId')(option);
                                         }}
-                                        className={`${props.errors.employeeId &&
-                                          props.touched.employeeId
-                                          ? "is-invalid"
-                                          : ""
-                                          }`}
+                                        className={`${
+                                          props.errors.employeeId && props.touched.employeeId
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
                                       />
-                                      {props.errors.employeeId &&
-                                        props.touched.employeeId && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.employeeId}
-                                          </div>
-                                        )}
+                                      {props.errors.employeeId && props.touched.employeeId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.employeeId}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                 )}
@@ -2450,91 +2159,71 @@ class CreateBankTransaction extends React.Component {
                                       </Label>
                                       <Select
                                         style={customStyles}
-                                        options={
-                                          moneyCategoryList
-                                            ? moneyCategoryList
-                                            : []
-                                        }
+                                        options={moneyCategoryList ? moneyCategoryList : []}
                                         id="employeeId"
                                         value={props.values.employeeId}
-                                        onChange={(option) => {
-                                          props.handleChange("employeeId")(
-                                            option
-                                          );
+                                        onChange={option => {
+                                          props.handleChange('employeeId')(option);
                                         }}
-                                        className={`${props.errors.employeeId &&
-                                          props.touched.employeeId
-                                          ? "is-invalid"
-                                          : ""
-                                          }`}
+                                        className={`${
+                                          props.errors.employeeId && props.touched.employeeId
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
                                       />
-                                      {props.errors.employeeId &&
-                                        props.touched.employeeId && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.employeeId}
-                                          </div>
-                                        )}
+                                      {props.errors.employeeId && props.touched.employeeId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.employeeId}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                 )}
 
-                                {props.values.coaCategoryId?.label ===
-                                  "Sales" && (
-                                    <Col lg={3}>
-                                      <FormGroup className="mb-3">
-                                        <Label htmlFor="customerId">
-                                          {" "}
-                                          <span className="text-danger">* </span>
-                                          Customer
-                                        </Label>
-                                        <Select
-                                          style={customStyles}
-                                          placeholder={
-                                            strings.Select + " Customer"
-                                          }
-                                          className={`select-default-width , ${props.errors.customerId &&
-                                            props.touched.customerId
-                                            ? "is-invalid"
-                                            : ""
-                                            }`}
-                                          options={
-                                            transactionCategoryList &&
-                                              transactionCategoryList.dataList[1]
-                                              ? transactionCategoryList
-                                                .dataList[0].options
-                                              : []
-                                          }
-                                          id="customerId"
-                                          value={props.values.customerId}
-                                          onChange={(option) => {
-                                            props.handleChange("customerId")(
-                                              option
-                                            );
+                                {props.values.coaCategoryId?.label === 'Sales' && (
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="customerId">
+                                        {' '}
+                                        <span className="text-danger">* </span>
+                                        Customer
+                                      </Label>
+                                      <Select
+                                        style={customStyles}
+                                        placeholder={strings.Select + ' Customer'}
+                                        className={`select-default-width , ${
+                                          props.errors.customerId && props.touched.customerId
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
+                                        options={
+                                          transactionCategoryList &&
+                                          transactionCategoryList.dataList[1]
+                                            ? transactionCategoryList.dataList[0].options
+                                            : []
+                                        }
+                                        id="customerId"
+                                        value={props.values.customerId}
+                                        onChange={option => {
+                                          props.handleChange('customerId')(option);
 
-                                            props.handleChange("invoiceIdList")(
-                                              []
-                                            );
-                                            this.getInvoices(
-                                              option,
-                                              props.values.transactionAmount
-                                            );
+                                          props.handleChange('invoiceIdList')([]);
+                                          this.getInvoices(option, props.values.transactionAmount);
 
-                                            this.getSuggestionInvoicesFotCust(
-                                              option.value,
-                                              props.values.transactionAmount
-                                            );
-
-                                          }}
-                                        />
-                                        {props.errors.customerId &&
-                                          props.touched.customerId && (
-                                            <div className="invalid-feedback">
-                                              {props.errors.customerId}
-                                            </div>
-                                          )}
-                                      </FormGroup>
-                                    </Col>
-                                  )}
+                                          this.getSuggestionInvoicesFotCust(
+                                            option.value,
+                                            props.values.transactionAmount
+                                          );
+                                        }}
+                                      />
+                                      {props.errors.customerId && props.touched.customerId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.customerId}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                )}
                                 {props.values.coaCategoryId.value === 2 && (
                                   <Col lg={3}>
                                     <FormGroup className="mb-3">
@@ -2544,12 +2233,13 @@ class CreateBankTransaction extends React.Component {
                                       </Label>
                                       <Select
                                         style={customStyles}
-                                        placeholder={strings.Select + " Invoice"}
+                                        placeholder={strings.Select + ' Invoice'}
                                         isMulti
-                                        className={`select-default-width, ${props.errors.invoiceIdList &&
-                                          props.touched.invoiceIdList
-                                          ? "is-invalid"
-                                          : ""}`}
+                                        className={`select-default-width, ${
+                                          props.errors.invoiceIdList && props.touched.invoiceIdList
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
                                         options={
                                           customer_invoice_list && customer_invoice_list.data
                                             ? customer_invoice_list.data
@@ -2557,20 +2247,20 @@ class CreateBankTransaction extends React.Component {
                                         }
                                         value={props.values.invoiceIdList}
                                         id="invoiceIdList"
-                                        onChange={(selectedOptions) => {
+                                        onChange={selectedOptions => {
                                           if (!selectedOptions || selectedOptions.length === 0) {
-
-                                            props.setFieldValue("transactionAmount", 0);
-                                            props.setFieldValue("invoiceIdList", []);
+                                            props.setFieldValue('transactionAmount', 0);
+                                            props.setFieldValue('invoiceIdList', []);
                                             return;
                                           }
 
                                           const totalDueAmount = selectedOptions.reduce(
-                                            (acc, selectedOption) => acc + (selectedOption.dueAmount || 0),
+                                            (acc, selectedOption) =>
+                                              acc + (selectedOption.dueAmount || 0),
                                             0
                                           );
 
-                                          props.setFieldValue("transactionAmount", totalDueAmount);
+                                          props.setFieldValue('transactionAmount', totalDueAmount);
 
                                           this.setexchnagedamount(selectedOptions);
                                           this.totalAmount(selectedOptions);
@@ -2593,68 +2283,55 @@ class CreateBankTransaction extends React.Component {
                             )}
 
                             {props.values.coaCategoryId &&
-                              (props.values.coaCategoryId?.label === "Sales" ||
-                                props.values.coaCategoryId?.label ===
-                                "Supplier Invoice") && (
+                              (props.values.coaCategoryId?.label === 'Sales' ||
+                                props.values.coaCategoryId?.label === 'Supplier Invoice') && (
                                 <>
                                   {props.values?.invoiceIdList.length > 0 && (
                                     <Row
                                       className="border-bottom mb-3"
                                       style={{
-                                        display: "flex",
-                                        justifyContent: "space-between",
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
                                       }}
                                     >
                                       <Col lg={1}>
-                                        <span className="font-weight-bold">
-                                          {" "}
-                                          Invoice
-                                        </span>
+                                        <span className="font-weight-bold"> Invoice</span>
                                       </Col>
                                       <Col lg={2}>
-                                        <span className="font-weight-bold">
-                                          {" "}
-                                          Invoice Date
-                                        </span>
+                                        <span className="font-weight-bold"> Invoice Date</span>
                                       </Col>
                                       <Col lg={2}>
-                                        <span className="font-weight-bold">
-                                          Invoice Amount
-                                        </span>
+                                        <span className="font-weight-bold">Invoice Amount</span>
                                       </Col>
-                                      {this.state.bankCurrency
-                                        .bankAccountCurrencyIsoCode !==
+                                      {this.state.bankCurrency.bankAccountCurrencyIsoCode !==
                                         props.values.curreancyname && (
-                                          <Col lg={2}>
-                                            <FormGroup className="mb-3">
-                                              <div>
-                                                <span className="font-weight-bold">
-                                                  Currency Rate
-                                                </span>
-                                              </div>
-                                            </FormGroup>
-                                          </Col>
-                                        )}
-                                      {this.state.bankCurrency
-                                        .bankAccountCurrencyIsoCode !==
+                                        <Col lg={2}>
+                                          <FormGroup className="mb-3">
+                                            <div>
+                                              <span className="font-weight-bold">
+                                                Currency Rate
+                                              </span>
+                                            </div>
+                                          </FormGroup>
+                                        </Col>
+                                      )}
+                                      {this.state.bankCurrency.bankAccountCurrencyIsoCode !==
                                         props.values.curreancyname && (
-                                          <Col lg={2}>
-                                            <FormGroup className="mb-3">
-                                              <div>
-                                                <span className="font-weight-bold">
-                                                  Amount
-                                                </span>
-                                              </div>
-                                            </FormGroup>
-                                          </Col>
-                                        )}
+                                        <Col lg={2}>
+                                          <FormGroup className="mb-3">
+                                            <div>
+                                              <span className="font-weight-bold">Amount</span>
+                                            </div>
+                                          </FormGroup>
+                                        </Col>
+                                      )}
                                       <Col lg={1}>
                                         <FormGroup
                                           className="font-weight-bold "
                                           style={{
-                                            display: "flex",
-                                            justifyContent: "center",
-                                            alignItems: "center",
+                                            display: 'flex',
+                                            justifyContent: 'center',
+                                            alignItems: 'center',
                                           }}
                                         >
                                           <div>Partially Paid</div>
@@ -2670,227 +2347,204 @@ class CreateBankTransaction extends React.Component {
                                       </Col>
                                     </Row>
                                   )}
-                                  {props.values?.invoiceIdList?.map(
-                                    (i, invindex) => {
-                                      return (
-                                        <Row
-                                          style={{
-                                            display: "flex",
-                                            justifyContent: "space-between",
-                                          }}
-                                        >
-                                          <Col lg={1}>
-                                            <span>{i.invoiceNumber}</span>
-                                          </Col>
+                                  {props.values?.invoiceIdList?.map((i, invindex) => {
+                                    return (
+                                      <Row
+                                        style={{
+                                          display: 'flex',
+                                          justifyContent: 'space-between',
+                                        }}
+                                      >
+                                        <Col lg={1}>
+                                          <span>{i.invoiceNumber}</span>
+                                        </Col>
+                                        <Col lg={2}>
+                                          <Input
+                                            disabled
+                                            id="1"
+                                            name="1"
+                                            value={dayjs(i.invoiceDate).format('DD-MM-YYYY')}
+                                          />
+                                        </Col>
+                                        <Col lg={2}>
+                                          <Input
+                                            style={{ textAlign: 'right' }}
+                                            disabled
+                                            id="1"
+                                            name="1"
+                                            value={` ${props.values.curreancyname} ${i.dueAmount}`}
+                                          />
+                                        </Col>
+
+                                        {this.state.bankCurrency.bankAccountCurrencyIsoCode !==
+                                          props.values.curreancyname && (
                                           <Col lg={2}>
-                                            <Input
-                                              disabled
-                                              id="1"
-                                              name="1"
-                                              value={dayjs(
-                                                i.invoiceDate
-                                              ).format("DD-MM-YYYY")}
-                                            />
-                                          </Col>
-                                          <Col lg={2}>
-                                            <Input
-                                              style={{ textAlign: "right" }}
-                                              disabled
-                                              id="1"
-                                              name="1"
-                                              value={` ${props.values.curreancyname} ${i.dueAmount}`}
-                                            />
-                                          </Col>
-
-                                          {this.state.bankCurrency
-                                            .bankAccountCurrencyIsoCode !==
-                                            props.values.curreancyname && (
-                                              <Col lg={2}>
-                                                <FormGroup className="mb-3">
-                                                  <div>
-                                                    <Input
-                                                      className="form-control"
-                                                      id="exchangeamount"
-                                                      name="exchangeamount"
-                                                      type="number"
-                                                      style={{
-                                                        textAlign: "right",
-                                                      }}
-                                                      disabled
-                                                      value={i.exchangeRate}
-                                                      onChange={(value) => {
-                                                        let local2 = [
-                                                          ...props.values
-                                                            ?.invoiceIdList,
-                                                        ].map((i) => {
-                                                          return {
-                                                            ...i,
-                                                            exchangeRate:
-                                                              value.target.value,
-                                                          };
-                                                        });
-
-                                                        this.setexchnagedamount(
-                                                          local2
-                                                        );
-                                                      }}
-                                                    />
-                                                  </div>
-                                                </FormGroup>
-                                              </Col>
-                                            )}
-
-                                          {this.state.bankCurrency
-                                            .bankAccountCurrencyIsoCode !==
-                                            props.values.curreancyname && (
-                                              <Col lg={2}>
-                                                <FormGroup className="mb-3">
-                                                  <div>
-                                                    <Input
-                                                      className="form-control"
-                                                      id="exchangeRate"
-                                                      style={{
-                                                        textAlign: "right",
-                                                      }}
-                                                      name="exchangeRate"
-                                                      disabled
-                                                      value={`${this.state.bankCurrency
-                                                        .bankAccountCurrencyIsoCode
-                                                        } ${i.convertedInvoiceAmount?.toLocaleString(
-                                                          navigator.language,
-                                                          {
-                                                            minimumFractionDigits: 2,
-                                                            maximumFractionDigits: 2,
-                                                          }
-                                                        )} `}
-                                                      onChange={(value) => { }}
-                                                    />
-                                                  </div>
-                                                </FormGroup>
-                                              </Col>
-                                            )}
-                                          <Col lg={1}>
-                                            <FormGroup
-                                              className="mb-3"
-                                              style={{
-                                                display: "flex",
-                                                justifyContent: "center",
-                                                alignItems: "center",
-                                              }}
-                                            >
+                                            <FormGroup className="mb-3">
                                               <div>
                                                 <Input
-                                                  disabled={
-                                                    props.values
-                                                      ?.transactionAmount -
-                                                    props.values?.invoiceIdList?.reduce(
-                                                      (accu, curr, index) =>
-                                                        accu +
-                                                        curr.dueAmount *
-                                                        curr.exchangeRate,
-                                                      0
-                                                    ) >=
-                                                    0
-                                                  }
-                                                  type="checkbox"
-                                                  checked={
-                                                    i.pp !== undefined
-                                                      ? i.pp
-                                                      : false
-                                                  }
-                                                  onChange={(e) => {
-                                                    this.onppclick(
-                                                      e.target.checked,
-                                                      invindex
-                                                    );
+                                                  className="form-control"
+                                                  id="exchangeamount"
+                                                  name="exchangeamount"
+                                                  type="number"
+                                                  style={{
+                                                    textAlign: 'right',
+                                                  }}
+                                                  disabled
+                                                  value={i.exchangeRate}
+                                                  onChange={value => {
+                                                    let local2 = [
+                                                      ...props.values?.invoiceIdList,
+                                                    ].map(i => {
+                                                      return {
+                                                        ...i,
+                                                        exchangeRate: value.target.value,
+                                                      };
+                                                    });
+
+                                                    this.setexchnagedamount(local2);
                                                   }}
                                                 />
                                               </div>
                                             </FormGroup>
                                           </Col>
+                                        )}
 
+                                        {this.state.bankCurrency.bankAccountCurrencyIsoCode !==
+                                          props.values.curreancyname && (
                                           <Col lg={2}>
                                             <FormGroup className="mb-3">
                                               <div>
                                                 <Input
                                                   className="form-control"
                                                   id="exchangeRate"
+                                                  style={{
+                                                    textAlign: 'right',
+                                                  }}
                                                   name="exchangeRate"
                                                   disabled
-                                                  style={{ textAlign: "right" }}
-                                                  value={`${this.state.bankCurrency
-                                                    .bankAccountCurrencyIsoCode
-                                                    } ${i.explainedAmount?.toLocaleString(
-                                                      navigator.language,
-                                                      {
-                                                        minimumFractionDigits: 2,
-                                                        maximumFractionDigits: 2,
-                                                      }
-                                                    )} `}
-                                                  onChange={(value) => { }}
+                                                  value={`${
+                                                    this.state.bankCurrency
+                                                      .bankAccountCurrencyIsoCode
+                                                  } ${i.convertedInvoiceAmount?.toLocaleString(
+                                                    navigator.language,
+                                                    {
+                                                      minimumFractionDigits: 2,
+                                                      maximumFractionDigits: 2,
+                                                    }
+                                                  )} `}
+                                                  onChange={value => {}}
                                                 />
-                                                {i.explainedAmount === 0 && (
-                                                  <div
-                                                    style={{
-                                                      color: "red",
-                                                      fontSize: "9px",
-                                                    }}
-                                                  >
-                                                    Expain Amount Cannot be Zero
-                                                  </div>
-                                                )}
                                               </div>
                                             </FormGroup>
                                           </Col>
-                                        </Row>
-                                      );
-                                    }
-                                  )}
+                                        )}
+                                        <Col lg={1}>
+                                          <FormGroup
+                                            className="mb-3"
+                                            style={{
+                                              display: 'flex',
+                                              justifyContent: 'center',
+                                              alignItems: 'center',
+                                            }}
+                                          >
+                                            <div>
+                                              <Input
+                                                disabled={
+                                                  props.values?.transactionAmount -
+                                                    props.values?.invoiceIdList?.reduce(
+                                                      (accu, curr, index) =>
+                                                        accu + curr.dueAmount * curr.exchangeRate,
+                                                      0
+                                                    ) >=
+                                                  0
+                                                }
+                                                type="checkbox"
+                                                checked={i.pp !== undefined ? i.pp : false}
+                                                onChange={e => {
+                                                  this.onppclick(e.target.checked, invindex);
+                                                }}
+                                              />
+                                            </div>
+                                          </FormGroup>
+                                        </Col>
+
+                                        <Col lg={2}>
+                                          <FormGroup className="mb-3">
+                                            <div>
+                                              <Input
+                                                className="form-control"
+                                                id="exchangeRate"
+                                                name="exchangeRate"
+                                                disabled
+                                                style={{ textAlign: 'right' }}
+                                                value={`${
+                                                  this.state.bankCurrency.bankAccountCurrencyIsoCode
+                                                } ${i.explainedAmount?.toLocaleString(
+                                                  navigator.language,
+                                                  {
+                                                    minimumFractionDigits: 2,
+                                                    maximumFractionDigits: 2,
+                                                  }
+                                                )} `}
+                                                onChange={value => {}}
+                                              />
+                                              {i.explainedAmount === 0 && (
+                                                <div
+                                                  style={{
+                                                    color: 'red',
+                                                    fontSize: '9px',
+                                                  }}
+                                                >
+                                                  Expain Amount Cannot be Zero
+                                                </div>
+                                              )}
+                                            </div>
+                                          </FormGroup>
+                                        </Col>
+                                      </Row>
+                                    );
+                                  })}
                                   {props.values?.invoiceIdList?.length > 0 && (
                                     <>
                                       <Row
                                         style={{
-                                          display: "flex",
-                                          flexDirection: "row-reverse",
-                                          justifyContent: "flex-start",
+                                          display: 'flex',
+                                          flexDirection: 'row-reverse',
+                                          justifyContent: 'flex-start',
                                         }}
                                       >
-                                        <Col lg={2} style={{ float: "right" }}>
+                                        <Col lg={2} style={{ float: 'right' }}>
                                           <Input
                                             disabled
-                                            style={{ textAlign: "right" }}
+                                            style={{ textAlign: 'right' }}
                                             id="total"
                                             name="total"
                                             value={amountFormat(
                                               props.values?.invoiceIdList?.reduce(
-                                                (accu, curr) =>
-                                                 curr.explainedAmount,
+                                                (accu, curr) => curr.explainedAmount,
                                                 0
                                               ),
-                                              this.state.bankCurrency
-                                                .bankAccountCurrencyIsoCode
+                                              this.state.bankCurrency.bankAccountCurrencyIsoCode
                                             )}
                                           />
                                         </Col>
                                         <Col lg={3}>
                                           <Input
-                                            style={{ textAlign: "right" }}
+                                            style={{ textAlign: 'right' }}
                                             disabled
                                             id="total"
                                             name="total"
-                                            value={"Total Explained Amount ="}
+                                            value={'Total Explained Amount ='}
                                           />
                                         </Col>
                                       </Row>
-                                      {this.setexcessorshortamount().data !==
-                                        0 &&
-                                        this.state.bankCurrency
-                                          .bankAccountCurrencyIsoCode !==
-                                        props.values.curreancyname && (
+                                      {this.setexcessorshortamount().data !== 0 &&
+                                        this.state.bankCurrency.bankAccountCurrencyIsoCode !==
+                                          props.values.curreancyname && (
                                           <Row
                                             style={{
-                                              display: "flex",
-                                              justifyContent: "flex-end",
+                                              display: 'flex',
+                                              justifyContent: 'flex-end',
 
                                               marginTop: 10,
                                             }}
@@ -2900,28 +2554,25 @@ class CreateBankTransaction extends React.Component {
                                                 <Select
                                                   options={[
                                                     {
-                                                      label: "Currency Gain ",
+                                                      label: 'Currency Gain ',
                                                       value: 79,
                                                     },
                                                     {
-                                                      label: "Currency Loss",
+                                                      label: 'Currency Loss',
                                                       value: 103,
                                                     },
                                                   ]}
                                                   isDisabled={true}
                                                   value={
-                                                    this.setexcessorshortamount()
-                                                      .data < 0
+                                                    this.setexcessorshortamount().data < 0
                                                       ? {
-                                                        label:
-                                                          "Currency Loss",
-                                                        value: 103,
-                                                      }
+                                                          label: 'Currency Loss',
+                                                          value: 103,
+                                                        }
                                                       : {
-                                                        label:
-                                                          "Currency Gain ",
-                                                        value: 103,
-                                                      }
+                                                          label: 'Currency Gain ',
+                                                          value: 103,
+                                                        }
                                                   }
                                                 />
                                               </Col>
@@ -2929,26 +2580,21 @@ class CreateBankTransaction extends React.Component {
 
                                             <Col lg={3}>
                                               <Input
-                                                style={{ textAlign: "right" }}
+                                                style={{ textAlign: 'right' }}
                                                 disabled
                                                 id="total"
                                                 name="total"
-                                                value={
-                                                  "Total Excess/Short Amount = "
-                                                }
+                                                value={'Total Excess/Short Amount = '}
                                               />
                                             </Col>
 
                                             <Col lg={2}>
                                               <Input
-                                                style={{ textAlign: "right" }}
+                                                style={{ textAlign: 'right' }}
                                                 disabled
                                                 id="total"
                                                 name="total"
-                                                value={
-                                                  this.setexcessorshortamount()
-                                                    .value
-                                                }
+                                                value={this.setexcessorshortamount().value}
                                               />
                                             </Col>
                                           </Row>
@@ -2959,17 +2605,14 @@ class CreateBankTransaction extends React.Component {
                               )}
 
                             {props.values.coaCategoryId &&
-                              props.values.coaCategoryId?.label ===
-                              "Supplier Invoice" &&
+                              props.values.coaCategoryId?.label === 'Supplier Invoice' &&
                               (this.state.invoiceCurrency &&
-                                this.state.invoiceCurrency !==
+                              this.state.invoiceCurrency !==
                                 this.state.bankCurrency.bankAccountCurrency ? (
                                 <Row>
                                   <Col lg={3}>
                                     <FormGroup className="mb-3">
-                                      <Label htmlFor="currencyCode">
-                                        {strings.Currency}
-                                      </Label>
+                                      <Label htmlFor="currencyCode">{strings.Currency}</Label>
                                       <Select
                                         style={customStyles}
                                         id="currencyCode"
@@ -2977,125 +2620,100 @@ class CreateBankTransaction extends React.Component {
                                         options={
                                           currency_convert_list
                                             ? selectCurrencyFactory.renderOptions(
-                                              "currencyName",
-                                              "currencyCode",
-                                              currency_convert_list,
-                                              "Currency"
-                                            )
+                                                'currencyName',
+                                                'currencyCode',
+                                                currency_convert_list,
+                                                'Currency'
+                                              )
                                             : []
                                         }
                                         value={
                                           currency_convert_list &&
                                           selectCurrencyFactory
                                             .renderOptions(
-                                              "currencyName",
-                                              "currencyCode",
+                                              'currencyName',
+                                              'currencyCode',
                                               currency_convert_list,
-                                              "Currency"
+                                              'Currency'
                                             )
                                             .find(
-                                              (option) =>
-                                                option.value ===
-                                                +this.state.invoiceCurrency
+                                              option => option.value === +this.state.invoiceCurrency
                                             )
                                         }
                                         isDisabled={true}
-                                        onChange={(option) => {
-                                          props.handleChange("currencyCode")(
-                                            option
-                                          );
+                                        onChange={option => {
+                                          props.handleChange('currencyCode')(option);
                                           this.setExchange(option.value);
                                           this.setCurrency(option.value);
                                         }}
                                       />
-                                      {props.errors.currencyCode &&
-                                        props.touched.currencyCode && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.currencyCode}
-                                          </div>
-                                        )}
+                                      {props.errors.currencyCode && props.touched.currencyCode && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.currencyCode}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                 </Row>
                               ) : (
-                                ""
+                                ''
                               ))}
 
                             {props.values.coaCategoryId &&
-                              (props.values.coaCategoryId?.label ===
-                                "VAT Payment" ||
-                                props.values.coaCategoryId?.label ===
-                                "VAT Claim") && (
+                              (props.values.coaCategoryId?.label === 'VAT Payment' ||
+                                props.values.coaCategoryId?.label === 'VAT Claim') && (
                                 <Row>
                                   <Col lg={4}>
                                     <FormGroup className="mb-3">
-                                      <Label htmlFor="currencyCode">
-                                        VAT Report Number
-                                      </Label>
+                                      <Label htmlFor="currencyCode">VAT Report Number</Label>
                                       <Select
                                         style={customStyles}
                                         id="VATReport"
                                         name="VATReportId"
-                                        options={this.state.VATlist.map((i) => {
+                                        options={this.state.VATlist.map(i => {
                                           return {
                                             label: i.vatNumber,
                                             value: i.id,
                                           };
                                         })}
-                                        value={props.values.VATReportId || ""}
-                                        onChange={(option) => {
-                                          props.handleChange("VATReportId")(
-                                            option
-                                          );
+                                        value={props.values.VATReportId || ''}
+                                        onChange={option => {
+                                          props.handleChange('VATReportId')(option);
                                           const info = this.state.VATlist.find(
-                                            (i) => i.id === option.value
+                                            i => i.id === option.value
                                           );
-                                          props.handleChange("vatAmountpc")(
-                                            info.totalAmount
-                                          );
-                                          if (
-                                            props.values.coaCategoryId
-                                              ?.label === "VAT Claim"
-                                          )
-                                            props.handleChange(
-                                              "transactionAmount"
-                                            )(info.totalAmount);
+                                          props.handleChange('vatAmountpc')(info.totalAmount);
+                                          if (props.values.coaCategoryId?.label === 'VAT Claim')
+                                            props.handleChange('transactionAmount')(
+                                              info.totalAmount
+                                            );
 
-                                          props.handleChange("vatDueAmount")(
-                                            info.dueAmount
-                                          );
+                                          props.handleChange('vatDueAmount')(info.dueAmount);
                                         }}
                                       />
-                                      {props.errors.VATReportId &&
-                                        props.touched.VATReportId && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.VATReportId}
-                                          </div>
-                                        )}
+                                      {props.errors.VATReportId && props.touched.VATReportId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.VATReportId}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                 </Row>
                               )}
                             {props.values.coaCategoryId &&
-                              this.state?.bankCurrency?.bankAccountCurrency !==
-                              150 && <hr />}
+                              this.state?.bankCurrency?.bankAccountCurrency !== 150 && <hr />}
                             {props.values.coaCategoryId &&
-                              this.state?.bankCurrency?.bankAccountCurrency !==
-                              150 && (
+                              this.state?.bankCurrency?.bankAccountCurrency !== 150 && (
                                 <Row>
                                   <Col>
-                                    <Label htmlFor="currency">
-                                      {strings.CurrencyExchangeRate}
-                                    </Label>
+                                    <Label htmlFor="currency">{strings.CurrencyExchangeRate}</Label>
                                   </Col>
                                 </Row>
                               )}
                             {props.values.coaCategoryId &&
-                              props.values?.coaCategoryId?.label !== "Sales" &&
-                              props.values?.coaCategoryId?.label !==
-                              "Supplier Invoice" &&
-                              this.state?.bankCurrency?.bankAccountCurrency !==
-                              150 && (
+                              props.values?.coaCategoryId?.label !== 'Sales' &&
+                              props.values?.coaCategoryId?.label !== 'Supplier Invoice' &&
+                              this.state?.bankCurrency?.bankAccountCurrency !== 150 && (
                                 <Row>
                                   <Col lg={1}>
                                     <Input disabled id="1" name="1" value={1} />
@@ -3112,10 +2730,8 @@ class CreateBankTransaction extends React.Component {
                                           id="currencyName"
                                           name="currencyName"
                                           value={props.values.currencyName}
-                                          onChange={(value) => {
-                                            props.handleChange("curreancyname")(
-                                              value
-                                            );
+                                          onChange={value => {
+                                            props.handleChange('curreancyname')(value);
                                           }}
                                         />
                                       </div>
@@ -3124,7 +2740,7 @@ class CreateBankTransaction extends React.Component {
                                   <FormGroup className="mt-2">
                                     <label>
                                       <b>=</b>
-                                    </label>{" "}
+                                    </label>{' '}
                                   </FormGroup>
                                   <Col lg={2}>
                                     <FormGroup className="mb-3">
@@ -3140,10 +2756,8 @@ class CreateBankTransaction extends React.Component {
                                           name="exchangeRate"
                                           maxLength="20"
                                           value={props.values.exchangeRate}
-                                          onChange={(option) => {
-                                            props.handleChange("exchangeRate")(
-                                              option
-                                            );
+                                          onChange={option => {
+                                            props.handleChange('exchangeRate')(option);
                                             //props.values.exchangeRate =
                                           }}
                                         />
@@ -3156,23 +2770,18 @@ class CreateBankTransaction extends React.Component {
                                       disabled
                                       id="currencyName"
                                       name="currencyName"
-                                      value={
-                                        this.state?.basecurrency?.currencyName
-                                      }
+                                      value={this.state?.basecurrency?.currencyName}
                                     />
                                   </Col>
                                 </Row>
                               )}
 
-                            {(props.values?.coaCategoryId?.label === "Sales" ||
-                              props.values?.coaCategoryId?.label ===
-                              "Supplier Invoice") &&
+                            {(props.values?.coaCategoryId?.label === 'Sales' ||
+                              props.values?.coaCategoryId?.label === 'Supplier Invoice') &&
                               props.values.curreancyname !==
-                              this.state?.bankCurrency
-                                ?.bankAccountCurrencyIsoCode &&
+                                this.state?.bankCurrency?.bankAccountCurrencyIsoCode &&
                               props.values.curreancyname &&
-                              this.state?.bankCurrency
-                                ?.bankAccountCurrencyIsoCode &&
+                              this.state?.bankCurrency?.bankAccountCurrencyIsoCode &&
                               this.state?.bankCurrency?.bankAccountCurrency && (
                                 <Row className="mt-2">
                                   <Col lg={1}>
@@ -3190,15 +2799,12 @@ class CreateBankTransaction extends React.Component {
                                           id="currencyName"
                                           name="currencyName"
                                           value={
-                                            props.values.curreancyname === "AED"
-                                              ? this.state?.bankCurrency
-                                                ?.bankAccountCurrencyIsoCode
+                                            props.values.curreancyname === 'AED'
+                                              ? this.state?.bankCurrency?.bankAccountCurrencyIsoCode
                                               : props.values.curreancyname
                                           }
-                                          onChange={(value) => {
-                                            props.handleChange("curreancyname")(
-                                              value
-                                            );
+                                          onChange={value => {
+                                            props.handleChange('curreancyname')(value);
                                           }}
                                         />
                                       </div>
@@ -3207,7 +2813,7 @@ class CreateBankTransaction extends React.Component {
                                   <FormGroup className="mt-2">
                                     <label>
                                       <b>=</b>
-                                    </label>{" "}
+                                    </label>{' '}
                                   </FormGroup>
                                   <Col lg={2}>
                                     <FormGroup className="mb-3">
@@ -3223,16 +2829,12 @@ class CreateBankTransaction extends React.Component {
                                           name="exchangeRate"
                                           maxLength="20"
                                           value={props.values.exchangeRate}
-                                          onChange={(option) => {
-                                            props.handleChange("exchangeRate")(
-                                              option
-                                            );
+                                          onChange={option => {
+                                            props.handleChange('exchangeRate')(option);
                                             this.setexchnagedamount(
                                               props.values.invoiceIdList,
                                               null,
-                                              option.target.value
-                                                ? option.target.value
-                                                : 0
+                                              option.target.value ? option.target.value : 0
                                             );
                                           }}
                                         />
@@ -3245,9 +2847,8 @@ class CreateBankTransaction extends React.Component {
                                       id="currencyName"
                                       name="currencyName"
                                       value={
-                                        props.values.curreancyname !== "AED"
-                                          ? this.state?.bankCurrency
-                                            ?.bankAccountCurrencyIsoCode
+                                        props.values.curreancyname !== 'AED'
+                                          ? this.state?.bankCurrency?.bankAccountCurrencyIsoCode
                                           : props.values.curreancyname
                                       }
                                     />
@@ -3255,66 +2856,56 @@ class CreateBankTransaction extends React.Component {
                                 </Row>
                               )}
 
-                            {props.values.coaCategoryId?.label !== "Corporate Tax Payment" && (<Row>
-                              <Col lg={8}>
-                                <FormGroup className="mb-3">
-                                  <Label htmlFor="description">
-                                    {strings.Description}
-                                  </Label>
-                                  <Input
-                                    type="textarea"
-                                    name="description"
-                                    id="description"
-                                    rows="6"
-                                    placeholder={strings.Description}
-                                    onChange={(option) => {
-                                      if (!option.target.value.includes("="))
-                                        props.handleChange("description")(
-                                          option
-                                        );
-                                    }}
-                                    value={props.values.description}
-                                  />
-                                </FormGroup>
-                              </Col>
-                            </Row>)}
+                            {props.values.coaCategoryId?.label !== 'Corporate Tax Payment' && (
+                              <Row>
+                                <Col lg={8}>
+                                  <FormGroup className="mb-3">
+                                    <Label htmlFor="description">{strings.Description}</Label>
+                                    <Input
+                                      type="textarea"
+                                      name="description"
+                                      id="description"
+                                      rows="6"
+                                      placeholder={strings.Description}
+                                      onChange={option => {
+                                        if (!option.target.value.includes('='))
+                                          props.handleChange('description')(option);
+                                      }}
+                                      value={props.values.description}
+                                    />
+                                  </FormGroup>
+                                </Col>
+                              </Row>
+                            )}
                             <Row>
                               <Col lg={8}>
                                 <Row>
                                   <Col lg={6}>
                                     <FormGroup className="mb-3">
-                                      <Label htmlFor="reference">
-                                        {strings.ReferenceNumber}
-                                      </Label>
+                                      <Label htmlFor="reference">{strings.ReferenceNumber}</Label>
                                       <Input
                                         type="text"
                                         maxLength="20"
                                         id="reference"
                                         name="reference"
                                         placeholder={strings.ReceiptNumber}
-                                        onChange={(option) => {
+                                        onChange={option => {
                                           // if (
                                           //   option.target.value === "" ||
                                           //   this.regExBoth.test(
                                           //     option.target.value
                                           //   )
                                           // ) {
-                                          props.handleChange("reference")(
-                                            option
-                                          );
+                                          props.handleChange('reference')(option);
                                           // }
                                         }}
                                         value={props.values.reference}
                                       />
-                                      {props.errors.reference &&
-                                        props.touched.reference && (
-                                          <div
-                                            className="invalid-file"
-                                            style={{ color: "red" }}
-                                          >
-                                            {props.errors.reference}
-                                          </div>
-                                        )}
+                                      {props.errors.reference && props.touched.reference && (
+                                        <div className="invalid-file" style={{ color: 'red' }}>
+                                          {props.errors.reference}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                 </Row>
@@ -3327,28 +2918,24 @@ class CreateBankTransaction extends React.Component {
                                         name="attachment"
                                         render={({ field, form }) => (
                                           <div>
-                                            <Label>{strings.Attachment}</Label>{" "}
-                                            <br />
+                                            <Label>{strings.Attachment}</Label> <br />
                                             <Button
                                               color="primary"
                                               onClick={() => {
-                                                document
-                                                  .getElementById("fileInput")
-                                                  .click();
+                                                document.getElementById('fileInput').click();
                                               }}
                                               className="btn-square mr-3"
                                             >
-                                              <i className="fa fa-upload"></i>{" "}
-                                              {strings.upload}
+                                              <i className="fa fa-upload"></i> {strings.upload}
                                             </Button>
                                             <input
                                               id="fileInput"
-                                              ref={(ref) => {
+                                              ref={ref => {
                                                 this.uploadFile = ref;
                                               }}
                                               type="file"
-                                              style={{ display: "none" }}
-                                              onChange={(e) => {
+                                              style={{ display: 'none' }}
+                                              onChange={e => {
                                                 this.handleFileChange(e, props);
                                               }}
                                             />
@@ -3358,22 +2945,21 @@ class CreateBankTransaction extends React.Component {
                                                   className="fa fa-close"
                                                   onClick={() =>
                                                     this.setState({
-                                                      fileName: "",
+                                                      fileName: '',
                                                     })
                                                   }
-                                                ></i>{" "}
+                                                ></i>{' '}
                                                 {this.state.fileName}
                                               </div>
                                             )}
                                           </div>
                                         )}
                                       />
-                                      {props.errors.attachment &&
-                                        props.touched.attachment && (
-                                          <div className="invalid-file">
-                                            {props.errors.attachment}
-                                          </div>
-                                        )}
+                                      {props.errors.attachment && props.touched.attachment && (
+                                        <div className="invalid-file">
+                                          {props.errors.attachment}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
                                 </Row>
@@ -3389,25 +2975,17 @@ class CreateBankTransaction extends React.Component {
                                     disabled={this.state.disabled}
                                     onClick={() => {
                                       //	added validation popup	msg
-                                      console.log(props.errors, "EERRROR");
+                                      console.log(props.errors, 'EERRROR');
                                       props.handleBlur();
-                                      if (
-                                        props.errors &&
-                                        Object.keys(props.errors).length != 0
-                                      )
+                                      if (props.errors && Object.keys(props.errors).length != 0)
                                         this.props.commonActions.fillManDatoryDetails();
-                                      this.setState(
-                                        { createMore: false },
-                                        () => {
-                                          props.handleSubmit();
-                                        }
-                                      );
+                                      this.setState({ createMore: false }, () => {
+                                        props.handleSubmit();
+                                      });
                                     }}
                                   >
-                                    <i className="fa fa-dot-circle-o"></i>{" "}
-                                    {this.state.disabled
-                                      ? "Creating..."
-                                      : strings.Create}
+                                    <i className="fa fa-dot-circle-o"></i>{' '}
+                                    {this.state.disabled ? 'Creating...' : strings.Create}
                                   </Button>
                                   <Button
                                     type="button"
@@ -3417,40 +2995,30 @@ class CreateBankTransaction extends React.Component {
                                     onClick={() => {
                                       //	added validation popup	msg
                                       props.handleBlur();
-                                      if (
-                                        props.errors &&
-                                        Object.keys(props.errors).length != 0
-                                      )
+                                      if (props.errors && Object.keys(props.errors).length != 0)
                                         this.props.commonActions.fillManDatoryDetails();
-                                      this.setState(
-                                        { createMore: true },
-                                        () => {
-                                          props.handleSubmit();
-                                        }
-                                      );
+                                      this.setState({ createMore: true }, () => {
+                                        props.handleSubmit();
+                                      });
                                     }}
                                   >
-                                    <i className="fa fa-refresh"></i>{" "}
-                                    {this.state.disabled
-                                      ? "Creating..."
-                                      : strings.CreateandMore}
+                                    <i className="fa fa-refresh"></i>{' '}
+                                    {this.state.disabled ? 'Creating...' : strings.CreateandMore}
                                   </Button>
                                   <Button
                                     color="secondary"
                                     className="btn-square"
                                     onClick={() => {
                                       this.props.history.push(
-                                        "/admin/banking/bank-account/transaction",
+                                        '/admin/banking/bank-account/transaction',
                                         {
                                           bankAccountId: id,
-                                          currency:
-                                            this.props.location.state?.currency,
+                                          currency: this.props.location.state?.currency,
                                         }
                                       );
                                     }}
                                   >
-                                    <i className="fa fa-ban"></i>{" "}
-                                    {strings.Cancel}
+                                    <i className="fa fa-ban"></i> {strings.Cancel}
                                   </Button>
                                 </FormGroup>
                               </Col>
@@ -3465,13 +3033,10 @@ class CreateBankTransaction extends React.Component {
             </Col>
           </Row>
         </div>
-        {this.state.disableLeavePage ? "" : <LeavePage />}
+        {this.state.disableLeavePage ? '' : <LeavePage />}
       </div>
     );
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CreateBankTransaction);
+export default connect(mapStateToProps, mapDispatchToProps)(CreateBankTransaction);

--- a/apps/frontend/src/screens/creditNotes/screens/create/screen.js
+++ b/apps/frontend/src/screens/creditNotes/screens/create/screen.js
@@ -1,6 +1,6 @@
-import React from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import {
   Card,
   CardHeader,
@@ -12,41 +12,37 @@ import {
   FormGroup,
   Input,
   Label,
-} from "reactstrap";
-import Select from "react-select";
-import DatePicker from "react-datepicker";
-import { Formik, Field } from "formik";
-import Switch from "react-switch";
-import * as Yup from "yup";
-import * as CreditNotesCreateActions from "./actions";
-import * as CreditNotesActions from "../../actions";
-import * as ProductActions from "../../../product/actions";
-import * as CurrencyConvertActions from "../../../currencyConvert/actions";
+} from 'reactstrap';
+import Select from 'react-select';
+import DatePicker from 'react-datepicker';
+import { Formik, Field } from 'formik';
+import Switch from 'react-switch';
+import * as Yup from 'yup';
+import * as CreditNotesCreateActions from './actions';
+import * as CreditNotesActions from '../../actions';
+import * as ProductActions from '../../../product/actions';
+import * as CurrencyConvertActions from '../../../currencyConvert/actions';
 import {
   LeavePage,
   Loader,
   ProductTableCalculation,
   ProductTable,
   TotalCalculation,
-} from "components";
-import "react-datepicker/dist/react-datepicker.css";
-import "react-bootstrap-table/dist/react-bootstrap-table-all.min.css";
-import { CommonActions } from "services/global";
-import {
-  selectCurrencyFactory,
-  selectOptionsFactory,
-  DropdownLists,
-} from "utils";
-import "./style.scss";
+} from 'components';
+import 'react-datepicker/dist/react-datepicker.css';
+import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
+import { CommonActions } from 'services/global';
+import { selectCurrencyFactory, selectOptionsFactory, DropdownLists } from 'utils';
+import './style.scss';
 import dayjs from '@/utils/date';
-import { data } from "../../../Language/index";
-import LocalizedStrings from "react-localization";
-import { Checkbox } from "@material-ui/core";
-import { TextareaAutosize, TextField } from "@material-ui/core";
+import { data } from '../../../Language/index';
+import LocalizedStrings from 'react-localization';
+import { Checkbox } from '@material-ui/core';
+import { TextareaAutosize, TextField } from '@material-ui/core';
 // Use import instead of require for Vite compatibility
-import invoiceimage from "assets/images/invoice/invoice.png";
+import invoiceimage from 'assets/images/invoice/invoice.png';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   const contact_list = state.customer_invoice.customer_list;
   return {
     currency_list: state.customer_invoice.currency_list,
@@ -63,17 +59,11 @@ const mapStateToProps = (state) => {
     companyDetails: state.common.company_details,
   };
 };
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     creditNotesActions: bindActionCreators(CreditNotesActions, dispatch),
-    currencyConvertActions: bindActionCreators(
-      CurrencyConvertActions,
-      dispatch
-    ),
-    creditNotesCreateActions: bindActionCreators(
-      CreditNotesCreateActions,
-      dispatch
-    ),
+    currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
+    creditNotesCreateActions: bindActionCreators(CreditNotesCreateActions, dispatch),
     productActions: bindActionCreators(ProductActions, dispatch),
     commonActions: bindActionCreators(CommonActions, dispatch),
   };
@@ -82,10 +72,10 @@ const mapDispatchToProps = (dispatch) => {
 const customStyles = {
   control: (base, state) => ({
     ...base,
-    borderColor: state.isFocused ? "#2064d8" : "#c7c7c7",
+    borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
     boxShadow: state.isFocused ? null : null,
-    "&:hover": {
-      borderColor: state.isFocused ? "#2064d8" : "#c7c7c7",
+    '&:hover': {
+      borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
     },
   }),
 };
@@ -96,103 +86,103 @@ class CreateCreditNote extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      language: window["localStorage"].getItem("language"),
-      customer_currency_symbol: "",
+      language: window['localStorage'].getItem('language'),
+      customer_currency_symbol: '',
       loading: false,
       disabled: false,
       discountOptions: [
-        { value: "FIXED", label: "Fixed" },
-        { value: "PERCENTAGE", label: "Percentage" },
+        { value: 'FIXED', label: 'Fixed' },
+        { value: 'PERCENTAGE', label: 'Percentage' },
       ],
       exciseTypeOption: [
-        { value: "Inclusive", label: "Inclusive" },
-        { value: "Exclusive", label: "Exclusive" },
+        { value: 'Inclusive', label: 'Inclusive' },
+        { value: 'Exclusive', label: 'Exclusive' },
       ],
       disabledDate: true,
       data: [
         {
           id: 0,
-          description: "",
+          description: '',
           quantity: 1,
-          unitPrice: "",
-          vatCategoryId: "",
-          exciseTaxId: "",
+          unitPrice: '',
+          vatCategoryId: '',
+          exciseTaxId: '',
           exciseAmount: 0,
           subTotal: 0,
           vatAmount: 0,
-          productId: "",
-          isExciseTaxExclusive: "",
-          discountType: "FIXED",
+          productId: '',
+          isExciseTaxExclusive: '',
+          discountType: 'FIXED',
           discount: 0,
-          unitType: "",
-          unitTypeId: "",
+          unitType: '',
+          unitTypeId: '',
         },
       ],
       idCount: 0,
       initValue: {
-        invoiceNumber: "",
-        receiptAttachmentDescription: "",
-        receiptNumber: "",
-        contact_po_number: "",
-        currency: "",
+        invoiceNumber: '',
+        receiptAttachmentDescription: '',
+        receiptNumber: '',
+        contact_po_number: '',
+        currency: '',
         // invoiceDueDate: '',
         creditNoteDate: new Date(),
-        contactId: "",
-        placeOfSupplyId: "",
-        project: "",
-        term: "",
+        contactId: '',
+        placeOfSupplyId: '',
+        project: '',
+        term: '',
         // exchangeRate:'',
         lineItemsString: [
           {
             id: 0,
-            description: "",
+            description: '',
             quantity: 1,
             exciseAmount: 0,
             discount: 0,
-            unitPrice: "",
-            vatCategoryId: "",
-            productId: "",
+            unitPrice: '',
+            vatCategoryId: '',
+            productId: '',
             subTotal: 0,
           },
         ],
-        creditNoteNumber: "",
+        creditNoteNumber: '',
         totalNet: 0,
         invoiceVATAmount: 0,
         totalVatAmount: 0,
         totalAmount: 0,
-        notes: "",
-        email: "",
+        notes: '',
+        email: '',
         discount: 0,
-        discountPercentage: "",
-        discountType: "FIXED",
-        creditAmount: "",
+        discountPercentage: '',
+        discountType: 'FIXED',
+        creditAmount: '',
         totalExciseAmount: 0,
       },
       currentData: {},
       contactType: 2,
-      selectedContact: "",
+      selectedContact: '',
       createMore: false,
-      fileName: "",
-      term: "",
-      selectedType: { value: "FIXED", label: "Fixed" },
-      discountPercentage: "",
+      fileName: '',
+      term: '',
+      selectedType: { value: 'FIXED', label: 'Fixed' },
+      discountPercentage: '',
       discountAmount: 0,
       exist: false,
-      prefix: "",
+      prefix: '',
       purchaseCategory: [],
       salesCategory: [],
       // exchangeRate:'',
       basecurrency: [],
       inventoryList: [],
-      remainingInvoiceAmount: "",
+      remainingInvoiceAmount: '',
       invoiceSelected: false,
       isCreatedWIWP: false,
-      quantityExceeded: "",
+      quantityExceeded: '',
       isCreatedWithoutInvoice: false,
-      loadingMsg: "Loading",
+      loadingMsg: 'Loading',
       disableLeavePage: false,
       lockInvoiceDetail: false,
-      receiptDate: "",
+      receiptDate: '',
       isfreshCN: true,
     };
 
@@ -200,54 +190,51 @@ class CreateCreditNote extends React.Component {
 
     this.file_size = 1024000;
     this.supported_format = [
-      "image/png",
-      "image/jpeg",
-      "text/plain",
-      "application/pdf",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      'image/png',
+      'image/jpeg',
+      'text/plain',
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     ];
 
     this.termList = [
-      { label: "Net 7 Days", value: "NET_7" },
-      { label: "Net 10 Days", value: "NET_10" },
-      { label: "Net 30 Days", value: "NET_30" },
-      { label: "Due on Receipt", value: "DUE_ON_RECEIPT" },
+      { label: 'Net 7 Days', value: 'NET_7' },
+      { label: 'Net 10 Days', value: 'NET_10' },
+      { label: 'Net 30 Days', value: 'NET_30' },
+      { label: 'Due on Receipt', value: 'DUE_ON_RECEIPT' },
     ];
     this.placelist = [
-      { label: "Abu Dhabi", value: "1" },
-      { label: "Dubai", value: "2" },
-      { label: "Sharjah", value: "3" },
-      { label: "Ajman", value: "4" },
-      { label: "Umm Al Quwain", value: "5" },
-      { label: "Ras al-Khaimah", value: "6" },
-      { label: "Fujairah", value: "7" },
+      { label: 'Abu Dhabi', value: '1' },
+      { label: 'Dubai', value: '2' },
+      { label: 'Sharjah', value: '3' },
+      { label: 'Ajman', value: '4' },
+      { label: 'Umm Al Quwain', value: '5' },
+      { label: 'Ras al-Khaimah', value: '6' },
+      { label: 'Fujairah', value: '7' },
     ];
     this.regEx = /^[0-9\b]+$/;
     this.regExBoth = /[a-zA-Z0-9]+$/;
     this.regExCNNum = /[a-zA-Z0-9-/]+$/;
     this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
-    this.regDecimalP =
-      /(^100(\.0{1,2})?$)|(^([1-9]([0-9])?|0)(\.[0-9]{1,2})?$)/;
+    this.regDecimalP = /(^100(\.0{1,2})?$)|(^([1-9]([0-9])?|0)(\.[0-9]{1,2})?$)/;
   }
 
-  discountType = (row) => {
+  discountType = row => {
     return (
       this.state.discountOptions &&
       selectOptionsFactory
-        .renderOptions("label", "value", this.state.discountOptions, "discount")
-        .find((option) => option.value === +row.discountType)
+        .renderOptions('label', 'value', this.state.discountOptions, 'discount')
+        .find(option => option.value === +row.discountType)
     );
   };
 
   setDate = (props, value) => {
     const { term } = this.state;
-    const val = term ? term.value.split("_") : "";
-    const temp = val[val.length - 1] === "Receipt" ? 1 : val[val.length - 1];
-    const values = value
-      ? value
-      : dayjs(props.values.creditNoteDate, "DD-MM-YYYY").toDate();
+    const val = term ? term.value.split('_') : '';
+    const temp = val[val.length - 1] === 'Receipt' ? 1 : val[val.length - 1];
+    const values = value ? value : dayjs(props.values.creditNoteDate, 'DD-MM-YYYY').toDate();
     // if (temp && values) {
     // 	const date = dayjs(values)
     // 		.add(temp - 1, 'days')
@@ -256,52 +243,42 @@ class CreateCreditNote extends React.Component {
     // }
   };
 
-  setExchange = (value) => {
+  setExchange = value => {
     let result = this.props.currency_convert_list
-      ? this.props.currency_convert_list.find((obj) => {
+      ? this.props.currency_convert_list.find(obj => {
           return obj.currencyCode === value;
         })
-      : "";
+      : '';
 
-    this.formRef.current.setFieldValue(
-      "exchangeRate",
-      result?.exchangeRate,
-      true
-    );
+    this.formRef.current.setFieldValue('exchangeRate', result?.exchangeRate, true);
   };
 
-  setCurrency = (value) => {
-    let result = this.props.currency_convert_list.filter((obj) => {
+  setCurrency = value => {
+    let result = this.props.currency_convert_list.filter(obj => {
       return obj.currencyCode === value;
     });
-    this.formRef.current.setFieldValue(
-      "curreancyname",
-      result[0].currencyName,
-      true
-    );
+    this.formRef.current.setFieldValue('curreancyname', result[0].currencyName, true);
   };
 
-  validationCheck = (value) => {
+  validationCheck = value => {
     const data = {
       moduleType: 28,
       name: value,
     };
-    this.props.creditNotesCreateActions
-      .checkValidation(data)
-      .then((response) => {
-        if (response.data === "Credit Note Number Already Exists") {
-          this.setState(
-            {
-              exist: true,
-            },
-            () => {}
-          );
-        } else {
-          this.setState({
-            exist: false,
-          });
-        }
-      });
+    this.props.creditNotesCreateActions.checkValidation(data).then(response => {
+      if (response.data === 'Credit Note Number Already Exists') {
+        this.setState(
+          {
+            exist: true,
+          },
+          () => {}
+        );
+      } else {
+        this.setState({
+          exist: false,
+        });
+      }
+    });
   };
 
   componentDidMount = () => {
@@ -310,30 +287,18 @@ class CreateCreditNote extends React.Component {
   };
 
   getDefaultNotes = () => {
-    this.props.commonActions.getNoteSettingsInfo().then((res) => {
+    this.props.commonActions.getNoteSettingsInfo().then(res => {
       if (res.status === 200) {
-        this.formRef.current.setFieldValue(
-          "notes",
-          res.data.defaultNotes,
-          true
-        );
-        this.formRef.current.setFieldValue(
-          "footNote",
-          res.data.defaultFootNotes,
-          true
-        );
+        this.formRef.current.setFieldValue('notes', res.data.defaultNotes, true);
+        this.formRef.current.setFieldValue('footNote', res.data.defaultFootNotes, true);
       }
     });
   };
   getInitialData = () => {
     const { companyDetails } = this.props;
     if (companyDetails) {
-      const {
-        currencyCode,
-        isRegisteredVat,
-        isDesignatedZone,
-        vatRegistrationDate,
-      } = companyDetails;
+      const { currencyCode, isRegisteredVat, isDesignatedZone, vatRegistrationDate } =
+        companyDetails;
       this.setState({
         initValue: {
           ...this.state.initValue,
@@ -346,8 +311,7 @@ class CreateCreditNote extends React.Component {
         isRegisteredVat: isRegisteredVat,
         loading: false,
       });
-      this.formRef?.current &&
-        this.formRef.current.setFieldValue("currencyCode", currencyCode);
+      this.formRef?.current && this.formRef.current.setFieldValue('currencyCode', currencyCode);
     }
     this.getInvoiceNo();
     this.props.creditNotesActions.getInvoiceListForDropdown();
@@ -359,33 +323,31 @@ class CreateCreditNote extends React.Component {
     this.props.productActions.getProductCategoryList();
     this.props.creditNotesActions
       .getTaxTreatment()
-      .then((res) => {
+      .then(res => {
         if (res.status === 200) {
           let array = [];
-          res.data.map((row) => {
+          res.data.map(row => {
             if (row.id !== 8) array.push(row);
           });
           this.setState({ taxTreatmentList: array });
         }
       })
-      .catch((err) => {
+      .catch(err => {
         this.setState({ disabled: false });
-        this.props.commonActions.tostifyAlert(
-          "error",
-          err.data ? err.data.message : "ERROR"
-        );
+        this.props.commonActions.tostifyAlert('error', err.data ? err.data.message : 'ERROR');
       });
-    this.props.commonActions.getCurrencyConversionList().then((response) => {
-      this.setState({
-        initValue: {
-          ...this.state.initValue,
-          ...{
-            currency: response.data
-              ? parseInt(response.data[0].currencyCode)
-              : "",
+    this.props.commonActions.getCurrencyConversionList().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        this.setState({
+          initValue: {
+            ...this.state.initValue,
+            ...{
+              currency: action.payload ? parseInt(action.payload[0].currencyCode) : '',
+            },
           },
-        },
-      });
+        });
+      }
     });
     this.getCompanyCurrency();
     this.salesCategory();
@@ -393,7 +355,7 @@ class CreateCreditNote extends React.Component {
     if (this.props.location?.state?.invoiceID) {
       this.getInvoiceDetails(this.props.location?.state?.invoiceID);
       this.formRef.current.setFieldValue(
-        "invoiceNumber",
+        'invoiceNumber',
         this.props.location?.state?.invoiceID,
         true
       );
@@ -401,54 +363,50 @@ class CreateCreditNote extends React.Component {
     }
   };
 
-  getCompanyCurrency = (basecurrency) => {
+  getCompanyCurrency = basecurrency => {
     this.props.currencyConvertActions
       .getCompanyCurrency()
-      .then((res) => {
+      .then(res => {
         if (res.status === 200) {
           this.setState({ basecurrency: res.data });
         }
       })
-      .catch((err) => {
+      .catch(err => {
         this.props.commonActions.tostifyAlert(
-          "error",
-          err && err.data ? err.data.message : "Something Went Wrong"
+          'error',
+          err && err.data ? err.data.message : 'Something Went Wrong'
         );
         this.setState({ loading: false });
       });
   };
   salesCategory = () => {
     try {
-      this.props.productActions
-        .getTransactionCategoryListForSalesProduct("2")
-        .then((res) => {
-          if (res.status === 200) {
-            this.setState(
-              {
-                salesCategory: res.data,
-              },
-              () => {}
-            );
-          }
-        });
+      this.props.productActions.getTransactionCategoryListForSalesProduct('2').then(res => {
+        if (res.status === 200) {
+          this.setState(
+            {
+              salesCategory: res.data,
+            },
+            () => {}
+          );
+        }
+      });
     } catch (err) {
       console.log(err);
     }
   };
   purchaseCategory = () => {
     try {
-      this.props.productActions
-        .getTransactionCategoryListForPurchaseProduct("10")
-        .then((res) => {
-          if (res.status === 200) {
-            this.setState(
-              {
-                purchaseCategory: res.data,
-              },
-              () => {}
-            );
-          }
-        });
+      this.props.productActions.getTransactionCategoryListForPurchaseProduct('10').then(res => {
+        if (res.status === 200) {
+          this.setState(
+            {
+              purchaseCategory: res.data,
+            },
+            () => {}
+          );
+        }
+      });
     } catch (err) {
       console.log(err);
     }
@@ -460,26 +418,22 @@ class CreateCreditNote extends React.Component {
       {
         data: data.concat({
           id: this.state.idCount + 1,
-          description: "",
+          description: '',
           quantity: 1,
-          unitPrice: "",
-          vatCategoryId: "",
-          productId: "",
+          unitPrice: '',
+          vatCategoryId: '',
+          productId: '',
           subTotal: 0,
-          discountType: "FIXED",
+          discountType: 'FIXED',
           discount: 0,
-          exciseTaxId: "",
-          unitType: "",
-          unitTypeId: "",
+          exciseTaxId: '',
+          unitType: '',
+          unitTypeId: '',
         }),
         idCount: this.state.idCount + 1,
       },
       () => {
-        this.formRef.current.setFieldValue(
-          "lineItemsString",
-          this.state.data,
-          true
-        );
+        this.formRef.current.setFieldValue('lineItemsString', this.state.data, true);
         this.formRef.current.setFieldTouched(
           `lineItemsString[${this.state.data.length - 1}]`,
           false,
@@ -500,24 +454,12 @@ class CreateCreditNote extends React.Component {
       }
       return obj;
     });
-    if (
-      name === "unitPrice" ||
-      name === "vatCategoryId" ||
-      name === "quantity"
-    ) {
-      form.setFieldValue(
-        field.name,
-        this.state.data[parseInt(idx, 10)][`${name}`],
-        true
-      );
+    if (name === 'unitPrice' || name === 'vatCategoryId' || name === 'quantity') {
+      form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
       this.updateAmount(data, props);
     } else {
       this.setState({ data }, () => {
-        form.setFieldValue(
-          field.name,
-          this.state.data[parseInt(idx, 10)][`${name}`],
-          true
-        );
+        form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
       });
     }
   };
@@ -525,71 +467,51 @@ class CreateCreditNote extends React.Component {
   prductValue = (e, row, name, form, field, props) => {
     const { product_list } = this.props;
     let data = this.state.data;
-    const result = product_list.find((item) => item.id === parseInt(e));
+    const result = product_list.find(item => item.id === parseInt(e));
     let idx;
     data.map((obj, index) => {
       if (obj.id === row.id) {
-        obj["unitPrice"] = result.unitPrice;
-        obj["vatCategoryId"] = result.vatCategoryId;
-        obj["description"] = result.description;
-        obj["exciseTaxId"] = result.exciseTaxId;
-        obj["discountType"] = result.discountType;
-        obj["isExciseTaxExclusive"] = result.isExciseTaxExclusive;
-        obj["unitType"] = result.unitType;
-        obj["unitTypeId"] = result.unitTypeId;
+        obj['unitPrice'] = result.unitPrice;
+        obj['vatCategoryId'] = result.vatCategoryId;
+        obj['description'] = result.description;
+        obj['exciseTaxId'] = result.exciseTaxId;
+        obj['discountType'] = result.discountType;
+        obj['isExciseTaxExclusive'] = result.isExciseTaxExclusive;
+        obj['unitType'] = result.unitType;
+        obj['unitTypeId'] = result.unitTypeId;
         idx = index;
       }
       return obj;
     });
-    form.setFieldValue(
-      `lineItemsString.${idx}.vatCategoryId`,
-      result.vatCategoryId,
-      true
-    );
-    form.setFieldValue(
-      `lineItemsString.${idx}.unitPrice`,
-      result.unitPrice,
-      true
-    );
-    form.setFieldValue(
-      `lineItemsString.${idx}.exciseTaxId`,
-      result.exciseTaxId,
-      true
-    );
-    form.setFieldValue(
-      `lineItemsString.${idx}.description`,
-      result.description,
-      true
-    );
-    form.setFieldValue(
-      `lineItemsString.${idx}.discountType`,
-      result.discountType,
-      true
-    );
+    form.setFieldValue(`lineItemsString.${idx}.vatCategoryId`, result.vatCategoryId, true);
+    form.setFieldValue(`lineItemsString.${idx}.unitPrice`, result.unitPrice, true);
+    form.setFieldValue(`lineItemsString.${idx}.exciseTaxId`, result.exciseTaxId, true);
+    form.setFieldValue(`lineItemsString.${idx}.description`, result.description, true);
+    form.setFieldValue(`lineItemsString.${idx}.discountType`, result.discountType, true);
     this.updateAmount(data, props);
   };
 
-  setValue = (value) => {
-    this.setState((prevState) => ({
+  setValue = value => {
+    this.setState(prevState => ({
       ...prevState,
       initValue: [],
     }));
   };
 
   deleteRow = (e, row, props) => {
-    const id = row["id"];
+    const id = row['id'];
     let newData = [];
     e.preventDefault();
     const data = this.state.data;
-    newData = data.filter((obj) => obj.id !== id);
-    props.setFieldValue("lineItemsString", newData, true);
+    newData = data.filter(obj => obj.id !== id);
+    props.setFieldValue('lineItemsString', newData, true);
     this.updateAmount(newData, props);
   };
 
   checkedRow = () => {
     if (this.state.data.length > 0) {
       let length = this.state.data.length - 1;
-      let temp = Object.values(this.state.data[`${length}`]).indexOf("");
+      let temp = Object.values(this.state.data[`${length}`]).indexOf('');
       if (temp > -1) {
         return true;
       } else {
@@ -603,11 +525,7 @@ class CreateCreditNote extends React.Component {
   updateAmount = (data, props) => {
     const { vat_list } = this.props;
     const { taxType } = this.state;
-    const list = ProductTableCalculation.updateAmount(
-      data ? data : [],
-      vat_list,
-      taxType
-    );
+    const list = ProductTableCalculation.updateAmount(data ? data : [], vat_list, taxType);
     this.setState({
       data: list.data ? list.data : [],
       initValue: {
@@ -617,9 +535,7 @@ class CreateCreditNote extends React.Component {
           totalVatAmount: list.totalVatAmount ? list.totalVatAmount : 0,
           discount: list.discount ? list.discount : 0,
           totalAmount: list.totalAmount ? list.totalAmount : 0,
-          totalExciseAmount: list.totalExciseAmount
-            ? list.totalExciseAmount
-            : 0,
+          totalExciseAmount: list.totalExciseAmount ? list.totalExciseAmount : 0,
         },
       },
     });
@@ -632,7 +548,7 @@ class CreateCreditNote extends React.Component {
     if (file) {
       reader.onloadend = () => {};
       reader.readAsDataURL(file);
-      props.setFieldValue("attachmentFile", file, true);
+      props.setFieldValue('attachmentFile', file, true);
     }
   };
 
@@ -661,109 +577,87 @@ class CreateCreditNote extends React.Component {
     const { isCreatedWIWP } = this.state;
     const formData = new FormData();
 
+    formData.append('isCreatedWithoutInvoice', this.state.isCreatedWithoutInvoice);
+    formData.append('isCreatedWIWP', isCreatedWIWP);
     formData.append(
-      "isCreatedWithoutInvoice",
-      this.state.isCreatedWithoutInvoice
+      'creditNoteNumber',
+      creditNoteNumber ? this.state.prefix + creditNoteNumber : ''
     );
-    formData.append("isCreatedWIWP", isCreatedWIWP);
+    formData.append('email', email ? email : '');
     formData.append(
-      "creditNoteNumber",
-      creditNoteNumber ? this.state.prefix + creditNoteNumber : ""
+      'creditNoteDate',
+      creditNoteDate ? dayjs(creditNoteDate, 'DD-MM-YYYY').toDate() : null
     );
-    formData.append("email", email ? email : "");
+    formData.append('referenceNo', receiptNumber !== null ? receiptNumber : '');
+    formData.append('exchangeRate', exchangeRate ? exchangeRate : '');
+    formData.append('contactPoNumber', contact_po_number !== null ? contact_po_number : '');
     formData.append(
-      "creditNoteDate",
-      creditNoteDate ? dayjs(creditNoteDate, "DD-MM-YYYY").toDate() : null
+      'receiptAttachmentDescription',
+      receiptAttachmentDescription !== null ? receiptAttachmentDescription : ''
     );
-    formData.append("referenceNo", receiptNumber !== null ? receiptNumber : "");
-    formData.append("exchangeRate", exchangeRate ? exchangeRate : "");
-    formData.append(
-      "contactPoNumber",
-      contact_po_number !== null ? contact_po_number : ""
-    );
-    formData.append(
-      "receiptAttachmentDescription",
-      receiptAttachmentDescription !== null ? receiptAttachmentDescription : ""
-    );
-    formData.append("notes", notes !== null ? notes : "");
-    formData.append("type", 7);
-    if (isCreatedWIWP === true)
-      formData.append("totalAmount", creditAmount);
+    formData.append('notes', notes !== null ? notes : '');
+    formData.append('type', 7);
+    if (isCreatedWIWP === true) formData.append('totalAmount', creditAmount);
 
-    formData.append("vatCategoryId", 2);
-    formData.append("taxType", this.state.taxType ? this.state.taxType : false);
+    formData.append('vatCategoryId', 2);
+    formData.append('taxType', this.state.taxType ? this.state.taxType : false);
 
     if (invoiceNumber) {
-      formData.append(
-        "invoiceId",
-        invoiceNumber.value ? invoiceNumber.value : invoiceNumber
-      );
-      formData.append("cnCreatedOnPaidInvoice", "1");
+      formData.append('invoiceId', invoiceNumber.value ? invoiceNumber.value : invoiceNumber);
+      formData.append('cnCreatedOnPaidInvoice', '1');
     }
     if (placeOfSupplyId) {
       formData.append(
-        "placeOfSupplyId",
+        'placeOfSupplyId',
         placeOfSupplyId.value ? placeOfSupplyId.value : placeOfSupplyId
       );
     }
     if (!isCreatedWIWP) {
-      formData.append("lineItemsString", JSON.stringify(this.state.data));
-      formData.append("totalVatAmount", this.state.initValue.totalVatAmount);
-      formData.append("totalAmount", this.state.initValue.totalAmount);
-      formData.append("discount", this.state.initValue.discount);
-      formData.append(
-        "totalExciseTaxAmount",
-        this.state.initValue.totalExciseAmount
-      );
+      formData.append('lineItemsString', JSON.stringify(this.state.data));
+      formData.append('totalVatAmount', this.state.initValue.totalVatAmount);
+      formData.append('totalAmount', this.state.initValue.totalAmount);
+      formData.append('discount', this.state.initValue.discount);
+      formData.append('totalExciseTaxAmount', this.state.initValue.totalExciseAmount);
     }
     if (contactId) {
-      formData.append(
-        "contactId",
-        contactId.value ? contactId.value : contactId
-      );
+      formData.append('contactId', contactId.value ? contactId.value : contactId);
     }
     if (currency !== null && currency) {
-      formData.append("currencyCode", this.state.customer_currency);
+      formData.append('currencyCode', this.state.customer_currency);
     }
-    if (
-      this.uploadFile &&
-      this.uploadFile.files &&
-      this.uploadFile?.files?.[0]
-    ) {
-      formData.append("attachmentFile", this.uploadFile?.files?.[0]);
+    if (this.uploadFile && this.uploadFile.files && this.uploadFile?.files?.[0]) {
+      formData.append('attachmentFile', this.uploadFile?.files?.[0]);
     }
 
-    this.setState({ loading: true, loadingMsg: "Creating Credit Note..." });
+    this.setState({ loading: true, loadingMsg: 'Creating Credit Note...' });
     this.props.creditNotesCreateActions
       .createCreditNote(formData)
-      .then((res) => {
+      .then(res => {
         this.setState({ disabled: false });
         this.setState({ loading: false });
         this.props.commonActions.tostifyAlert(
-          "success",
-          res.data
-            ? res.data.message
-            : "New Tax Credit Note Created Successfully."
+          'success',
+          res.data ? res.data.message : 'New Tax Credit Note Created Successfully.'
         );
         if (this.state.createMore) {
           this.props.creditNotesActions.getInvoiceListForDropdown();
           this.setState(
             {
               disableLeavePage: false,
-              remainingInvoiceAmount: "",
+              remainingInvoiceAmount: '',
               createMore: false,
-              selectedContact: "",
-              term: "",
-              exchangeRate: "",
+              selectedContact: '',
+              term: '',
+              exchangeRate: '',
               data: [
                 {
                   id: 0,
-                  description: "",
+                  description: '',
                   quantity: 1,
-                  unitPrice: "",
-                  vatCategoryId: "",
+                  unitPrice: '',
+                  vatCategoryId: '',
                   subTotal: 0,
-                  productId: "",
+                  productId: '',
                 },
               ],
               initValue: {
@@ -772,9 +666,9 @@ class CreateCreditNote extends React.Component {
                   totalNet: 0,
                   totalVatAmount: 0,
                   totalAmount: 0,
-                  discountType: "",
+                  discountType: '',
                   discount: 0,
-                  discountPercentage: "",
+                  discountPercentage: '',
                   totalExciseAmount: 0,
                 },
               },
@@ -782,38 +676,32 @@ class CreateCreditNote extends React.Component {
             () => {
               resetForm(this.state.initValue);
               this.getInvoiceNo();
-              this.formRef.current.setFieldValue(
-                "lineItemsString",
-                this.state.data,
-                false
-              );
+              this.formRef.current.setFieldValue('lineItemsString', this.state.data, false);
             }
           );
         } else {
-          this.props.history.push("/admin/income/credit-notes");
+          this.props.history.push('/admin/income/credit-notes');
           this.setState({ loading: false });
         }
       })
-      .catch((err) => {
+      .catch(err => {
         this.setState({
           disabled: false,
           loading: false,
           disableLeavePage: false,
         });
         this.props.commonActions.tostifyAlert(
-          "error",
-          err && err.data
-            ? err.data.message
-            : "New Tax Credit Note Created Unsuccessfully."
+          'error',
+          err && err.data ? err.data.message : 'New Tax Credit Note Created Unsuccessfully.'
         );
       });
   };
-  getCurrentNumber = (data) => {
+  getCurrentNumber = data => {
     this.getInvoiceNo();
   };
 
   getCurrentProduct = () => {
-    this.props.creditNotesActions.getProductList().then((res) => {
+    this.props.creditNotesActions.getProductList().then(res => {
       this.setState(
         {
           data: [
@@ -850,35 +738,19 @@ class CreateCreditNote extends React.Component {
         res.data[0].unitType,
         true
       );
-      this.formRef.current.setFieldValue(
-        `lineItemsString.${0}.quantity`,
-        1,
-        true
-      );
+      this.formRef.current.setFieldValue(`lineItemsString.${0}.quantity`, 1, true);
       this.formRef.current.setFieldValue(
         `lineItemsString.${0}.vatCategoryId`,
         res.data[0].vatCategoryId,
         true
       );
-      this.formRef.current.setFieldValue(
-        `lineItemsString.${0}.productId`,
-        res.data[0].id,
-        true
-      );
-      this.formRef.current.setFieldValue(
-        `lineItemsString.${0}.discountType`,
-        1,
-        true
-      );
-      this.formRef.current.setFieldValue(
-        `lineItemsString.${0}.exciseTaxId`,
-        1,
-        true
-      );
+      this.formRef.current.setFieldValue(`lineItemsString.${0}.productId`, res.data[0].id, true);
+      this.formRef.current.setFieldValue(`lineItemsString.${0}.discountType`, 1, true);
+      this.formRef.current.setFieldValue(`lineItemsString.${0}.exciseTaxId`, 1, true);
     });
   };
   getInvoiceNo = () => {
-    this.props.creditNotesCreateActions.getInvoiceNo().then((res) => {
+    this.props.creditNotesCreateActions.getInvoiceNo().then(res => {
       if (res.status === 200) {
         this.setState({
           initValue: {
@@ -887,7 +759,7 @@ class CreateCreditNote extends React.Component {
           },
         });
         this.formRef.current.setFieldValue(
-          "creditNoteNumber",
+          'creditNoteNumber',
           res.data,
           true,
           this.validationCheck(res.data)
@@ -905,10 +777,10 @@ class CreateCreditNote extends React.Component {
 
     return currencyCode;
   };
-  getTaxTreatment = (opt) => {
+  getTaxTreatment = opt => {
     let customer_taxTreatmentId = 0;
-    let customer_item_taxTreatment = "";
-    this.props.customer_list.map((item) => {
+    let customer_item_taxTreatment = '';
+    this.props.customer_list.map(item => {
       if (item.label.contactId == opt) {
         this.setState({
           customer_taxTreatment: item.label.taxTreatment.id,
@@ -924,93 +796,71 @@ class CreateCreditNote extends React.Component {
     return customer_taxTreatmentId;
   };
 
-  getInvoiceDetails = (value) => {
+  getInvoiceDetails = value => {
     if (value) {
-      this.props.creditNotesCreateActions
-        .getInvoiceById(value)
-        .then((response) => {
-          if (response.status === 200) {
-            const customerdetails = {
-              label:
-                response.data.organisationName === ""
-                  ? response.data.name
-                  : response.data.organisationName,
-              value: response.data.contactId,
-            };
+      this.props.creditNotesCreateActions.getInvoiceById(value).then(response => {
+        if (response.status === 200) {
+          const customerdetails = {
+            label:
+              response.data.organisationName === ''
+                ? response.data.name
+                : response.data.organisationName,
+            value: response.data.contactId,
+          };
 
-            this.setState(
-              {
-                invoiceID: this.props.location?.state?.invoiceID,
-                isfreshCN: false,
-                receiptDate: response.data.receiptDate,
-                taxType: response.data.taxType,
-                placeOfSupplyId: response.data.placeOfSupplyId,
-                option: {
-                  label:
-                    response.data.organisationName === ""
-                      ? response.data.name
-                      : response.data.organisationName,
-                  value: response.data.contactId,
-                },
-                data: response.data.invoiceLineItems,
-                totalAmount: response.data.totalAmount,
-                customer_currency: response.data.currencyCode,
-                remainingInvoiceAmount: response.data.remainingInvoiceAmount,
+          this.setState(
+            {
+              invoiceID: this.props.location?.state?.invoiceID,
+              isfreshCN: false,
+              receiptDate: response.data.receiptDate,
+              taxType: response.data.taxType,
+              placeOfSupplyId: response.data.placeOfSupplyId,
+              option: {
+                label:
+                  response.data.organisationName === ''
+                    ? response.data.name
+                    : response.data.organisationName,
+                value: response.data.contactId,
               },
-              () => {
-                this.formRef.current.setFieldValue(
-                  "lineItemsString",
-                  this.state.data,
-                  true
-                );
-                this.formRef.current.setFieldTouched(
-                  `lineItemsString[${this.state.data.length - 1}]`,
-                  false,
-                  true
-                );
-                this.updateAmount(this.state.data);
-              }
-            );
-            this.formRef.current.setFieldValue(
-              "currency",
-              response.data.currencyCode,
-              true
-            );
-            this.formRef.current.setFieldValue(
-              "taxTreatmentid",
-              this.getTaxTreatment(customerdetails.value),
-              true
-            );
-            this.formRef.current.setFieldValue(
-              "placeOfSupplyId",
-              this.state.placeOfSupplyId,
-              true
-            );
-            this.setExchange(
-              this.getCurrency(
-                response?.data?.currencyCode,
-                response?.data?.currencyName,
-                response?.data?.currencyIsoCode
-              )
-            );
-            this.formRef.current.setFieldValue(
-              "contactId",
-              response.data.contactId,
-              true
-            );
-            this.formRef.current.setFieldValue(
-              "remainingInvoiceAmount",
-              this.state.remainingInvoiceAmount,
-              true
-            );
-            this.formRef.current.setFieldValue(
-              "currencyCode",
-              response.data.currencyCode,
-              true
-            );
-            // this.getTaxTreatment(this.state.option.value)
-          }
-        });
+              data: response.data.invoiceLineItems,
+              totalAmount: response.data.totalAmount,
+              customer_currency: response.data.currencyCode,
+              remainingInvoiceAmount: response.data.remainingInvoiceAmount,
+            },
+            () => {
+              this.formRef.current.setFieldValue('lineItemsString', this.state.data, true);
+              this.formRef.current.setFieldTouched(
+                `lineItemsString[${this.state.data.length - 1}]`,
+                false,
+                true
+              );
+              this.updateAmount(this.state.data);
+            }
+          );
+          this.formRef.current.setFieldValue('currency', response.data.currencyCode, true);
+          this.formRef.current.setFieldValue(
+            'taxTreatmentid',
+            this.getTaxTreatment(customerdetails.value),
+            true
+          );
+          this.formRef.current.setFieldValue('placeOfSupplyId', this.state.placeOfSupplyId, true);
+          this.setExchange(
+            this.getCurrency(
+              response?.data?.currencyCode,
+              response?.data?.currencyName,
+              response?.data?.currencyIsoCode
+            )
+          );
+          this.formRef.current.setFieldValue('contactId', response.data.contactId, true);
+          this.formRef.current.setFieldValue(
+            'remainingInvoiceAmount',
+            this.state.remainingInvoiceAmount,
+            true
+          );
+          this.formRef.current.setFieldValue('currencyCode', response.data.currencyCode, true);
+          // this.getTaxTreatment(this.state.option.value)
+        }
+      });
     }
   };
   showDescription(row, form, field, props, idx) {
@@ -1023,9 +873,9 @@ class CreateCreditNote extends React.Component {
           multiline
           minRows={1}
           maxRows={4}
-          value={row["description"] !== "" ? row["description"] : ""}
-          onChange={(e) => {
-            this.selectItem(e.target.value, row, "description", form, field);
+          value={row['description'] !== '' ? row['description'] : ''}
+          onChange={e => {
+            this.selectItem(e.target.value, row, 'description', form, field);
           }}
           placeholder={strings.Description}
           className={`textarea ${
@@ -1036,8 +886,8 @@ class CreateCreditNote extends React.Component {
             props.touched.lineItemsString &&
             props.touched.lineItemsString[parseInt(idx, 10)] &&
             props.touched.lineItemsString[parseInt(idx, 10)].description
-              ? "is-invalid"
-              : ""
+              ? 'is-invalid'
+              : ''
           }`}
         />
       </div>
@@ -1081,9 +931,7 @@ class CreateCreditNote extends React.Component {
                       <Col lg={12}>
                         <div className="h4 mb-0 d-flex align-items-center">
                           <i className="nav-icon fas fa-donate" />
-                          <span className="ml-2">
-                            {strings.CreateCreditNote}
-                          </span>
+                          <span className="ml-2">{strings.CreateCreditNote}</span>
                         </div>
                       </Col>
                     </Row>
@@ -1104,36 +952,26 @@ class CreateCreditNote extends React.Component {
                             onSubmit={(values, { resetForm }) => {
                               this.handleSubmit(values, resetForm);
                             }}
-                            validate={(values) => {
+                            validate={values => {
                               let errors = {};
 
                               if (exist === true) {
-                                errors.creditNoteNumber =
-                                  "Tax Credit Note already exists";
+                                errors.creditNoteNumber = 'Tax Credit Note already exists';
                               }
 
-                              if (
-                                isCreatedWIWP == false &&
-                                !values.invoiceNumber
-                              ) {
-                                errors.invoiceNumber =
-                                  "Invoice number is required";
+                              if (isCreatedWIWP == false && !values.invoiceNumber) {
+                                errors.invoiceNumber = 'Invoice number is required';
                               }
-                              if (
-                                isCreatedWIWP &&
-                                values.creditAmount == ""
-                              ) {
-                                errors.creditAmount =
-                                  "Credit Amount is required";
+                              if (isCreatedWIWP && values.creditAmount == '') {
+                                errors.creditAmount = 'Credit Amount is required';
                               }
                               if (
                                 this.state.invoiceSelected &&
                                 isCreatedWIWP &&
-                                values.creditAmount >
-                                  this.state.remainingInvoiceAmount
+                                values.creditAmount > this.state.remainingInvoiceAmount
                               ) {
                                 errors.creditAmount =
-                                  "Credit Amount Cannot Be Greater Than Remaining Invoice Amount";
+                                  'Credit Amount Cannot Be Greater Than Remaining Invoice Amount';
                               }
                               return errors;
                             }}
@@ -1142,11 +980,9 @@ class CreateCreditNote extends React.Component {
                               // 	'Invoice Number is required',
                               // ),
                               creditNoteNumber: Yup.string().required(
-                                "Tax credit note number is required"
+                                'Tax credit note number is required'
                               ),
-                              contactId: Yup.string().required(
-                                "Customer name is required"
-                              ),
+                              contactId: Yup.string().required('Customer name is required'),
                               // contactId: Yup.string().required(
                               // 	'Customer is required',
                               // ),
@@ -1156,27 +992,21 @@ class CreateCreditNote extends React.Component {
                               // 	'Currency is required',
                               // ),
                               creditNoteDate: Yup.string().required(
-                                "Tax credit note date is required"
+                                'Tax credit note date is required'
                               ),
                               lineItemsString: Yup.array()
-                                .required(
-                                  "Atleast one Tax Credit Note sub detail is mandatory"
-                                )
+                                .required('Atleast one Tax Credit Note sub detail is mandatory')
                                 .of(
                                   Yup.object().shape({
                                     quantity: Yup.string()
-                                      .test(
-                                        "quantity",
-                                        strings.QuantityGreaterThan0,
-                                        (value) => {
-                                          if (value > 0) {
-                                            return true;
-                                          } else {
-                                            return false;
-                                          }
+                                      .test('quantity', strings.QuantityGreaterThan0, value => {
+                                        if (value > 0) {
+                                          return true;
+                                        } else {
+                                          return false;
                                         }
-                                      )
-                                      .required("Quantity is required"),
+                                      })
+                                      .required('Quantity is required'),
                                     // 			unitPrice: Yup.string()
                                     // 				.required('Value is required')
                                     // 				.test(
@@ -1199,70 +1029,51 @@ class CreateCreditNote extends React.Component {
                                   })
                                 ),
                               attachmentFile: Yup.mixed()
-                                .test(
-                                  "fileType",
-                                  "*Unsupported file format",
-                                  (value) => {
-                                    value &&
-                                      this.setState({
-                                        fileName: value.name,
-                                      });
-                                    if (
-                                      !value ||
-                                      (value &&
-                                        this.supported_format.includes(
-                                          value.type
-                                        ))
-                                    ) {
-                                      return true;
-                                    } else {
-                                      return false;
-                                    }
+                                .test('fileType', '*Unsupported file format', value => {
+                                  value &&
+                                    this.setState({
+                                      fileName: value.name,
+                                    });
+                                  if (
+                                    !value ||
+                                    (value && this.supported_format.includes(value.type))
+                                  ) {
+                                    return true;
+                                  } else {
+                                    return false;
                                   }
-                                )
-                                .test(
-                                  "fileSize",
-                                  "*File size is too large",
-                                  (value) => {
-                                    if (
-                                      !value ||
-                                      (value && value.size <= this.file_size)
-                                    ) {
-                                      return true;
-                                    } else {
-                                      return false;
-                                    }
+                                })
+                                .test('fileSize', '*File size is too large', value => {
+                                  if (!value || (value && value.size <= this.file_size)) {
+                                    return true;
+                                  } else {
+                                    return false;
                                   }
-                                ),
+                                }),
                             })}
                           >
-                            {(props) => (
+                            {props => (
                               <Form onSubmit={props.handleSubmit}>
                                 <Row>
                                   {!this.state.isCreatedWithoutInvoice && (
                                     <Col lg={3}>
                                       <FormGroup className="mb-3">
                                         <Label htmlFor="invoiceNumber">
-                                          <span className="text-danger">
-                                            *{" "}
-                                          </span>
+                                          <span className="text-danger">* </span>
                                           {strings.InvoiceNumber}
                                         </Label>
                                         <Select
                                           isDisabled={lockInvoiceDetail}
                                           id="invoiceNumber"
                                           name="invoiceNumber"
-                                          placeholder={
-                                            strings.Select +
-                                            strings.InvoiceNumber
-                                          }
+                                          placeholder={strings.Select + strings.InvoiceNumber}
                                           options={
                                             invoice_list.data
                                               ? selectOptionsFactory.renderOptions(
-                                                  "label",
-                                                  "value",
+                                                  'label',
+                                                  'value',
                                                   invoice_list.data,
-                                                  "Invoice Number"
+                                                  'Invoice Number'
                                                 )
                                               : []
                                           }
@@ -1272,25 +1083,19 @@ class CreateCreditNote extends React.Component {
                                               : invoice_list.data &&
                                                 selectOptionsFactory
                                                   .renderOptions(
-                                                    "label",
-                                                    "value",
+                                                    'label',
+                                                    'value',
                                                     invoice_list.data,
-                                                    "Invoice Number"
+                                                    'Invoice Number'
                                                   )
                                                   .find(
-                                                    (obj) =>
-                                                      obj.value ===
-                                                      props.values.invoiceNumber
+                                                    obj => obj.value === props.values.invoiceNumber
                                                   )
                                           }
-                                          onChange={(option) => {
+                                          onChange={option => {
                                             if (option && option.value) {
-                                              this.getInvoiceDetails(
-                                                option.value
-                                              );
-                                              props.handleChange(
-                                                "invoiceNumber"
-                                              )(option);
+                                              this.getInvoiceDetails(option.value);
+                                              props.handleChange('invoiceNumber')(option);
                                               this.setState({
                                                 invoiceSelected: true,
                                               });
@@ -1298,15 +1103,13 @@ class CreateCreditNote extends React.Component {
                                               this.setState({
                                                 invoiceSelected: false,
                                               });
-                                              props.handleChange(
-                                                "invoiceNumber"
-                                              )("");
+                                              props.handleChange('invoiceNumber')('');
                                               this.setState({
                                                 invoiceSelected: false,
                                               });
                                             }
                                             this.formRef.current.setFieldValue(
-                                              "receiptNumber",
+                                              'receiptNumber',
                                               option.label,
                                               true
                                             );
@@ -1314,8 +1117,8 @@ class CreateCreditNote extends React.Component {
                                           className={
                                             props.errors.invoiceNumber &&
                                             props.touched.invoiceNumber
-                                              ? "is-invalid"
-                                              : ""
+                                              ? 'is-invalid'
+                                              : ''
                                           }
                                         />
                                         {props.errors.invoiceNumber &&
@@ -1340,34 +1143,23 @@ class CreateCreditNote extends React.Component {
                                         type="text"
                                         id="creditNoteNumber"
                                         name="creditNoteNumber"
-                                        placeholder={
-                                          strings.Enter +
-                                          strings.CreditNoteNumber
-                                        }
+                                        placeholder={strings.Enter + strings.CreditNoteNumber}
                                         value={props.values.creditNoteNumber}
-                                        onBlur={props.handleBlur(
-                                          "creditNoteNumber"
-                                        )}
-                                        onChange={(option) => {
+                                        onBlur={props.handleBlur('creditNoteNumber')}
+                                        onChange={option => {
                                           if (
-                                            option.target.value === "" ||
-                                            this.regExCNNum.test(
-                                              option.target.value
-                                            )
+                                            option.target.value === '' ||
+                                            this.regExCNNum.test(option.target.value)
                                           ) {
-                                            props.handleChange(
-                                              "creditNoteNumber"
-                                            )(option);
+                                            props.handleChange('creditNoteNumber')(option);
                                           }
-                                          this.validationCheck(
-                                            option.target.value
-                                          );
+                                          this.validationCheck(option.target.value);
                                         }}
                                         className={
                                           props.errors.creditNoteNumber &&
                                           props.touched.creditNoteNumber
-                                            ? "is-invalid"
-                                            : ""
+                                            ? 'is-invalid'
+                                            : ''
                                         }
                                       />
                                       {props.errors.creditNoteNumber &&
@@ -1391,10 +1183,10 @@ class CreateCreditNote extends React.Component {
                                         options={
                                           customer_list_dropdown
                                             ? selectOptionsFactory.renderOptions(
-                                                "label",
-                                                "value",
+                                                'label',
+                                                'value',
                                                 customer_list_dropdown,
-                                                "Customer Name"
+                                                'Customer Name'
                                               )
                                             : []
                                         }
@@ -1404,91 +1196,71 @@ class CreateCreditNote extends React.Component {
                                             : customer_list_dropdown &&
                                               selectOptionsFactory
                                                 .renderOptions(
-                                                  "label",
-                                                  "value",
+                                                  'label',
+                                                  'value',
                                                   customer_list_dropdown,
-                                                  "Customer Name"
+                                                  'Customer Name'
                                                 )
-                                                .find(
-                                                  (obj) =>
-                                                    obj.value ===
-                                                    props.values.contactId
-                                                )
+                                                .find(obj => obj.value === props.values.contactId)
                                         }
                                         isDisabled={this.state.invoiceSelected}
-                                        onChange={(option) => {
+                                        onChange={option => {
                                           if (option && option.value) {
-                                            props.handleChange("contactId")(
-                                              option
-                                            );
+                                            props.handleChange('contactId')(option);
                                           } else {
-                                            props.handleChange("contactId")("");
+                                            props.handleChange('contactId')('');
                                           }
                                         }}
                                         className={
-                                          props.errors.contactId &&
-                                          props.touched.contactId
-                                            ? "is-invalid"
-                                            : ""
+                                          props.errors.contactId && props.touched.contactId
+                                            ? 'is-invalid'
+                                            : ''
                                         }
                                       />
-                                      {props.errors.contactId &&
-                                        props.touched.contactId && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.contactId}
-                                          </div>
-                                        )}
+                                      {props.errors.contactId && props.touched.contactId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.contactId}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
 
                                   <Col lg={3}>
                                     <FormGroup className="mb-3">
-                                      <Label htmlFor="taxTreatmentid">
-                                        {strings.TaxTreatment}
-                                      </Label>
+                                      <Label htmlFor="taxTreatmentid">{strings.TaxTreatment}</Label>
                                       <Select
                                         options={
                                           taxTreatmentList
                                             ? selectOptionsFactory.renderOptions(
-                                                "name",
-                                                "id",
+                                                'name',
+                                                'id',
                                                 taxTreatmentList,
-                                                "VAT"
+                                                'VAT'
                                               )
                                             : []
                                         }
                                         isDisabled={true}
                                         id="taxTreatmentid"
                                         name="taxTreatmentid"
-                                        placeholder={
-                                          strings.Select + strings.TaxTreatment
-                                        }
+                                        placeholder={strings.Select + strings.TaxTreatment}
                                         value={
                                           taxTreatmentList &&
                                           selectOptionsFactory
-                                            .renderOptions(
-                                              "name",
-                                              "id",
-                                              taxTreatmentList,
-                                              "VAT"
-                                            )
+                                            .renderOptions('name', 'id', taxTreatmentList, 'VAT')
                                             .find(
-                                              (option) =>
+                                              option =>
                                                 option.label ===
-                                                this.state
-                                                  .customer_taxTreatment_des
+                                                this.state.customer_taxTreatment_des
                                             )
                                         }
-                                        onChange={(option) => {
-                                          props.handleChange("taxTreatmentid")(
-                                            option
-                                          );
+                                        onChange={option => {
+                                          props.handleChange('taxTreatmentid')(option);
                                         }}
                                         className={
                                           props.errors.taxTreatmentid &&
                                           props.touched.taxTreatmentid
-                                            ? "is-invalid"
-                                            : ""
+                                            ? 'is-invalid'
+                                            : ''
                                         }
                                       />
                                       {props.errors.taxTreatmentid &&
@@ -1500,34 +1272,27 @@ class CreateCreditNote extends React.Component {
                                     </FormGroup>
                                   </Col>
                                   <Col lg={3}>
-                                    {this.state.customer_taxTreatment_des !==
-                                      "NON GCC" &&
+                                    {this.state.customer_taxTreatment_des !== 'NON GCC' &&
                                       this.state.customer_taxTreatment_des !==
-                                        "GCC VAT REGISTERED" &&
+                                        'GCC VAT REGISTERED' &&
                                       this.state.customer_taxTreatment_des !==
-                                        "GCC NON-VAT REGISTERED" && (
+                                        'GCC NON-VAT REGISTERED' && (
                                         <FormGroup className="mb-3">
                                           <Label htmlFor="placeOfSupplyId">
-                                            <span className="text-danger">
-                                              *{" "}
-                                            </span>
+                                            <span className="text-danger">* </span>
                                             {strings.PlaceofSupply}
                                           </Label>
                                           <Select
                                             id="placeOfSupplyId"
                                             name="placeOfSupplyId"
-                                            placeholder={
-                                              strings.Select +
-                                              strings.PlaceofSupply
-                                            }
+                                            placeholder={strings.Select + strings.PlaceofSupply}
                                             options={
-                                              console.log(this.placelist) ||
-                                              this.placelist
+                                              console.log(this.placelist) || this.placelist
                                                 ? selectOptionsFactory.renderOptions(
-                                                    "label",
-                                                    "value",
+                                                    'label',
+                                                    'value',
                                                     this.placelist,
-                                                    "Place of Supply"
+                                                    'Place of Supply'
                                                   )
                                                 : []
                                             }
@@ -1535,46 +1300,33 @@ class CreateCreditNote extends React.Component {
                                               this.placelist &&
                                               selectOptionsFactory
                                                 .renderOptions(
-                                                  "label",
-                                                  "value",
+                                                  'label',
+                                                  'value',
                                                   this.placelist,
-                                                  "Place of Supply"
+                                                  'Place of Supply'
                                                 )
                                                 .find(
-                                                  (option) =>
+                                                  option =>
                                                     option.value ==
                                                     (this.state.invoiceId
-                                                      ? this.state
-                                                          .placeOfSupplyId &&
-                                                        this.state
-                                                          .placeOfSupplyId
-                                                          .value !== null
-                                                        ? this.state
-                                                            .placeOfSupplyId
-                                                            .value
-                                                        : this.state
-                                                            .placeOfSupplyId
-                                                      : props.values
-                                                          .placeOfSupplyId !==
-                                                        null
-                                                      ? props.values.placeOfSupplyId.toString()
-                                                      : "")
+                                                      ? this.state.placeOfSupplyId &&
+                                                        this.state.placeOfSupplyId.value !== null
+                                                        ? this.state.placeOfSupplyId.value
+                                                        : this.state.placeOfSupplyId
+                                                      : props.values.placeOfSupplyId !== null
+                                                        ? props.values.placeOfSupplyId.toString()
+                                                        : '')
                                                 )
                                             }
-                                            isDisabled={
-                                              this.state.placeOfSupplyId !==
-                                              null
-                                            }
+                                            isDisabled={this.state.placeOfSupplyId !== null}
                                             className={
                                               props.errors.placeOfSupplyId &&
                                               props.touched.placeOfSupplyId
-                                                ? "is-invalid"
-                                                : ""
+                                                ? 'is-invalid'
+                                                : ''
                                             }
-                                            onChange={(option) => {
-                                              props.handleChange(
-                                                "placeOfSupplyId"
-                                              )(option);
+                                            onChange={option => {
+                                              props.handleChange('placeOfSupplyId')(option);
                                               this.setState({
                                                 placeOfSupplyId: option,
                                               });
@@ -1601,44 +1353,34 @@ class CreateCreditNote extends React.Component {
                                       <DatePicker
                                         id="creditNoteDate"
                                         name="creditNoteDate"
-                                        placeholderText={
-                                          strings.Select +
-                                          strings.CreditNoteDate
-                                        }
+                                        placeholderText={strings.Select + strings.CreditNoteDate}
                                         showMonthDropdown
                                         showYearDropdown
                                         dateFormat="dd-MM-yyyy"
                                         minDate={
                                           new Date(
-                                            dayjs(
-                                              this.state.receiptDate,
-                                              "YYYY-MM-DD"
-                                            ).format()
+                                            dayjs(this.state.receiptDate, 'YYYY-MM-DD').format()
                                           )
                                         }
                                         dropdownMode="select"
                                         value={props.values.creditNoteDate}
                                         selected={props.values.creditNoteDate}
-                                        onChange={(value) => {
-                                          props.handleChange("creditNoteDate")(
-                                            value
-                                          );
+                                        onChange={value => {
+                                          props.handleChange('creditNoteDate')(value);
                                           this.setDate(props, value);
                                         }}
                                         className={`form-control ${
                                           props.errors.creditNoteDate &&
                                           props.touched.creditNoteDate
-                                            ? "is-invalid"
-                                            : ""
+                                            ? 'is-invalid'
+                                            : ''
                                         }`}
                                       />
                                       {props.errors.creditNoteDate &&
                                         props.touched.creditNoteDate && (
                                           <div className="invalid-feedback">
-                                            {props.errors.creditNoteDate.includes(
-                                              "nullable()"
-                                            )
-                                              ? "Tax credit note date is required"
+                                            {props.errors.creditNoteDate.includes('nullable()')
+                                              ? 'Tax credit note date is required'
                                               : props.errors.creditNoteDate}
                                           </div>
                                         )}
@@ -1653,16 +1395,14 @@ class CreateCreditNote extends React.Component {
                                       <Select
                                         isDisabled={true}
                                         styles={customStyles}
-                                        placeholder={
-                                          strings.Select + strings.Currency
-                                        }
+                                        placeholder={strings.Select + strings.Currency}
                                         options={
                                           currency_convert_list
                                             ? selectCurrencyFactory.renderOptions(
-                                                "currencyName",
-                                                "currencyCode",
+                                                'currencyName',
+                                                'currencyCode',
                                                 currency_convert_list,
-                                                "Currency"
+                                                'Currency'
                                               )
                                             : []
                                         }
@@ -1672,37 +1412,32 @@ class CreateCreditNote extends React.Component {
                                           currency_convert_list &&
                                           selectCurrencyFactory
                                             .renderOptions(
-                                              "currencyName",
-                                              "currencyCode",
+                                              'currencyName',
+                                              'currencyCode',
                                               currency_convert_list,
-                                              "Currency"
+                                              'Currency'
                                             )
                                             .find(
-                                              (option) =>
-                                                option.value ===
-                                                +this.state.customer_currency
+                                              option =>
+                                                option.value === +this.state.customer_currency
                                             )
                                         }
                                         className={
-                                          props.errors.currency &&
-                                          props.touched.currency
-                                            ? "is-invalid"
-                                            : ""
+                                          props.errors.currency && props.touched.currency
+                                            ? 'is-invalid'
+                                            : ''
                                         }
-                                        onChange={(option) => {
-                                          props.handleChange("currency")(
-                                            option
-                                          );
+                                        onChange={option => {
+                                          props.handleChange('currency')(option);
                                           // this.setExchange(option.value);
                                           this.setCurrency(option.value);
                                         }}
                                       />
-                                      {props.errors.currency &&
-                                        props.touched.currency && (
-                                          <div className="invalid-feedback">
-                                            {props.errors.currency}
-                                          </div>
-                                        )}
+                                      {props.errors.currency && props.touched.currency && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.currency}
+                                        </div>
+                                      )}
                                     </FormGroup>
                                   </Col>
 
@@ -1719,17 +1454,11 @@ class CreateCreditNote extends React.Component {
                                             name="remainingInvoiceAmount"
                                             placeholder="Remaining invoice Amount"
                                             disabled={true}
-                                            value={
-                                              this.state.remainingInvoiceAmount
-                                            }
+                                            value={this.state.remainingInvoiceAmount}
                                           />
-                                          {props.errors
-                                            .remainingInvoiceAmount && (
+                                          {props.errors.remainingInvoiceAmount && (
                                             <div className="text-danger">
-                                              {
-                                                props.errors
-                                                  .remainingInvoiceAmount
-                                              }
+                                              {props.errors.remainingInvoiceAmount}
                                             </div>
                                           )}
                                         </FormGroup>
@@ -1740,9 +1469,7 @@ class CreateCreditNote extends React.Component {
                                     <Col lg={3}>
                                       <FormGroup className="mb-3">
                                         <Label htmlFor="creditAmount">
-                                          <span className="text-danger">
-                                            *{" "}
-                                          </span>
+                                          <span className="text-danger">* </span>
                                           {strings.CreditAmount}
                                         </Label>
                                         <Input
@@ -1750,31 +1477,22 @@ class CreateCreditNote extends React.Component {
                                           maxLength="14,2"
                                           id="creditAmount"
                                           name="creditAmount"
-                                          placeholder={
-                                            strings.Enter + strings.CreditAmount
-                                          }
+                                          placeholder={strings.Enter + strings.CreditAmount}
                                           value={props.values.creditAmount}
                                           // onBlur={props.handleBlur('currencyCode')}
-                                          onChange={(value) => {
+                                          onChange={value => {
                                             if (
-                                              (this.regDecimal.test(
-                                                value.target.value
-                                              ) &&
-                                                parseFloat(
-                                                  value.target.value
-                                                ) >= 1) ||
-                                              value.target.value === ""
+                                              (this.regDecimal.test(value.target.value) &&
+                                                parseFloat(value.target.value) >= 1) ||
+                                              value.target.value === ''
                                             ) {
-                                              props.handleChange(
-                                                "creditAmount"
-                                              )(value);
+                                              props.handleChange('creditAmount')(value);
                                             }
                                           }}
                                           className={
-                                            props.errors.creditAmount &&
-                                            props.touched.creditAmount
-                                              ? "is-invalid"
-                                              : ""
+                                            props.errors.creditAmount && props.touched.creditAmount
+                                              ? 'is-invalid'
+                                              : ''
                                           }
                                         />
                                         {props.errors.creditAmount && (
@@ -1785,7 +1503,6 @@ class CreateCreditNote extends React.Component {
                                       </FormGroup>
                                     </Col>
                                   )}
-                                
                                 </Row>
                                 <hr />
                                 {isCreatedWIWP === false && (
@@ -1794,30 +1511,20 @@ class CreateCreditNote extends React.Component {
                                       <Col lg={8} className="mb-3"></Col>
                                       <Col>
                                         {this.state.taxType === false ? (
-                                          <span
-                                            style={{ color: "#0069d9" }}
-                                            className="mr-4"
-                                          >
+                                          <span style={{ color: '#0069d9' }} className="mr-4">
                                             <b>{strings.Exclusive}</b>
                                           </span>
                                         ) : (
-                                          <span className="mr-4">
-                                            {strings.Exclusive}
-                                          </span>
+                                          <span className="mr-4">{strings.Exclusive}</span>
                                         )}
                                         <Switch
                                           value={props.values.taxType}
                                           checked={this.state.taxType}
                                           disabled
-                                          onChange={(taxType) => {
-                                            props.handleChange("taxType")(
-                                              taxType
-                                            );
+                                          onChange={taxType => {
+                                            props.handleChange('taxType')(taxType);
                                             this.setState({ taxType }, () => {
-                                              this.updateAmount(
-                                                this.state.data,
-                                                props
-                                              );
+                                              this.updateAmount(this.state.data, props);
                                             });
                                           }}
                                           onColor="#2064d8"
@@ -1832,16 +1539,11 @@ class CreateCreditNote extends React.Component {
                                           className="react-switch "
                                         />
                                         {this.state.taxType === true ? (
-                                          <span
-                                            style={{ color: "#0069d9" }}
-                                            className="ml-4"
-                                          >
+                                          <span style={{ color: '#0069d9' }} className="ml-4">
                                             <b>{strings.Inclusive}</b>
                                           </span>
                                         ) : (
-                                          <span className="ml-4">
-                                            {strings.Inclusive}
-                                          </span>
+                                          <span className="ml-4">{strings.Inclusive}</span>
                                         )}
                                       </Col>
                                     </Row>
@@ -1851,25 +1553,21 @@ class CreateCreditNote extends React.Component {
                                           data={data}
                                           initValue={initValue}
                                           isRegisteredVat={isRegisteredVat}
-                                          universal_currency_list={
-                                            universal_currency_list
-                                          }
-                                          setData={(data) => {
+                                          universal_currency_list={universal_currency_list}
+                                          setData={data => {
                                             this.setState({ data: data });
                                             this.formRef.current.setFieldValue(
-                                              "lineItemsString",
+                                              'lineItemsString',
                                               data,
                                               true
                                             );
                                             this.formRef.current.setFieldTouched(
-                                              `lineItemsString[${
-                                                data.length - 1
-                                              }]`,
+                                              `lineItemsString[${data.length - 1}]`,
                                               false,
                                               true
                                             );
                                           }}
-                                          setIdCount={(idCount) => {
+                                          setIdCount={idCount => {
                                             this.setState({ idCount: idCount });
                                           }}
                                           props={props}
@@ -1877,23 +1575,16 @@ class CreateCreditNote extends React.Component {
                                           vat_list={vat_list}
                                           product_list={product_list}
                                           excise_list={excise_list}
-                                          discountEnabled={
-                                            initValue.discount != 0
-                                              ? true
-                                              : false
-                                          }
+                                          discountEnabled={initValue.discount != 0 ? true : false}
                                           idCount={idCount}
-                                          updateAmount={(data) => {
+                                          updateAmount={data => {
                                             this.updateAmount(data);
                                           }}
                                           enableAccount={false}
-                                          exchangeRate={
-                                            props.values.exchangeRate
-                                          }
+                                          exchangeRate={props.values.exchangeRate}
                                           disableVat={!isRegisteredVat}
-                                          getProductType={(id) => {
-                                            const vat_list =
-                                              this.getProductType(id);
+                                          getProductType={id => {
+                                            const vat_list = this.getProductType(id);
                                             return vat_list;
                                           }}
                                           disableAll={true}
@@ -1908,20 +1599,10 @@ class CreateCreditNote extends React.Component {
                                             <Input
                                               type="checkbox"
                                               id="discountEnabled"
-                                              checked={
-                                                initValue.discount != 0
-                                                  ? true
-                                                  : false
-                                              }
-                                              value={
-                                                initValue.discount != 0
-                                                  ? true
-                                                  : false
-                                              }
+                                              checked={initValue.discount != 0 ? true : false}
+                                              value={initValue.discount != 0 ? true : false}
                                             />
-                                            <Label>
-                                              {strings.ApplyLineItemDiscount}
-                                            </Label>
+                                            <Label>{strings.ApplyLineItemDiscount}</Label>
                                           </FormGroup>
                                         </Col>
                                       </Row>
@@ -1932,23 +1613,19 @@ class CreateCreditNote extends React.Component {
                                   <Row>
                                     <Col lg={8}>
                                       <FormGroup className="py-2">
-                                        <Label htmlFor="notes">
-                                          {strings.RefundNotes}
-                                        </Label>
+                                        <Label htmlFor="notes">{strings.RefundNotes}</Label>
                                         <br />
                                         <TextField
                                           type="textarea"
                                           multiline
-                                          style={{ width: "500px" }}
+                                          style={{ width: '500px' }}
                                           className="textarea"
                                           inputProps={{ maxLength: 255 }}
                                           name="notes"
                                           id="notes"
                                           maxRows={4}
                                           placeholder={strings.DeliveryNotes}
-                                          onChange={(option) =>
-                                            props.handleChange("notes")(option)
-                                          }
+                                          onChange={option => props.handleChange('notes')(option)}
                                           value={props.values.notes}
                                         />
                                       </FormGroup>
@@ -1965,19 +1642,15 @@ class CreateCreditNote extends React.Component {
                                               id="receiptNumber"
                                               name="receiptNumber"
                                               value={props.values.receiptNumber}
-                                              placeholder={
-                                                strings.ReceiptNumber
-                                              }
-                                              onChange={(value) => {
-                                                props.handleChange(
-                                                  "receiptNumber"
-                                                )(value);
+                                              placeholder={strings.ReceiptNumber}
+                                              onChange={value => {
+                                                props.handleChange('receiptNumber')(value);
                                               }}
                                               className={
                                                 props.errors.receiptNumber &&
                                                 props.touched.receiptNumber
-                                                  ? "is-invalid"
-                                                  : " "
+                                                  ? 'is-invalid'
+                                                  : ' '
                                               }
                                             />
                                             {props.errors.receiptNumber &&
@@ -1994,36 +1667,26 @@ class CreateCreditNote extends React.Component {
                                               name="attachmentFile"
                                               render={({ field, form }) => (
                                                 <div>
-                                                  <Label>
-                                                    {strings.ReceiptAttachment}
-                                                  </Label>{" "}
-                                                  <br />
+                                                  <Label>{strings.ReceiptAttachment}</Label> <br />
                                                   <Button
                                                     color="primary"
                                                     onClick={() => {
-                                                      document
-                                                        .getElementById(
-                                                          "fileInput"
-                                                        )
-                                                        .click();
+                                                      document.getElementById('fileInput').click();
                                                     }}
                                                     className="btn-square mr-3"
                                                   >
-                                                    <i className="fa fa-upload"></i>{" "}
+                                                    <i className="fa fa-upload"></i>{' '}
                                                     {strings.upload}
                                                   </Button>
                                                   <input
                                                     id="fileInput"
-                                                    ref={(ref) => {
+                                                    ref={ref => {
                                                       this.uploadFile = ref;
                                                     }}
                                                     type="file"
-                                                    style={{ display: "none" }}
-                                                    onChange={(e) => {
-                                                      this.handleFileChange(
-                                                        e,
-                                                        props
-                                                      );
+                                                    style={{ display: 'none' }}
+                                                    onChange={e => {
+                                                      this.handleFileChange(e, props);
                                                     }}
                                                   />
                                                   {this.state.fileName && (
@@ -2032,10 +1695,10 @@ class CreateCreditNote extends React.Component {
                                                         className="fa fa-close"
                                                         onClick={() =>
                                                           this.setState({
-                                                            fileName: "",
+                                                            fileName: '',
                                                           })
                                                         }
-                                                      ></i>{" "}
+                                                      ></i>{' '}
                                                       {this.state.fileName}
                                                     </div>
                                                   )}
@@ -2060,22 +1723,17 @@ class CreateCreditNote extends React.Component {
                                           type="textarea"
                                           className="textarea form-control"
                                           maxLength="250"
-                                          style={{ width: "700px" }}
+                                          style={{ width: '700px' }}
                                           name="receiptAttachmentDescription"
                                           id="receiptAttachmentDescription"
                                           rows="2"
-                                          placeholder={
-                                            strings.ReceiptAttachmentDescription
+                                          placeholder={strings.ReceiptAttachmentDescription}
+                                          onChange={option =>
+                                            props.handleChange('receiptAttachmentDescription')(
+                                              option
+                                            )
                                           }
-                                          onChange={(option) =>
-                                            props.handleChange(
-                                              "receiptAttachmentDescription"
-                                            )(option)
-                                          }
-                                          value={
-                                            props.values
-                                              .receiptAttachmentDescription
-                                          }
+                                          value={props.values.receiptAttachmentDescription}
                                         />
                                       </FormGroup>
                                     </Col>
@@ -2083,16 +1741,10 @@ class CreateCreditNote extends React.Component {
                                       <Col lg={4}>
                                         <TotalCalculation
                                           initValue={initValue}
-                                          currency_symbol={
-                                            initValue.currencyIsoCode
-                                          }
+                                          currency_symbol={initValue.currencyIsoCode}
                                           isRegisteredVat={isRegisteredVat}
                                           strings={strings}
-                                          discountEnabled={
-                                            initValue.discount != 0
-                                              ? true
-                                              : false
-                                          }
+                                          discountEnabled={initValue.discount != 0 ? true : false}
                                         />
                                       </Col>
                                     )}
@@ -2101,22 +1753,18 @@ class CreateCreditNote extends React.Component {
                                   <Row>
                                     <Col lg={8}>
                                       <FormGroup className="py-2">
-                                        <Label htmlFor="notes">
-                                          {strings.RefundNotes}
-                                        </Label>
+                                        <Label htmlFor="notes">{strings.RefundNotes}</Label>
                                         <br />
                                         <TextareaAutosize
                                           type="textarea"
-                                          style={{ width: "700px" }}
+                                          style={{ width: '700px' }}
                                           className="textarea form-control"
                                           maxLength="255"
                                           name="notes"
                                           id="notes"
                                           rows="2"
                                           placeholder={strings.DeliveryNotes}
-                                          onChange={(option) =>
-                                            props.handleChange("notes")(option)
-                                          }
+                                          onChange={option => props.handleChange('notes')(option)}
                                           value={props.values.notes}
                                         />
                                       </FormGroup>
@@ -2136,40 +1784,27 @@ class CreateCreditNote extends React.Component {
                                         disabled={
                                           this.state.disabled ||
                                           (parseFloat(
-                                            parseFloat(
-                                              initValue.totalAmount
-                                            ).toFixed(2)
-                                          ) >
-                                            this.state.remainingInvoiceAmount &&
+                                            parseFloat(initValue.totalAmount).toFixed(2)
+                                          ) > this.state.remainingInvoiceAmount &&
                                             !isCreatedWIWP)
                                         }
                                         onClick={() => {
-                                          console.log(props.errors, "Error");
+                                          console.log(props.errors, 'Error');
                                           //	added validation popup	msg
                                           props.handleBlur();
-                                          if (
-                                            props.errors &&
-                                            Object.keys(props.errors).length !=
-                                              0
-                                          )
+                                          if (props.errors && Object.keys(props.errors).length != 0)
                                             this.props.commonActions.fillManDatoryDetails();
 
-                                          this.setState(
-                                            { createMore: false },
-                                            () => {
-                                              props.handleSubmit();
-                                            }
-                                          );
+                                          this.setState({ createMore: false }, () => {
+                                            props.handleSubmit();
+                                          });
                                         }}
                                       >
-                                        <i className="fa fa-dot-circle-o"></i>{" "}
-                                        {this.state.disabled
-                                          ? "Creating..."
-                                          : strings.Create}
+                                        <i className="fa fa-dot-circle-o"></i>{' '}
+                                        {this.state.disabled ? 'Creating...' : strings.Create}
                                       </Button>
 
-                                      {!this.props.location?.state
-                                        ?.invoiceID && (
+                                      {!this.props.location?.state?.invoiceID && (
                                         <Button
                                           type="button"
                                           color="primary"
@@ -2177,12 +1812,8 @@ class CreateCreditNote extends React.Component {
                                           disabled={
                                             this.state.disabled ||
                                             (parseFloat(
-                                              parseFloat(
-                                                initValue.totalAmount
-                                              ).toFixed(2)
-                                            ) >
-                                              this.state
-                                                .remainingInvoiceAmount &&
+                                              parseFloat(initValue.totalAmount).toFixed(2)
+                                            ) > this.state.remainingInvoiceAmount &&
                                               !isCreatedWIWP)
                                           }
                                           onClick={() => {
@@ -2190,8 +1821,7 @@ class CreateCreditNote extends React.Component {
                                             props.handleBlur();
                                             if (
                                               props.errors &&
-                                              Object.keys(props.errors)
-                                                .length != 0
+                                              Object.keys(props.errors).length != 0
                                             )
                                               this.props.commonActions.fillManDatoryDetails();
                                             this.setState(
@@ -2204,9 +1834,9 @@ class CreateCreditNote extends React.Component {
                                             );
                                           }}
                                         >
-                                          <i className="fa fa-refresh"></i>{" "}
+                                          <i className="fa fa-refresh"></i>{' '}
                                           {this.state.disabled
-                                            ? "Creating..."
+                                            ? 'Creating...'
                                             : strings.CreateandMore}
                                         </Button>
                                       )}
@@ -2214,44 +1844,32 @@ class CreateCreditNote extends React.Component {
                                         color="secondary"
                                         className="btn-square"
                                         onClick={() => {
-                                          if (
-                                            this.props?.location?.state
-                                              ?.renderURL
-                                          ) {
+                                          if (this.props?.location?.state?.renderURL) {
                                             this.props.history.push(
                                               `${this.props?.location?.state?.renderURL}`,
                                               {
-                                                id: this.props?.location?.state
-                                                  ?.renderID,
+                                                id: this.props?.location?.state?.renderID,
                                               }
                                             );
-                                          } else if (
-                                            this.props.location?.state
-                                              ?.invoiceID
-                                          )
+                                          } else if (this.props.location?.state?.invoiceID)
                                             this.props.history.push(
-                                              "/admin/income/customer-invoice"
+                                              '/admin/income/customer-invoice'
                                             );
                                           else
-                                            this.props.history.push(
-                                              "/admin/income/credit-notes"
-                                            );
+                                            this.props.history.push('/admin/income/credit-notes');
                                         }}
                                       >
-                                        <i className="fa fa-ban"></i>{" "}
-                                        {strings.Cancel}
+                                        <i className="fa fa-ban"></i> {strings.Cancel}
                                       </Button>
                                     </FormGroup>
                                   </Col>
                                 </Row>
 
-                                {parseFloat(
-                                  parseFloat(initValue.totalAmount).toFixed(2)
-                                ) > this.state.remainingInvoiceAmount &&
+                                {parseFloat(parseFloat(initValue.totalAmount).toFixed(2)) >
+                                  this.state.remainingInvoiceAmount &&
                                   !isCreatedWIWP && (
-                                    <div style={{ color: "red" }}>
-                                      Remaining Invoice Amount cananot less than
-                                      Total Amount sdgsdg
+                                    <div style={{ color: 'red' }}>
+                                      Remaining Invoice Amount cananot less than Total Amount sdgsdg
                                       {this.state.isCreatedWithoutInvoice}
                                     </div>
                                   )}
@@ -2267,7 +1885,7 @@ class CreateCreditNote extends React.Component {
             </Row>
           </div>
         </div>
-        {this.state.disableLeavePage ? "" : <LeavePage />}
+        {this.state.disableLeavePage ? '' : <LeavePage />}
       </div>
     );
   }

--- a/apps/frontend/src/screens/debitNotes/screens/detail/screen.js
+++ b/apps/frontend/src/screens/debitNotes/screens/detail/screen.js
@@ -2,18 +2,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Row,
-	Col,
-	Form,
-	FormGroup,
-	Input,
-	Label,
-	NavLink,
-	UncontrolledTooltip
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Input,
+  Label,
+  NavLink,
+  UncontrolledTooltip,
 } from 'reactstrap';
 import { Checkbox } from '@material-ui/core';
 import Select from 'react-select';
@@ -37,1907 +37,1950 @@ import { selectCurrencyFactory, selectOptionsFactory, renderList } from 'utils';
 
 import './style.scss';
 import dayjs from '@/utils/date';
-import Switch from "react-switch";
+import Switch from 'react-switch';
 import API_ROOT_URL from '../../../../constants/config';
-import { data } from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 
-
-const mapStateToProps = (state) => {
-	return {
-		tax_treatment_list: state.common.tax_treatment_list,
-		contact_list: state.customer_invoice.contact_list,
-		currency_list: state.customer_invoice.currency_list,
-		vat_list: state.common.vat_list,
-		product_list: state.common.product_list,
-		excise_list: state.common.excise_list,
-		customer_list: state.common.customer_list,
-		country_list: state.customer_invoice.country_list,
-		universal_currency_list: state.common.universal_currency_list,
-		currency_convert_list: state.common.currency_convert_list,
-		company_details: state.common.company_details,
-	};
+const mapStateToProps = state => {
+  return {
+    tax_treatment_list: state.common.tax_treatment_list,
+    contact_list: state.customer_invoice.contact_list,
+    currency_list: state.customer_invoice.currency_list,
+    vat_list: state.common.vat_list,
+    product_list: state.common.product_list,
+    excise_list: state.common.excise_list,
+    customer_list: state.common.customer_list,
+    country_list: state.customer_invoice.country_list,
+    universal_currency_list: state.common.universal_currency_list,
+    currency_convert_list: state.common.currency_convert_list,
+    company_details: state.common.company_details,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
-		debitNotesActions: bindActionCreators(DebitNotesActions, dispatch,),
-		debitNotesDetailActions: bindActionCreators(DebitNotesDetailActions, dispatch,),
-		commonActions: bindActionCreators(CommonActions, dispatch),
+const mapDispatchToProps = dispatch => {
+  return {
+    currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
+    debitNotesActions: bindActionCreators(DebitNotesActions, dispatch),
+    debitNotesDetailActions: bindActionCreators(DebitNotesDetailActions, dispatch),
+    commonActions: bindActionCreators(CommonActions, dispatch),
 
-		ProductActions: bindActionCreators(ProductActions, dispatch),
-		supplierInvoiceDetailActions: bindActionCreators(
-			SupplierInvoiceDetailActions,
-			dispatch,
-		),
-	};
+    ProductActions: bindActionCreators(ProductActions, dispatch),
+    supplierInvoiceDetailActions: bindActionCreators(SupplierInvoiceDetailActions, dispatch),
+  };
 };
 const customStyles = {
-	control: (base, state) => ({
-		...base,
-		borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		boxShadow: state.isFocused ? null : null,
-		'&:hover': {
-			borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		},
-	}),
+  control: (base, state) => ({
+    ...base,
+    borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    boxShadow: state.isFocused ? null : null,
+    '&:hover': {
+      borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    },
+  }),
 };
 
 let strings = new LocalizedStrings(data);
 class DetailDebitNote extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			language: window['localStorage'].getItem('language'),
-			loading: true,
-			dialog: false,
-			disabled: false,
-			disabled1: false,
-			customer_currency_symbol: '',
-			discountOptions: [
-				{ value: 'FIXED', label: 'Fixed' },
-				{ value: 'PERCENTAGE', label: '%' },
-			],
-			exciseTypeOption: [
-				{ value: 'Inclusive', label: 'Inclusive' },
-				{ value: 'Exclusive', label: 'Exclusive' },
-			],
-			discount_option: '',
-			data: [],
-			debitNoteId: '',
-			initValue: {
-				total_excise: 0,
-				totalNet: 0,
-				totalVatAmount: 0,
-				totalAmount: 0,
-				totalDiscount: 0,
-			},
-			contactType: 1,
-			openCustomerModal: false,
-			openProductModal: false,
-			invoiceSelected: false,
-			term: '',
-			placeOfSupplyId: '',
-			selectedType: '',
-			discountPercentage: '',
-			discountAmount: 0,
-			fileName: '',
-			purchaseCategory: [],
-			basecurrency: [],
-			customer_currency: '',
-			loadingMsg: "Loading",
-			showInvoiceNumber: false,
-			taxType: false,
-			disableLeavePage: false,
-			isCreatedWithoutInvoice: false,
-			isReverseChargeEnabled: false,
-			receiptDate: '',
-		};
-		this.formRef = React.createRef();
-		this.regEx = /^[0-9\b]+$/;
-		this.regExBoth = /[a-zA-Z0-9]+$/;
-		this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: window['localStorage'].getItem('language'),
+      loading: true,
+      dialog: false,
+      disabled: false,
+      disabled1: false,
+      customer_currency_symbol: '',
+      discountOptions: [
+        { value: 'FIXED', label: 'Fixed' },
+        { value: 'PERCENTAGE', label: '%' },
+      ],
+      exciseTypeOption: [
+        { value: 'Inclusive', label: 'Inclusive' },
+        { value: 'Exclusive', label: 'Exclusive' },
+      ],
+      discount_option: '',
+      data: [],
+      debitNoteId: '',
+      initValue: {
+        total_excise: 0,
+        totalNet: 0,
+        totalVatAmount: 0,
+        totalAmount: 0,
+        totalDiscount: 0,
+      },
+      contactType: 1,
+      openCustomerModal: false,
+      openProductModal: false,
+      invoiceSelected: false,
+      term: '',
+      placeOfSupplyId: '',
+      selectedType: '',
+      discountPercentage: '',
+      discountAmount: 0,
+      fileName: '',
+      purchaseCategory: [],
+      basecurrency: [],
+      customer_currency: '',
+      loadingMsg: 'Loading',
+      showInvoiceNumber: false,
+      taxType: false,
+      disableLeavePage: false,
+      isCreatedWithoutInvoice: false,
+      isReverseChargeEnabled: false,
+      receiptDate: '',
+    };
+    this.formRef = React.createRef();
+    this.regEx = /^[0-9\b]+$/;
+    this.regExBoth = /[a-zA-Z0-9]+$/;
+    this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
 
-		this.file_size = 1024000;
-		this.supported_format = [
-			'image/png',
-			'image/jpeg',
-			'text/plain',
-			'application/pdf',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-			'application/vnd.ms-excel',
-			'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		];
-	}
+    this.file_size = 1024000;
+    this.supported_format = [
+      'image/png',
+      'image/jpeg',
+      'text/plain',
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ];
+  }
 
-	componentDidMount = () => {
-		this.initializeData();
-		this.props.commonActions.getVatList();
-		this.props.commonActions.getCustomerList(this.state.contactType,).then(response => {
-			if (response.status === 200)
-				this.getCurrency(response.data.contactId)
-		});
-		this.props.commonActions.getExciseList();
-		this.props.debitNotesActions.getCountryList();
-		this.props.commonActions.getProductList();
-	};
-	initializeData = () => {
-		this.props.commonActions.getTaxTreatmentList();
-		if (this.props.location.state && this.props.location.state.id) {
-			this.props.debitNotesActions
-				.getDebitNoteById(this.props.location.state.id,
-					this.props.location.state.isCNWithoutProduct ? this.props.location.state.isCNWithoutProduct : false)
-				.then((res) => {
-					if (res.status === 200) {
-						this.setState(
-							{
-								taxType: res.data.taxType ? res.data.taxType : false,
-								isCreatedWithoutInvoice: res.data.invoiceId ? false : true,
-								debitNoteId: this.props.location.state.id,
-								isReverseChargeEnabled: res.data.isReverseChargeEnabled,
-								initValue: {
-									invoiceNumber: res.data.invoiceId ? { value: res.data.invoiceId, label: res.data.invoiceNumber } : '',
-									receiptAttachmentDescription: res.data
-										.receiptAttachmentDescription
-										? res.data.receiptAttachmentDescription
-										: '',
-									referenceNumber: res.data.referenceNo
-										? res.data.referenceNo
-										: '',
-									contact_po_number: res.data.contactPoNumber
-										? res.data.contactPoNumber
-										: '',
-									currency: res.data.currencyCode ? res.data.currencyCode : '',
-									exchangeRate: res.data.exchangeRate ? res.data.exchangeRate : '',
-									currencyName: res.data.currencyName ? res.data.currencyName : '',
-									invoiceDate: res.data.creditNoteDate
-										? new Date(res.data.creditNoteDate)
-										: '',
-									contactId: res.data.contactId ? res.data.contactId : '',
-									debitNoteNumber: res.data.creditNoteNumber
-										? res.data.creditNoteNumber
-										: '',
+  componentDidMount = () => {
+    this.initializeData();
+    this.props.commonActions.getVatList();
+    this.props.commonActions.getCustomerList(this.state.contactType).then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled'))
+        this.getCurrency(action.payload.contactId);
+    });
+    this.props.commonActions.getExciseList();
+    this.props.debitNotesActions.getCountryList();
+    this.props.commonActions.getProductList();
+  };
+  initializeData = () => {
+    this.props.commonActions.getTaxTreatmentList();
+    if (this.props.location.state && this.props.location.state.id) {
+      this.props.debitNotesActions
+        .getDebitNoteById(
+          this.props.location.state.id,
+          this.props.location.state.isCNWithoutProduct
+            ? this.props.location.state.isCNWithoutProduct
+            : false
+        )
+        .then(res => {
+          if (res.status === 200) {
+            this.setState(
+              {
+                taxType: res.data.taxType ? res.data.taxType : false,
+                isCreatedWithoutInvoice: res.data.invoiceId ? false : true,
+                debitNoteId: this.props.location.state.id,
+                isReverseChargeEnabled: res.data.isReverseChargeEnabled,
+                initValue: {
+                  invoiceNumber: res.data.invoiceId
+                    ? { value: res.data.invoiceId, label: res.data.invoiceNumber }
+                    : '',
+                  receiptAttachmentDescription: res.data.receiptAttachmentDescription
+                    ? res.data.receiptAttachmentDescription
+                    : '',
+                  referenceNumber: res.data.referenceNo ? res.data.referenceNo : '',
+                  contact_po_number: res.data.contactPoNumber ? res.data.contactPoNumber : '',
+                  currency: res.data.currencyCode ? res.data.currencyCode : '',
+                  exchangeRate: res.data.exchangeRate ? res.data.exchangeRate : '',
+                  currencyName: res.data.currencyName ? res.data.currencyName : '',
+                  invoiceDate: res.data.creditNoteDate ? new Date(res.data.creditNoteDate) : '',
+                  contactId: res.data.contactId ? res.data.contactId : '',
+                  debitNoteNumber: res.data.creditNoteNumber ? res.data.creditNoteNumber : '',
 
-									totalAmount: res.data.totalAmount ? res.data.totalAmount : 0,
-									debitAmount: res.data.totalAmount ? res.data.totalAmount : 0,
-									notes: res.data.notes ? res.data.notes : '',
-									lineItemsString: res.data.invoiceLineItems
-										? res.data.invoiceLineItems
-										: [],
-									discount: res.data.discount ? res.data.discount : 0,
-									discountPercentage: res.data.discountPercentage
-										? res.data.discountPercentage
-										: '',
-									discountType: res.data.discountType
-										? res.data.discountType
-										: '',
+                  totalAmount: res.data.totalAmount ? res.data.totalAmount : 0,
+                  debitAmount: res.data.totalAmount ? res.data.totalAmount : 0,
+                  notes: res.data.notes ? res.data.notes : '',
+                  lineItemsString: res.data.invoiceLineItems ? res.data.invoiceLineItems : [],
+                  discount: res.data.discount ? res.data.discount : 0,
+                  discountPercentage: res.data.discountPercentage
+                    ? res.data.discountPercentage
+                    : '',
+                  discountType: res.data.discountType ? res.data.discountType : '',
 
-									fileName: res.data.fileName ? res.data.fileName : '',
-									// filePath: res.data.filePath ? res.data.filePath : '',
-									total_excise: res.data.totalExciseTaxAmount ? res.data.totalExciseTaxAmount : 0,
-								},
-								isDNWIWithoutProduct: res.data.invoiceLineItems ? false : true,
-								discountPercentage: res.data.discountPercentage
-									? res.data.discountPercentage
-									: '',
-								data: res.data.invoiceLineItems
-									? res.data.invoiceLineItems
-									: [],
-								invoiceSelected: res.data.invoiceId ? true : false,
-								remainingInvoiceAmount: res.data.remainingInvoiceAmount,
-								loading: false,
-							},
-							() => {
-								const { data } = this.state;
+                  fileName: res.data.fileName ? res.data.fileName : '',
+                  // filePath: res.data.filePath ? res.data.filePath : '',
+                  total_excise: res.data.totalExciseTaxAmount ? res.data.totalExciseTaxAmount : 0,
+                },
+                isDNWIWithoutProduct: res.data.invoiceLineItems ? false : true,
+                discountPercentage: res.data.discountPercentage ? res.data.discountPercentage : '',
+                data: res.data.invoiceLineItems ? res.data.invoiceLineItems : [],
+                invoiceSelected: res.data.invoiceId ? true : false,
+                remainingInvoiceAmount: res.data.remainingInvoiceAmount,
+                loading: false,
+              },
+              () => {
+                const { data } = this.state;
 
-								if (data.length > 0) {
-									this.updateAmount(data);
-									const idCount =
-										data.length > 0
-											? Math.max.apply(
-												Math,
-												data.map((item) => {
-													return item.id;
-												}),
-											)
-											: 0;
-									this.setState({
-										idCount,
-									});
-									this.formRef.current.setFieldValue(
-										'lineItemsString',
-										data,
-										true,
-									);
-									this.formRef.current.setFieldTouched(
-										`lineItemsString[${data.length - 1}]`,
-										false,
-										true,
-									);
-								} else {
-									this.setState({
-										idCount: 0,
-									});
-								}
-							},
-						);
-						this.getCurrency(res.data.contactId ? res.data.contactId : '')
-						this.formRef.current.setFieldValue('taxTreatmentId', res.data.taxTreatment ? res.data.taxTreatment : '', true);
-						this.formRef.current.setFieldValue('contactId', res.data.contactId ? res.data.contactId : '', true);
-						this.formRef.current.setFieldValue('remainingInvoiceAmount', res.data.remainingInvoiceAmount, true);
-						this.formRef.current.setFieldValue('currency', res.data.currencyCode ? res.data.currencyCode : '', true);
-						this.formRef.current.setFieldValue('invoiceNumber', res.data.invoiceId ? res.data.invoiceId : '', true);
-						this.getInvoiceDetails(this.state.initValue.invoiceNumber.value)
-						this.purchaseCategory();
+                if (data.length > 0) {
+                  this.updateAmount(data);
+                  const idCount =
+                    data.length > 0
+                      ? Math.max.apply(
+                          Math,
+                          data.map(item => {
+                            return item.id;
+                          })
+                        )
+                      : 0;
+                  this.setState({
+                    idCount,
+                  });
+                  this.formRef.current.setFieldValue('lineItemsString', data, true);
+                  this.formRef.current.setFieldTouched(
+                    `lineItemsString[${data.length - 1}]`,
+                    false,
+                    true
+                  );
+                } else {
+                  this.setState({
+                    idCount: 0,
+                  });
+                }
+              }
+            );
+            this.getCurrency(res.data.contactId ? res.data.contactId : '');
+            this.formRef.current.setFieldValue(
+              'taxTreatmentId',
+              res.data.taxTreatment ? res.data.taxTreatment : '',
+              true
+            );
+            this.formRef.current.setFieldValue(
+              'contactId',
+              res.data.contactId ? res.data.contactId : '',
+              true
+            );
+            this.formRef.current.setFieldValue(
+              'remainingInvoiceAmount',
+              res.data.remainingInvoiceAmount,
+              true
+            );
+            this.formRef.current.setFieldValue(
+              'currency',
+              res.data.currencyCode ? res.data.currencyCode : '',
+              true
+            );
+            this.formRef.current.setFieldValue(
+              'invoiceNumber',
+              res.data.invoiceId ? res.data.invoiceId : '',
+              true
+            );
+            this.getInvoiceDetails(this.state.initValue.invoiceNumber.value);
+            this.purchaseCategory();
+          }
+        });
+    } else {
+      this.props.history.push('/admin/expense/debit-notes');
+    }
+  };
 
-					}
-				});
-		} else {
-			this.props.history.push('/admin/expense/debit-notes');
-		}
-	};
+  purchaseCategory = () => {
+    try {
+      this.props.ProductActions.getTransactionCategoryListForPurchaseProduct('10').then(res => {
+        if (res.status === 200) {
+          this.setState(
+            {
+              purchaseCategory: res.data,
+              purchaseCategoryOptions: renderList.getTransactionCategoryList(res.data),
+            },
+            () => {
+              console.log(this.state.purchaseCategory);
+            }
+          );
+        }
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  };
 
-	purchaseCategory = () => {
-		try {
-			this.props.ProductActions.getTransactionCategoryListForPurchaseProduct(
-				'10',
-			).then((res) => {
-				if (res.status === 200) {
-					this.setState(
-						{
-							purchaseCategory: res.data,
-							purchaseCategoryOptions: renderList.getTransactionCategoryList(res.data),
-						},
-						() => {
-							console.log(this.state.purchaseCategory);
-						},
-					);
-				}
-			});
-		} catch (err) {
-			console.log(err);
-		}
-	};
+  renderExcise = (cell, row, props) => {
+    const { excise_list } = this.props;
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-	renderExcise = (cell, row, props) => {
-		const { excise_list } = this.props;
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+    return (
+      <Field
+        name={`lineItemsString.${idx}.exciseTaxId`}
+        render={({ field, form }) => (
+          <Select
+            styles={customStyles}
+            isDisabled
+            options={
+              excise_list
+                ? selectOptionsFactory.renderOptions('name', 'id', excise_list, 'Excise')
+                : []
+            }
+            value={
+              row.exciseTaxId
+                ? excise_list &&
+                  selectOptionsFactory
+                    .renderOptions('name', 'id', excise_list, 'Excise')
+                    .find(option => option.value === +row.exciseTaxId)
+                : ''
+            }
+            id="exciseTaxId"
+            placeholder={strings.Select + strings.Excises}
+            onChange={e => {
+              this.selectItem(e.value, row, 'exciseTaxId', form, field, props);
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.exciseTaxId`}
-				render={({ field, form }) => (
-					<Select
-						styles={customStyles}
-						isDisabled
-						options={
-							excise_list
-								? selectOptionsFactory.renderOptions(
-									'name',
-									'id',
-									excise_list,
-									'Excise',
-								)
-								: []
-						}
-						value={row.exciseTaxId ? excise_list &&
-							selectOptionsFactory
-								.renderOptions('name', 'id', excise_list, 'Excise')
-								.find((option) => option.value === +row.exciseTaxId)
-							: ''
-						}
-						id="exciseTaxId"
-						placeholder={strings.Select + strings.Excises}
-						onChange={(e) => {
+              this.updateAmount(this.state.data, props);
+            }}
+            className={`${
+              props.errors.lineItemsString &&
+              props.errors.lineItemsString[parseInt(idx, 10)] &&
+              props.errors.lineItemsString[parseInt(idx, 10)].exciseTaxId &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.lineItemsString &&
+              props.touched.lineItemsString[parseInt(idx, 10)] &&
+              props.touched.lineItemsString[parseInt(idx, 10)].exciseTaxId
+                ? 'is-invalid'
+                : ''
+            }`}
+          />
+        )}
+      />
+    );
+  };
 
-							this.selectItem(
-								e.value,
-								row,
-								'exciseTaxId',
-								form,
-								field,
-								props,
-							);
+  renderQuantity = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-							this.updateAmount(
-								this.state.data,
-								props,
-							);
-						}}
-						className={`${props.errors.lineItemsString &&
-							props.errors.lineItemsString[parseInt(idx, 10)] &&
-							props.errors.lineItemsString[parseInt(idx, 10)].exciseTaxId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.lineItemsString &&
-							props.touched.lineItemsString[parseInt(idx, 10)] &&
-							props.touched.lineItemsString[parseInt(idx, 10)].exciseTaxId
-							? 'is-invalid'
-							: ''
-							}`}
-					/>
-				)}
-			/>
-		);
-	};
+    return (
+      <Field
+        name={`lineItemsString.${idx}.quantity`}
+        render={({ field, form }) => (
+          <div>
+            <Input
+              type="text"
+              min="0"
+              maxLength="10"
+              value={row['quantity'] !== 0 ? row['quantity'] : 0}
+              onChange={e => {
+                if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                  this.selectItem(e.target.value, row, 'quantity', form, field, props);
+                }
+              }}
+              placeholder={strings.Quantity}
+              className={`form-control 
+           						${
+                        props.errors.lineItemsString &&
+                        props.errors.lineItemsString[parseInt(idx, 10)] &&
+                        props.errors.lineItemsString[parseInt(idx, 10)].quantity &&
+                        Object.keys(props.touched).length > 0 &&
+                        props.touched.lineItemsString &&
+                        props.touched.lineItemsString[parseInt(idx, 10)] &&
+                        props.touched.lineItemsString[parseInt(idx, 10)].quantity
+                          ? 'is-invalid'
+                          : ''
+                      }`}
+            />
+            {props.errors.lineItemsString &&
+              props.errors.lineItemsString[parseInt(idx, 10)] &&
+              props.errors.lineItemsString[parseInt(idx, 10)].quantity &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.lineItemsString &&
+              props.touched.lineItemsString[parseInt(idx, 10)] &&
+              props.touched.lineItemsString[parseInt(idx, 10)].quantity && (
+                <div className="invalid-feedback">
+                  {props.errors.lineItemsString[parseInt(idx, 10)].quantity}
+                </div>
+              )}
+          </div>
+        )}
+      />
+    );
+  };
 
-	renderQuantity = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderUnitPrice = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.quantity`}
-				render={({ field, form }) => (
-					<div>
-						<Input
-							type="text"
-							min="0"
-							maxLength="10"
-							value={row['quantity'] !== 0 ? row['quantity'] : 0}
-							onChange={(e) => {
-								if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
-									this.selectItem(
-										e.target.value,
-										row,
-										'quantity',
-										form,
-										field,
-										props,
-									);
-								}
-							}}
-							placeholder={strings.Quantity}
-							className={`form-control 
-           						${props.errors.lineItemsString &&
-									props.errors.lineItemsString[parseInt(idx, 10)] &&
-									props.errors.lineItemsString[parseInt(idx, 10)]
-										.quantity &&
-									Object.keys(props.touched).length > 0 &&
-									props.touched.lineItemsString &&
-									props.touched.lineItemsString[parseInt(idx, 10)] &&
-									props.touched.lineItemsString[parseInt(idx, 10)]
-										.quantity
-									? 'is-invalid'
-									: ''
-								}`}
-						/>
-						{props.errors.lineItemsString &&
-							props.errors.lineItemsString[parseInt(idx, 10)] &&
-							props.errors.lineItemsString[parseInt(idx, 10)].quantity &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.lineItemsString &&
-							props.touched.lineItemsString[parseInt(idx, 10)] &&
-							props.touched.lineItemsString[parseInt(idx, 10)].quantity && (
-								<div className="invalid-feedback">
-									{props.errors.lineItemsString[parseInt(idx, 10)].quantity}
-								</div>
-							)}
-					</div>
-				)}
-			/>
-		);
-	};
+    return (
+      <Field
+        name={`lineItemsString.${idx}.unitPrice`}
+        render={({ field, form }) => (
+          <Input
+            type="text"
+            disabled
+            value={row['unitPrice'] !== 0 ? row['unitPrice'] : 0}
+            onChange={e => {
+              if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                this.selectItem(e.target.value, row, 'unitPrice', form, field, props);
+              }
+            }}
+            placeholder={strings.UnitPrice}
+            className={`form-control 
+                       ${
+                         props.errors.lineItemsString &&
+                         props.errors.lineItemsString[parseInt(idx, 10)] &&
+                         props.errors.lineItemsString[parseInt(idx, 10)].unitPrice &&
+                         Object.keys(props.touched).length > 0 &&
+                         props.touched.lineItemsString &&
+                         props.touched.lineItemsString[parseInt(idx, 10)] &&
+                         props.touched.lineItemsString[parseInt(idx, 10)].unitPrice
+                           ? 'is-invalid'
+                           : ''
+                       }`}
+          />
+        )}
+      />
+    );
+  };
 
-	renderUnitPrice = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderSubTotal = (cell, row, extraData) => {
+    return row.subTotal === 0
+      ? this.state.customer_currency_symbol +
+          ' ' +
+          row.subTotal.toLocaleString(navigator.language, { minimumFractionDigits: 2 })
+      : this.state.customer_currency_symbol +
+          ' ' +
+          row.subTotal.toLocaleString(navigator.language, { minimumFractionDigits: 2 });
+  };
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.unitPrice`}
-				render={({ field, form }) => (
-					<Input
-						type="text"
-						disabled
-						value={row['unitPrice'] !== 0 ? row['unitPrice'] : 0}
-						onChange={(e) => {
-							if (
-								e.target.value === '' ||
-								this.regDecimal.test(e.target.value)
-							) {
-								this.selectItem(
-									e.target.value,
-									row,
-									'unitPrice',
-									form,
-									field,
-									props,
-								);
-							}
-						}}
-						placeholder={strings.UnitPrice}
-						className={`form-control 
-                       ${props.errors.lineItemsString &&
-								props.errors.lineItemsString[parseInt(idx, 10)] &&
-								props.errors.lineItemsString[parseInt(idx, 10)]
-									.unitPrice &&
-								Object.keys(props.touched).length > 0 &&
-								props.touched.lineItemsString &&
-								props.touched.lineItemsString[parseInt(idx, 10)] &&
-								props.touched.lineItemsString[parseInt(idx, 10)]
-									.unitPrice
-								? 'is-invalid'
-								: ''
-							}`}
-					/>
-				)}
-			/>
-		);
-	};
+  renderVatAmount = (cell, row, extraData) => {
+    return row.vatAmount === 0
+      ? this.state.customer_currency_symbol +
+          ' ' +
+          row.vatAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 })
+      : this.state.customer_currency_symbol +
+          ' ' +
+          row.vatAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 });
+  };
+  selectItem = (e, row, name, form, field, props) => {
+    //e.preventDefault();
+    let data = this.state.data;
+    let idx;
+    data.map((obj, index) => {
+      if (obj.id === row.id) {
+        obj[`${name}`] = e;
+        idx = index;
+      }
+      return obj;
+    });
+    if (name === 'unitPrice' || name === 'vatCategoryId' || name === 'quantity') {
+      form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
+      this.updateAmount(data, props);
+    } else {
+      this.setState({ data }, () => {
+        form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
+      });
+    }
+  };
 
-	renderSubTotal = (cell, row, extraData) => {
-		return row.subTotal === 0 ? this.state.customer_currency_symbol + " " + row.subTotal.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) : this.state.customer_currency_symbol + " " + row.subTotal.toLocaleString(navigator.language, { minimumFractionDigits: 2 });
-	};
+  renderVat = (cell, row, props) => {
+    const { vat_list } = this.props;
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-	renderVatAmount = (cell, row, extraData) => {
-		return row.vatAmount === 0 ? this.state.customer_currency_symbol + " " + row.vatAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) : this.state.customer_currency_symbol + " " + row.vatAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 });
-	};
-	selectItem = (e, row, name, form, field, props) => {
-		//e.preventDefault();
-		let data = this.state.data;
-		let idx;
-		data.map((obj, index) => {
-			if (obj.id === row.id) {
-				obj[`${name}`] = e;
-				idx = index;
-			}
-			return obj;
-		});
-		if (
-			name === 'unitPrice' ||
-			name === 'vatCategoryId' ||
-			name === 'quantity'
-		) {
-			form.setFieldValue(
-				field.name,
-				this.state.data[parseInt(idx, 10)][`${name}`],
-				true,
-			);
-			this.updateAmount(data, props);
-		} else {
-			this.setState({ data }, () => {
-				form.setFieldValue(
-					field.name,
-					this.state.data[parseInt(idx, 10)][`${name}`],
-					true,
-				);
-			});
-		}
-	};
+    return (
+      <Field
+        name={`lineItemsString.${idx}.vatCategoryId`}
+        render={({ field, form }) => (
+          <Select
+            isDisabled
+            styles={customStyles}
+            options={
+              vat_list ? selectOptionsFactory.renderOptions('name', 'id', vat_list, 'Vat') : []
+            }
+            value={
+              vat_list &&
+              selectOptionsFactory
+                .renderOptions('name', 'id', vat_list, 'Vat')
+                .find(option => option.value === +row.vatCategoryId)
+            }
+            id="vatCategoryId"
+            placeholder={strings.Select + strings.Vat}
+            onChange={e => {
+              this.selectItem(e.value, row, 'vatCategoryId', form, field, props);
+            }}
+            className={`${
+              props.errors.lineItemsString &&
+              props.errors.lineItemsString[parseInt(idx, 10)] &&
+              props.errors.lineItemsString[parseInt(idx, 10)].vatCategoryId &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.lineItemsString &&
+              props.touched.lineItemsString[parseInt(idx, 10)] &&
+              props.touched.lineItemsString[parseInt(idx, 10)].vatCategoryId
+                ? 'is-invalid'
+                : ''
+            }`}
+          />
+        )}
+      />
+    );
+  };
 
-	renderVat = (cell, row, props) => {
-		const { vat_list } = this.props;
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderDiscount = (cell, row, props) => {
+    const { discountOptions } = this.state;
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.vatCategoryId`}
-				render={({ field, form }) => (
-					<Select
-						isDisabled
-						styles={customStyles}
-						options={
-							vat_list
-								? selectOptionsFactory.renderOptions(
-									'name',
-									'id',
-									vat_list,
-									'Vat',
-								)
-								: []
-						}
-						value={
-							vat_list &&
-							selectOptionsFactory
-								.renderOptions('name', 'id', vat_list, 'Vat')
-								.find((option) => option.value === +row.vatCategoryId)
-						}
-						id="vatCategoryId"
-						placeholder={strings.Select + strings.Vat}
-						onChange={(e) => {
-							this.selectItem(
-								e.value,
-								row,
-								'vatCategoryId',
-								form,
-								field,
-								props,
-							);
-						}}
-						className={`${props.errors.lineItemsString &&
-							props.errors.lineItemsString[parseInt(idx, 10)] &&
-							props.errors.lineItemsString[parseInt(idx, 10)].vatCategoryId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.lineItemsString &&
-							props.touched.lineItemsString[parseInt(idx, 10)] &&
-							props.touched.lineItemsString[parseInt(idx, 10)].vatCategoryId
-							? 'is-invalid'
-							: ''
-							}`}
-					/>
-				)}
-			/>
-		);
-	};
+    return (
+      <Field
+        name={`lineItemsString.${idx}.discountType`}
+        render={({ field, form }) => (
+          <div>
+            <div className="input-group">
+              <Input
+                disabled
+                type="text"
+                min="0"
+                maxLength="14,2"
+                value={row['discount'] !== 0 ? row['discount'] : 0}
+                onChange={e => {
+                  if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                    this.selectItem(e.target.value, row, 'discount', form, field, props);
+                  }
 
-	renderDiscount = (cell, row, props) => {
-		const { discountOptions } = this.state;
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+                  this.updateAmount(this.state.data, props);
+                }}
+                placeholder={strings.discount}
+                className={`form-control 
+		   								${
+                        props.errors.lineItemsString &&
+                        props.errors.lineItemsString[parseInt(idx, 10)] &&
+                        props.errors.lineItemsString[parseInt(idx, 10)].discount &&
+                        Object.keys(props.touched).length > 0 &&
+                        props.touched.lineItemsString &&
+                        props.touched.lineItemsString[parseInt(idx, 10)] &&
+                        props.touched.lineItemsString[parseInt(idx, 10)].discount
+                          ? 'is-invalid'
+                          : ''
+                      }`}
+              />
+              <div className="dropdown open input-group-append">
+                <div style={{ width: '100%' }}>
+                  <Select
+                    isDisabled
+                    options={discountOptions}
+                    id="discountType"
+                    name="discountType"
+                    value={
+                      discountOptions &&
+                      discountOptions.find(option => option.value == row.discountType)
+                    }
+                    onChange={e => {
+                      this.selectItem(e.value, row, 'discountType', form, field, props);
+                      this.updateAmount(this.state.data, props);
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      />
+    );
+  };
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.discountType`}
-				render={({ field, form }) => (
-					<div>
-						<div className="input-group">
-							<Input
-								disabled
-								type="text"
-								min="0"
-								maxLength="14,2"
-								value={row['discount'] !== 0 ? row['discount'] : 0}
-								onChange={(e) => {
-									if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
-										this.selectItem(
-											e.target.value,
-											row,
-											'discount',
-											form,
-											field,
-											props,
-										);
-									}
+  discountType = row => {
+    return (
+      this.state.discountOptions &&
+      selectOptionsFactory
+        .renderOptions('label', 'value', this.state.discountOptions, 'discount')
+        .find(option => option.value === +row.discountType)
+    );
+  };
 
-									this.updateAmount(
-										this.state.data,
-										props,
-									);
+  prductValue = (e, row, name, form, field, props) => {
+    const { product_list } = this.props;
+    let data = this.state.data;
+    const result = product_list.find(item => item.id === parseInt(e));
+    let idx;
+    data.map((obj, index) => {
+      if (obj.id === row.id) {
+        obj['unitPrice'] = parseInt(result.unitPrice);
+        // obj['vatCategoryId'] = result.vatCategoryId;
+        obj['description'] = result.description;
+        // obj['exciseTaxId'] = result.exciseTaxId;
+        // obj['isExciseTaxExclusive'] = result.isExciseTaxExclusive;
+        idx = index;
+      }
+      return obj;
+    });
+    // form.setFieldValue(
+    // 	`lineItemsString.${idx}.vatCategoryId`,
+    // 	result.vatCategoryId,
+    // 	true,
+    // );
+    form.setFieldValue(`lineItemsString.${idx}.unitPrice`, result.unitPrice, true);
+    form.setFieldValue(`lineItemsString.${idx}.description`, result.description, true);
+    // form.setFieldValue(
+    // 	`lineItemsString.${idx}.exciseTaxId`,
+    // 	result.exciseTaxId,
+    // 	true,
+    // );
+    this.updateAmount(data, props);
+  };
+  renderProduct = (cell, row, props) => {
+    const { product_list } = this.props;
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-								}}
-								placeholder={strings.discount}
-								className={`form-control 
-		   								${props.errors.lineItemsString &&
-										props.errors.lineItemsString[parseInt(idx, 10)] &&
-										props.errors.lineItemsString[parseInt(idx, 10)].discount &&
-										Object.keys(props.touched).length > 0 &&
-										props.touched.lineItemsString &&
-										props.touched.lineItemsString[parseInt(idx, 10)] &&
-										props.touched.lineItemsString[parseInt(idx, 10)].discount
-										? 'is-invalid'
-										: ''
-									}`}
-							/>
-							<div className="dropdown open input-group-append">
-								<div style={{ width: '100%' }}>
-									<Select
-										isDisabled
-										options={discountOptions}
-										id="discountType"
-										name="discountType"
-										value={
-											discountOptions &&
-											discountOptions.find((option) => option.value == row.discountType)
-										}
-										onChange={(e) => {
-											this.selectItem(
-												e.value,
-												row,
-												'discountType',
-												form,
-												field,
-												props,
-											);
-											this.updateAmount(
-												this.state.data,
-												props,
-											);
-										}}
-									/>
-								</div>
-							</div>
-						</div>
-					</div>
+    return (
+      <Field
+        name={`lineItemsString.${idx}.productId`}
+        render={({ field, form }) => (
+          <>
+            <Select
+              styles={customStyles}
+              isDisabled
+              options={
+                product_list
+                  ? selectOptionsFactory.renderOptions('name', 'id', product_list, 'Product')
+                  : []
+              }
+              value={
+                product_list &&
+                selectOptionsFactory
+                  .renderOptions('name', 'id', product_list, 'Product')
+                  .find(option => option.value === +row.productId)
+              }
+              id="productId"
+              onChange={e => {
+                if (e && e.label !== 'Select Product') {
+                  this.selectItem(e.value, row, 'productId', form, field, props);
+                  this.prductValue(e.value, row, 'productId', form, field, props);
+                }
+              }}
+              className={`${
+                props.errors.lineItemsString &&
+                props.errors.lineItemsString[parseInt(idx, 10)] &&
+                props.errors.lineItemsString[parseInt(idx, 10)].productId &&
+                Object.keys(props.touched).length > 0 &&
+                props.touched.lineItemsString &&
+                props.touched.lineItemsString[parseInt(idx, 10)] &&
+                props.touched.lineItemsString[parseInt(idx, 10)].productId
+                  ? 'is-invalid'
+                  : ''
+              }`}
+            />
+            <div className="mt-1">
+              <TextField
+                disabled
+                type="textarea"
+                inputProps={{ maxLength: 2000 }}
+                multiline
+                minRows={1}
+                maxRows={4}
+                value={row['description'] ? row['description'] : ''}
+                onChange={e => {
+                  this.selectItem(e.target.value, row, 'description', form, field);
+                }}
+                placeholder={strings.Description}
+                className={`textarea ${
+                  props.errors.lineItemsString &&
+                  props.errors.lineItemsString[parseInt(idx, 10)] &&
+                  props.errors.lineItemsString[parseInt(idx, 10)].description &&
+                  Object.keys(props.touched).length > 0 &&
+                  props.touched.lineItemsString &&
+                  props.touched.lineItemsString[parseInt(idx, 10)] &&
+                  props.touched.lineItemsString[parseInt(idx, 10)].description
+                    ? 'is-invalid'
+                    : ''
+                }`}
+              />
+            </div>
+          </>
+        )}
+      />
+    );
+  };
 
-				)}
+  renderAccount = (cell, row, props) => {
+    const { purchaseCategory, purchaseCategoryOptions } = this.state;
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-			/>
-		);
-	}
+    return (
+      <Field
+        name={`lineItemsString.${idx}.transactionCategoryId`}
+        render={({ field, form }) => (
+          <Select
+            styles={{
+              menu: provided => ({ ...provided, zIndex: 9999 }),
+            }}
+            options={purchaseCategory ? purchaseCategory : []}
+            id="transactionCategoryId"
+            onChange={e => {
+              this.selectItem(e.value, row, 'transactionCategoryId', form, field, props);
+            }}
+            isDisabled={true}
+            value={
+              purchaseCategoryOptions
+                ? purchaseCategoryOptions.find(obj => obj.value === row.transactionCategoryId)
+                : ''
+            }
+            placeholder={strings.Select + strings.Account}
+            className={`${
+              props.errors.lineItemsString &&
+              props.errors.lineItemsString[parseInt(idx, 10)] &&
+              props.errors.lineItemsString[parseInt(idx, 10)].transactionCategoryId &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.lineItemsString &&
+              props.touched.lineItemsString[parseInt(idx, 10)] &&
+              props.touched.lineItemsString[parseInt(idx, 10)].transactionCategoryId
+                ? 'is-invalid'
+                : ''
+            }`}
+          />
+        )}
+      />
+    );
+  };
 
-	discountType = (row) => {
-		return this.state.discountOptions &&
-			selectOptionsFactory
-				.renderOptions('label', 'value', this.state.discountOptions, 'discount')
-				.find((option) => option.value === +row.discountType)
-	}
+  deleteRow = (e, row, props) => {
+    const id = row['id'];
+    let newData = [];
+    e.preventDefault();
+    const data = this.state.data;
+    newData = data.filter(obj => obj.id !== id);
+    props.setFieldValue('lineItemsString', newData, true);
+    this.updateAmount(newData, props);
+  };
 
-	prductValue = (e, row, name, form, field, props) => {
-		const { product_list } = this.props;
-		let data = this.state.data;
-		const result = product_list.find((item) => item.id === parseInt(e));
-		let idx;
-		data.map((obj, index) => {
-			if (obj.id === row.id) {
-				obj['unitPrice'] = parseInt(result.unitPrice);
-				// obj['vatCategoryId'] = result.vatCategoryId;
-				obj['description'] = result.description;
-				// obj['exciseTaxId'] = result.exciseTaxId;
-				// obj['isExciseTaxExclusive'] = result.isExciseTaxExclusive;
-				idx = index;
-			}
-			return obj;
-		});
-		// form.setFieldValue(
-		// 	`lineItemsString.${idx}.vatCategoryId`,
-		// 	result.vatCategoryId,
-		// 	true,
-		// );
-		form.setFieldValue(
-			`lineItemsString.${idx}.unitPrice`,
-			result.unitPrice,
-			true,
-		);
-		form.setFieldValue(
-			`lineItemsString.${idx}.description`,
-			result.description,
-			true,
-		);
-		// form.setFieldValue(
-		// 	`lineItemsString.${idx}.exciseTaxId`,
-		// 	result.exciseTaxId,
-		// 	true,
-		// );
-		this.updateAmount(data, props);
-	};
-	renderProduct = (cell, row, props) => {
-		const { product_list } = this.props;
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderActions = (cell, rows, props) => {
+    return (
+      <Button
+        size="sm"
+        className="btn-twitter btn-brand icon"
+        disabled={this.state.data.length === 1 ? true : false}
+        onClick={e => {
+          this.deleteRow(e, rows, props);
+        }}
+      >
+        <i className="fas fa-trash"></i>
+      </Button>
+    );
+  };
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.productId`}
-				render={({ field, form }) => (
-					<>
-						<Select
-							styles={customStyles}
-							isDisabled
-							options={
-								product_list
-									? selectOptionsFactory.renderOptions(
-										'name',
-										'id',
-										product_list,
-										'Product',
-									)
-									: []
-							}
-							value={
-								product_list &&
-								selectOptionsFactory
-									.renderOptions('name', 'id', product_list, 'Product')
-									.find((option) => option.value === +row.productId)
-							}
-							id="productId"
-							onChange={(e) => {
-								if (e && e.label !== 'Select Product') {
-									this.selectItem(e.value, row, 'productId', form, field, props);
-									this.prductValue(e.value, row, 'productId', form, field, props);
-								}
-							}}
-							className={`${props.errors.lineItemsString &&
-								props.errors.lineItemsString[parseInt(idx, 10)] &&
-								props.errors.lineItemsString[parseInt(idx, 10)].productId &&
-								Object.keys(props.touched).length > 0 &&
-								props.touched.lineItemsString &&
-								props.touched.lineItemsString[parseInt(idx, 10)] &&
-								props.touched.lineItemsString[parseInt(idx, 10)].productId
-								? 'is-invalid'
-								: ''
-								}`}
-						/>
-						<div className='mt-1'>
-							<TextField
-								disabled
-								type="textarea"
-								inputProps={{ maxLength: 2000 }}
-								multiline
-								minRows={1}
-								maxRows={4}
-								value={row['description'] ? row['description'] : ''}
-								onChange={(e) => {
-									this.selectItem(e.target.value, row, 'description', form, field);
-								}}
-								placeholder={strings.Description}
-								className={`textarea ${props.errors.lineItemsString &&
-									props.errors.lineItemsString[parseInt(idx, 10)] &&
-									props.errors.lineItemsString[parseInt(idx, 10)].description &&
-									Object.keys(props.touched).length > 0 &&
-									props.touched.lineItemsString &&
-									props.touched.lineItemsString[parseInt(idx, 10)] &&
-									props.touched.lineItemsString[parseInt(idx, 10)].description
-									? 'is-invalid'
-									: ''
-									}`}
-							/>
-						</div>
-					</>
-				)}
-			/>
-		);
-	};
+  updateAmount = (data, props) => {
+    const { vat_list } = this.props;
+    const { taxType } = this.state;
+    const list = ProductTableCalculation.updateAmount(data ? data : [], vat_list, taxType);
+    this.setState({
+      data: list.data,
+      initValue: {
+        ...this.state.initValue,
+        ...{
+          totalNet: list.totalNet ? list.totalNet : 0,
+          totalVatAmount: list.totalVatAmount ? list.totalVatAmount : 0,
+          totalAmount: list.totalAmount ? list.totalAmount : 0,
+          total_excise: list.total_excise ? list.total_excise : 0,
+          totalDiscount: list.discount ? list.discount : 0,
+        },
+      },
+    });
+  };
 
-	renderAccount = (cell, row, props) => {
-		const { purchaseCategory, purchaseCategoryOptions } = this.state;
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  handleFileChange = (e, props) => {
+    e.preventDefault();
+    let reader = new FileReader();
+    let file = e.target.files[0];
+    if (file) {
+      reader.onloadend = () => {};
+      reader.readAsDataURL(file);
+      props.setFieldValue('attachmentFile', file, true);
+    }
+  };
 
-		return (
-			<Field
-				name={`lineItemsString.${idx}.transactionCategoryId`}
-				render={({ field, form }) => (
-					<Select
-						styles={{
-							menu: (provided) => ({ ...provided, zIndex: 9999 }),
-						}}
-						options={purchaseCategory ? purchaseCategory : []}
-						id="transactionCategoryId"
-						onChange={(e) => {
-							this.selectItem(
-								e.value,
-								row,
-								'transactionCategoryId',
-								form,
-								field,
-								props,
-							);
-						}}
-						isDisabled={true}
-						value={purchaseCategoryOptions ? purchaseCategoryOptions.find((obj) => obj.value === row.transactionCategoryId) : ''}
-						placeholder={strings.Select + strings.Account}
-						className={`${props.errors.lineItemsString &&
-							props.errors.lineItemsString[parseInt(idx, 10)] &&
-							props.errors.lineItemsString[parseInt(idx, 10)]
-								.transactionCategoryId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.lineItemsString &&
-							props.touched.lineItemsString[parseInt(idx, 10)] &&
-							props.touched.lineItemsString[parseInt(idx, 10)]
-								.transactionCategoryId
-							? 'is-invalid'
-							: ''
-							}`}
-					/>
-				)}
-			/>
-		);
-	};
+  handleSubmit = data => {
+    this.setState({ disabled: true, disableLeavePage: true });
+    const { debitNoteId } = this.state;
+    const {
+      debitNoteNumber,
+      email,
+      invoiceDate,
+      referenceNumber,
+      contact_po_number,
+      receiptAttachmentDescription,
+      notes,
+      debitAmount,
+      invoiceNumber,
+      currency,
+      contactId,
+      exchangeRate,
+    } = data;
 
-	deleteRow = (e, row, props) => {
-		const id = row['id'];
-		let newData = [];
-		e.preventDefault();
-		const data = this.state.data;
-		newData = data.filter((obj) => obj.id !== id);
-		props.setFieldValue('lineItemsString', newData, true);
-		this.updateAmount(newData, props);
-	};
+    let formData = new FormData();
+    formData.append('creditNoteId', debitNoteId);
+    formData.append('isCreatedWithoutInvoice', this.state.isCreatedWithoutInvoice);
+    formData.append('isCreatedWIWP', this.state.isDNWIWithoutProduct);
+    formData.append('creditNoteNumber', debitNoteNumber ? debitNoteNumber : '');
+    formData.append('email', email ? email : '');
+    formData.append('creditNoteDate', invoiceDate ? dayjs(invoiceDate) : new Date());
+    formData.append('referenceNo', referenceNumber !== null ? referenceNumber : '');
+    formData.append('exchangeRate', exchangeRate ? exchangeRate : 1);
+    formData.append('contactPoNumber', contact_po_number !== null ? contact_po_number : '');
+    formData.append(
+      'receiptAttachmentDescription',
+      receiptAttachmentDescription !== null ? receiptAttachmentDescription : ''
+    );
+    formData.append('notes', notes !== null ? notes : '');
+    formData.append('type', 13);
+    if (this.state.isDNWIWithoutProduct === true) formData.append('totalAmount', debitAmount);
 
-	renderActions = (cell, rows, props) => {
-		return (
-			<Button
-				size="sm"
-				className="btn-twitter btn-brand icon"
-				disabled={this.state.data.length === 1 ? true : false}
-				onClick={(e) => {
-					this.deleteRow(e, rows, props);
-				}}
-			>
-				<i className="fas fa-trash"></i>
-			</Button>
-		);
-	};
+    formData.append('vatCategoryId', 2);
+    formData.append('taxType', this.state.taxType ? this.state.taxType : false);
 
-	updateAmount = (data, props) => {
-		const { vat_list } = this.props;
-		const { taxType } = this.state;
-		const list = ProductTableCalculation.updateAmount(data ? data : [], vat_list, taxType);
-		this.setState(
-			{
-				data: list.data,
-				initValue: {
-					...this.state.initValue,
-					...{
-						totalNet: list.totalNet ? list.totalNet : 0,
-						totalVatAmount: list.totalVatAmount ? list.totalVatAmount : 0,
-						totalAmount: list.totalAmount ? list.totalAmount : 0,
-						total_excise: list.total_excise ? list.total_excise : 0,
-						totalDiscount: list.discount ? list.discount : 0,
-					},
+    if (invoiceNumber) {
+      formData.append('invoiceId', invoiceNumber.value ? invoiceNumber.value : invoiceNumber);
+      formData.append('cnCreatedOnPaidInvoice', '1');
+    }
+    if (!this.state.isDNWIWithoutProduct) {
+      formData.append('lineItemsString', JSON.stringify(this.state.data));
+      formData.append('totalVatAmount', this.state.initValue.totalVatAmount);
+      formData.append('totalAmount', this.state.initValue.totalAmount);
+      formData.append('discount', this.state.initValue.totalDiscount);
+      formData.append('totalExciseTaxAmount', this.state.initValue.total_excise);
+      formData.append('isReverseChargeEnabled', this.state.isReverseChargeEnabled);
+    }
+    if (contactId) {
+      formData.append('contactId', contactId.value ? contactId.value : contactId);
+    }
+    if (currency) {
+      formData.append('currency', currency.value ? currency.value : currency);
+    }
+    if (this.uploadFile && this.uploadFile.files && this.uploadFile?.files?.[0]) {
+      formData.append('attachmentFile', this.uploadFile?.files?.[0]);
+    }
+    this.setState({ loading: true, loadingMsg: 'Updating Credit Note...' });
+    this.props.debitNotesDetailActions
+      .updateDebitNote(formData)
+      .then(res => {
+        this.setState({ disabled: false, loading: false });
+        this.props.commonActions.tostifyAlert('success', strings.DebitNoteUpdatedSuccessfully);
+        this.props.history.push('/admin/expense/debit-notes');
+      })
+      .catch(err => {
+        this.props.commonActions.tostifyAlert('error', strings.DebitNoteUpdatedUnsuccessfully);
+        this.setState({ disabled: false, loading: false, disableLeavePage: false });
+        this.initializeData();
+      });
+  };
 
-				},
-			},
+  deleteDebitNote = () => {
+    const message1 = (
+      <text>
+        <b>Delete Debit Note?</b>
+      </text>
+    );
+    const message = 'This Debit Note  will be deleted permanently and cannot be recovered. ';
+    this.setState({
+      dialog: (
+        <ConfirmDeleteModal
+          isOpen={true}
+          okHandler={this.removeDebitNote}
+          cancelHandler={this.removeDialog}
+          message={message}
+          message1={message1}
+        />
+      ),
+    });
+  };
 
-		);
+  removeDebitNote = () => {
+    this.setState({ disabled1: true, disableLeavePage: true });
+    const { debitNoteId } = this.state;
+    this.props.debitNotesDetailActions
+      .deleteDebitNote(debitNoteId)
+      .then(res => {
+        if (res.status === 200) {
+          this.props.commonActions.tostifyAlert('success', strings.DebitNoteDeletedSuccessfully);
+          this.props.history.push('/admin/expense/debit-notes');
+        }
+      })
+      .catch(err => {
+        this.setState({ disabled1: false, disableLeavePage: false });
+        this.props.commonActions.tostifyAlert('error', strings.DebitNoteDeletedUnsuccessfully);
+      });
+  };
 
-	};
+  removeDialog = () => {
+    this.setState({
+      dialog: null,
+    });
+  };
 
-	handleFileChange = (e, props) => {
-		e.preventDefault();
-		let reader = new FileReader();
-		let file = e.target.files[0];
-		if (file) {
-			reader.onloadend = () => { };
-			reader.readAsDataURL(file);
-			props.setFieldValue('attachmentFile', file, true);
-		}
-	};
+  getCurrency = opt => {
+    let currency;
+    this.props.customer_list.map(item => {
+      if (item.label.contactId == opt) {
+        currency = item.label.currency.currencyCode;
+        this.formRef.current.setFieldValue('currency', currency, true);
+        this.formRef.current.setFieldValue(
+          'customer_currency_symbol',
+          item.label.currency.currencyIsoCode,
+          true
+        );
+        this.setState({ customer_currency_symbol: item.label.currency.currencyIsoCode });
+      }
+    });
+    return currency;
+  };
+  getTaxTreatment = opt => {
+    this.props.customer_list.map(item => {
+      if (item.label.contactId == opt) {
+        this.formRef.current.setFieldValue(
+          'taxTreatmentId',
+          item.label.taxTreatment.taxTreatment,
+          true
+        );
+      }
+    });
+  };
+  getInvoiceDetails = value => {
+    if (value) {
+      this.props.debitNotesActions.getInvoiceById(value).then(response => {
+        if ((response.status = 200)) {
+          const custmerName = {
+            label:
+              response.data.organisationName === ''
+                ? response.data.name
+                : response.data.organisationName,
+            value: response.data.contactId,
+          };
+          this.setState(
+            {
+              receiptDate: response.data.receiptDate
+                ? new Date(dayjs(response.data.receiptDate, 'YYYY-MM-DD').format())
+                : new Date(),
+              option: custmerName,
+              isReverseChargeEnabled: response.data.isReverseChargeEnabled,
+              data: response.data.invoiceLineItems ? response.data.invoiceLineItems : [],
+              taxType: response.data.taxType ? response.data.taxType : false,
+              totalAmount: response.data.totalAmount,
+              remainingInvoiceAmount: response.data.remainingInvoiceAmount,
+              shippingCharges: response.data.shippingCharges ? response.data.shippingCharges : 0,
+              customer_currency_symbol: response.data.currencyIsoCode
+                ? response.data.currencyIsoCode
+                : '',
+              initValue: {
+                ...this.state.initValue,
+                ...{
+                  currency: response.data.currencyCode ? response.data.currencyCode : '',
+                  lineItemsString: response.data.invoiceLineItems
+                    ? response.data.invoiceLineItems
+                    : [],
+                  totalAmount: response.data.totalAmount,
+                  totalDiscount: response.data.discount,
+                  taxTreatmentId: response.data.taxTreatment ? response.data.taxTreatment : '',
+                  exchangeRate: response.data.exchangeRate ? response.data.exchangeRate : 1,
+                },
+              },
+            },
+            () => {
+              this.formRef.current.setFieldValue('lineItemsString', this.state.data, true);
+              this.formRef.current.setFieldTouched(
+                `lineItemsString[${this.state.data.length - 1}]`,
+                false,
+                true
+              );
+            }
+          );
+          this.updateAmount(this.state.data);
+          this.formRef.current.setFieldValue('contactId', custmerName, true);
+          this.formRef.current.setFieldValue(
+            'remainingInvoiceAmount',
+            this.state.remainingInvoiceAmount,
+            true
+          );
+          this.formRef.current.setFieldValue('currency', this.state.customer_currency, true);
+          this.formRef.current.setFieldValue(
+            'taxTreatmentId',
+            response.data.taxTreatment ? response.data.taxTreatment : '',
+            true
+          );
+          this.formRef.current.setFieldValue(
+            'exchangeRate',
+            response.data.exchangeRate ? response.data.exchangeRate : '',
+            true
+          );
+          this.formRef.current.setFieldValue(
+            'currency',
+            response.data.currencyCode ? response.data.currencyCode : '',
+            true
+          );
+          this.getTaxTreatment(custmerName.value);
+          this.getCurrency(custmerName.value);
+        }
+      });
+    }
+  };
+  render() {
+    strings.setLanguage(this.state.language);
+    const {
+      data,
+      loadingMsg,
+      initValue,
+      loading,
+      dialog,
+      isCreatedWithoutInvoice,
+      isReverseChargeEnabled,
+    } = this.state;
 
-	handleSubmit = (data) => {
-		this.setState({ disabled: true, disableLeavePage: true });
-		const { debitNoteId } = this.state;
-		const {
-			debitNoteNumber,
-			email,
-			invoiceDate,
-			referenceNumber,
-			contact_po_number,
-			receiptAttachmentDescription,
-			notes,
-			debitAmount,
-			invoiceNumber,
-			currency,
-			contactId,
-			exchangeRate,
-		} = data;
+    const {
+      tax_treatment_list,
+      invoice_list,
+      currency_convert_list,
+      customer_list,
+      universal_currency_list,
+      company_details,
+    } = this.props;
+    let tmpCustomer_list = [];
+    const { isRegisteredVat, isDesignatedZone } = company_details;
 
-		let formData = new FormData();
-		formData.append('creditNoteId', debitNoteId);
-		formData.append('isCreatedWithoutInvoice', this.state.isCreatedWithoutInvoice);
-		formData.append('isCreatedWIWP', this.state.isDNWIWithoutProduct);
-		formData.append('creditNoteNumber', debitNoteNumber ? debitNoteNumber : '',);
-		formData.append('email', email ? email : '',);
-		formData.append('creditNoteDate', invoiceDate ? dayjs(invoiceDate) : new Date());
-		formData.append('referenceNo', referenceNumber !== null ? referenceNumber : '',);
-		formData.append('exchangeRate', exchangeRate ? exchangeRate : 1);
-		formData.append('contactPoNumber', contact_po_number !== null ? contact_po_number : '',);
-		formData.append('receiptAttachmentDescription', receiptAttachmentDescription !== null ? receiptAttachmentDescription : '',);
-		formData.append('notes', notes !== null ? notes : '');
-		formData.append('type', 13);
-		if (this.state.isDNWIWithoutProduct === true)
-			formData.append('totalAmount', debitAmount);
+    customer_list.map(item => {
+      let obj = { label: item.label.contactName, value: item.value };
+      tmpCustomer_list.push(obj);
+    });
 
-		formData.append('vatCategoryId', 2);
-		formData.append('taxType', this.state.taxType ? this.state.taxType : false);
+    return loading == true ? (
+      <Loader loadingMsg={loadingMsg} />
+    ) : (
+      <div>
+        <div className="detail-customer-invoice-screen">
+          <div className="animated fadeIn">
+            <Row>
+              <Col lg={12} className="mx-auto">
+                <Card>
+                  <CardHeader>
+                    <Row>
+                      <Col lg={12}>
+                        <div className="h4 mb-0 d-flex align-items-center">
+                          <i className="fa fa-credit-card" />
+                          <span className="ml-2">Update Debit Note</span>
+                        </div>
+                      </Col>
+                    </Row>
+                  </CardHeader>
+                  <CardBody>
+                    {dialog}
+                    {loading ? (
+                      <Loader />
+                    ) : (
+                      <Row>
+                        <Col lg={12}>
+                          <Formik
+                            initialValues={this.state.initValue}
+                            ref={this.formRef}
+                            onSubmit={(values, { resetForm }) => {
+                              this.handleSubmit(values);
+                            }}
+                            validate={values => {
+                              let errors = {};
 
-		if (invoiceNumber) {
-			formData.append('invoiceId', invoiceNumber.value ? invoiceNumber.value : invoiceNumber);
-			formData.append('cnCreatedOnPaidInvoice', '1');
-		}
-		if (!this.state.isDNWIWithoutProduct) {
-			formData.append('lineItemsString', JSON.stringify(this.state.data));
-			formData.append('totalVatAmount', this.state.initValue.totalVatAmount);
-			formData.append('totalAmount', this.state.initValue.totalAmount);
-			formData.append('discount', this.state.initValue.totalDiscount);
-			formData.append('totalExciseTaxAmount', this.state.initValue.total_excise);
-			formData.append('isReverseChargeEnabled', this.state.isReverseChargeEnabled);
-		}
-		if (contactId) {
-			formData.append('contactId', contactId.value ? contactId.value : contactId);
-		}
-		if (currency) {
-			formData.append('currency', currency.value ? currency.value : currency);
-		}
-		if (this.uploadFile && this.uploadFile.files && this.uploadFile?.files?.[0]) {
-			formData.append('attachmentFile', this.uploadFile?.files?.[0]);
-		}
-		this.setState({ loading: true, loadingMsg: "Updating Credit Note..." });
-		this.props.debitNotesDetailActions
-			.updateDebitNote(formData)
-			.then((res) => {
-				this.setState({ disabled: false, loading: false });
-				this.props.commonActions.tostifyAlert('success', strings.DebitNoteUpdatedSuccessfully);
-				this.props.history.push('/admin/expense/debit-notes');
-			})
-			.catch((err) => {
-				this.props.commonActions.tostifyAlert('error', strings.DebitNoteUpdatedUnsuccessfully);
-				this.setState({ disabled: false, loading: false, disableLeavePage: false });
-				this.initializeData();
-			});
-	};
+                              if (!isCreatedWithoutInvoice && !values.invoiceNumber) {
+                                errors.invoiceNumber = 'Invoice number is Required';
+                              }
 
-	deleteDebitNote = () => {
-		const message1 =
-			<text>
-				<b>Delete Debit Note?</b>
-			</text>
-		const message = 'This Debit Note  will be deleted permanently and cannot be recovered. ';
-		this.setState({
-			dialog: (
-				<ConfirmDeleteModal
-					isOpen={true}
-					okHandler={this.removeDebitNote}
-					cancelHandler={this.removeDialog}
-					message={message}
-					message1={message1}
-				/>
-			),
-		});
-	};
+                              if (isCreatedWithoutInvoice == true && !values.debitAmount)
+                                errors.debitAmount = 'Credit Amount is Required';
 
-	removeDebitNote = () => {
-		this.setState({ disabled1: true, disableLeavePage: true });
-		const { debitNoteId } = this.state;
-		this.props.debitNotesDetailActions
-			.deleteDebitNote(debitNoteId)
-			.then((res) => {
-				if (res.status === 200) {
-					this.props.commonActions.tostifyAlert('success', strings.DebitNoteDeletedSuccessfully);
-					this.props.history.push('/admin/expense/debit-notes');
-				}
-			})
-			.catch((err) => {
-				this.setState({ disabled1: false, disableLeavePage: false });
-				this.props.commonActions.tostifyAlert('error', strings.DebitNoteDeletedUnsuccessfully);
-			});
-	};
+                              if (
+                                this.state.invoiceSelected &&
+                                parseFloat(initValue.totalAmount) >
+                                  parseFloat(this.state.remainingInvoiceAmount)
+                              ) {
+                                errors.totalAmount =
+                                  'Invoice Total Amount Cannot be greater than  Remaining Invoice Amount';
+                              }
+                              if (
+                                this.state.invoiceSelected &&
+                                this.state.isDNWIWithoutProduct &&
+                                values.debitAmount &&
+                                parseFloat(values.debitAmount) >
+                                  parseFloat(this.state.remainingInvoiceAmount)
+                              ) {
+                                errors.debitAmount =
+                                  strings.AmountCannotBeGreaterThanTheInvoiceamount;
+                              }
+                              return errors;
+                            }}
+                            validationSchema={Yup.object().shape({
+                              debitNoteNumber: Yup.string().required(
+                                strings.Debit_Note_Number_Is_Required
+                              ),
+                              contactId: Yup.string().required('Customer Name is Required'),
+                              invoiceDate: Yup.string().required(strings.invoiceDateIsRequired),
+                              lineItemsString: Yup.array().of(
+                                Yup.object().shape({
+                                  quantity: Yup.string()
+                                    .test('quantity', strings.QuantityGreaterThan0, value => {
+                                      if (value > 0) {
+                                        return true;
+                                      } else {
+                                        return false;
+                                      }
+                                    })
+                                    .required(strings.QuatityIsRequired),
+                                })
+                              ),
+                            })}
+                          >
+                            {props => (
+                              <Form onSubmit={props.handleSubmit}>
+                                {!isCreatedWithoutInvoice && (
+                                  <Row>
+                                    <Col lg={3}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="invoiceNumber">
+                                          <span className="text-danger">* </span>
+                                          {strings.InvoiceNumber}
+                                        </Label>
+                                        <Select
+                                          isDisabled
+                                          id="invoiceNumber"
+                                          name="invoiceNumber"
+                                          placeholder={strings.Select + strings.InvoiceNumber}
+                                          options={
+                                            invoice_list
+                                              ? selectOptionsFactory.renderOptions(
+                                                  'label',
+                                                  'value',
+                                                  invoice_list,
+                                                  'Invoice Number'
+                                                )
+                                              : []
+                                          }
+                                          value={
+                                            props.values.invoiceNumber?.value
+                                              ? props.values.invoiceNumber
+                                              : invoice_list &&
+                                                selectOptionsFactory
+                                                  .renderOptions(
+                                                    'label',
+                                                    'value',
+                                                    invoice_list,
+                                                    'Invoice Number'
+                                                  )
+                                                  .find(
+                                                    obj => obj.value === props.values.invoiceNumber
+                                                  )
+                                          }
+                                          onChange={option => {
+                                            if (option && option.value) {
+                                              this.setState({ invoiceSelected: true }, () => {
+                                                props.handleChange('invoiceNumber')(option);
+                                                props.handleChange('referenceNumber')(option.label);
+                                                this.getInvoiceDetails(option.value);
+                                              });
+                                            } else {
+                                              this.setState({ invoiceSelected: false }, () => {
+                                                props.handleChange('invoiceNumber')('');
+                                                props.handleChange('referenceNumber')('');
+                                              });
+                                            }
+                                          }}
+                                          className={
+                                            props.errors.invoiceNumber &&
+                                            props.touched.invoiceNumber
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                        />
+                                        {props.errors.invoiceNumber &&
+                                          props.touched.invoiceNumber && (
+                                            <div className="invalid-feedback">
+                                              {props.errors.invoiceNumber}
+                                            </div>
+                                          )}
+                                      </FormGroup>
+                                    </Col>
+                                  </Row>
+                                )}
+                                <Row>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="debitNoteNumber">
+                                        <span className="text-danger">* </span>
+                                        {strings.DebitNoteNumber}
+                                      </Label>
+                                      <Input
+                                        disabled
+                                        maxLength="50"
+                                        type="text"
+                                        id="debitNoteNumber"
+                                        name="debitNoteNumber"
+                                        placeholder={strings.DebitNoteNumber}
+                                        value={props.values.debitNoteNumber}
+                                        //onBlur={props.handleBlur('debitNoteNumber')}
+                                        onChange={option => {
+                                          if (option?.target?.value === '')
+                                            props.handleChange('debitNoteNumber')('');
+                                          else if (this.regExDNNum.test(option?.target?.value)) {
+                                            props.handleChange('debitNoteNumber')(
+                                              option?.target?.value
+                                            );
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.debitNoteNumber &&
+                                          props.touched.debitNoteNumber
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.debitNoteNumber &&
+                                        props.touched.debitNoteNumber && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.debitNoteNumber}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="contactId">
+                                        <span className="text-danger">* </span>
+                                        {strings.SupplierName}
+                                      </Label>
+                                      <Select
+                                        id="contactId"
+                                        name="contactId"
+                                        placeholder={strings.Select + strings.SupplierName}
+                                        options={tmpCustomer_list ? tmpCustomer_list : []}
+                                        value={
+                                          props.values.contactId?.values
+                                            ? props.values.contactId
+                                            : tmpCustomer_list &&
+                                              tmpCustomer_list.find(
+                                                obj => obj.value === props.values.contactId
+                                              )
+                                        }
+                                        isDisabled={this.state.invoiceSelected}
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            this.formRef.current.setFieldValue(
+                                              'currency',
+                                              this.getCurrency(option.value),
+                                              true
+                                            );
+                                            this.getTaxTreatment(option.value);
+                                            props.handleChange('contactId')(option);
+                                          } else {
+                                            props.handleChange('contactId')('');
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.contactId && props.touched.contactId
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.contactId && props.touched.contactId && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.contactId}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  {isRegisteredVat && (
+                                    <Col lg={3}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="taxTreatmentId">
+                                          {strings.TaxTreatment}
+                                        </Label>
+                                        <Select
+                                          options={
+                                            tax_treatment_list
+                                              ? selectOptionsFactory.renderOptions(
+                                                  'name',
+                                                  'id',
+                                                  tax_treatment_list,
+                                                  'Tax Treatment'
+                                                )
+                                              : []
+                                          }
+                                          isDisabled={true}
+                                          id="taxTreatmentId"
+                                          name="taxTreatmentId"
+                                          placeholder={strings.Select + strings.TaxTreatment}
+                                          value={
+                                            props.values.taxTreatmentId?.value
+                                              ? props.values.taxTreatmentId
+                                              : tax_treatment_list &&
+                                                selectOptionsFactory
+                                                  .renderOptions(
+                                                    'name',
+                                                    'id',
+                                                    tax_treatment_list,
+                                                    'Tax Treatment'
+                                                  )
+                                                  .find(
+                                                    option =>
+                                                      option.label === props.values.taxTreatmentId
+                                                  )
+                                          }
+                                          onChange={option => {
+                                            props.handleChange('taxTreatmentId')(option);
+                                          }}
+                                          className={
+                                            props.errors.taxTreatmentId &&
+                                            props.touched.taxTreatmentId
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                        />
+                                        {props.errors.taxTreatmentId &&
+                                          props.touched.taxTreatmentId && (
+                                            <div className="invalid-feedback">
+                                              {props.errors.taxTreatmentId}
+                                            </div>
+                                          )}
+                                      </FormGroup>
+                                    </Col>
+                                  )}
+                                </Row>
+                                <Row>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="invoiceDate">
+                                        <span className="text-danger">* </span>
+                                        Debit Note Date
+                                      </Label>
+                                      <DatePicker
+                                        id="invoiceDate"
+                                        name="invoiceDate"
+                                        placeholderText={
+                                          strings.Enter + strings.DebitNote + strings.Date
+                                        }
+                                        showMonthDropdown
+                                        showYearDropdown
+                                        dateFormat="dd-MM-yyyy"
+                                        dropdownMode="select"
+                                        // value={dayjs(props.values.invoiceDate).format('DD-MM-YYYY')}
+                                        minDate={this.state.receiptDate}
+                                        selected={props.values.invoiceDate}
+                                        onChange={value => {
+                                          props.handleChange('invoiceDate')(value);
+                                        }}
+                                        className={`form-control ${
+                                          props.errors.invoiceDate && props.touched.invoiceDate
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
+                                      />
+                                      {props.errors.invoiceDate && props.touched.invoiceDate && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.invoiceDate.includes('nullable()')
+                                            ? strings.Debit_Note_Date_Is_Required
+                                            : props.errors.invoiceDate}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
 
-	removeDialog = () => {
-		this.setState({
-			dialog: null,
-		});
-	};
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="currency">
+                                        <span className="text-danger">* </span>
+                                        {strings.Currency}
+                                      </Label>
+                                      <Select
+                                        isDisabled={true}
+                                        styles={customStyles}
+                                        placeholder={strings.Select + strings.Currency}
+                                        options={
+                                          currency_convert_list
+                                            ? selectCurrencyFactory.renderOptions(
+                                                'currencyName',
+                                                'currencyCode',
+                                                currency_convert_list,
+                                                'Currency'
+                                              )
+                                            : []
+                                        }
+                                        id="currency"
+                                        name="currency"
+                                        value={
+                                          props.values.currency?.value
+                                            ? props.values.currency
+                                            : currency_convert_list &&
+                                              selectCurrencyFactory
+                                                .renderOptions(
+                                                  'currencyName',
+                                                  'currencyCode',
+                                                  currency_convert_list,
+                                                  'Currency'
+                                                )
+                                                .find(
+                                                  option => option.value === props.values.currency
+                                                )
+                                        }
+                                        className={
+                                          props.errors.currency && props.touched.currency
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                        onChange={option => {
+                                          props.handleChange('currency')(option);
+                                        }}
+                                      />
+                                      {props.errors.currency && props.touched.currency && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.currency}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  {this.state.invoiceSelected && (
+                                    <Col lg={3}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="remainingInvoiceAmount">
+                                          Remaining Invoice Amount
+                                        </Label>
+                                        <Input
+                                          type="text"
+                                          id="remainingInvoiceAmount"
+                                          name="remainingInvoiceAmount"
+                                          placeholder="Remaining invoice Amount"
+                                          disabled={true}
+                                          value={this.state.remainingInvoiceAmount}
+                                        />
+                                        {props.errors.remainingInvoiceAmount && (
+                                          <div className="text-danger">
+                                            {props.errors.remainingInvoiceAmount}
+                                          </div>
+                                        )}
+                                      </FormGroup>
+                                    </Col>
+                                  )}
 
-	getCurrency = (opt) => {
-		let currency;
-		this.props.customer_list.map(item => {
-			if (item.label.contactId == opt) {
-				currency = item.label.currency.currencyCode;
-				this.formRef.current.setFieldValue('currency', currency, true,);
-				this.formRef.current.setFieldValue('customer_currency_symbol', item.label.currency.currencyIsoCode, true,);
-				this.setState({ customer_currency_symbol: item.label.currency.currencyIsoCode })
-			}
-		})
-		return currency;
-	}
-	getTaxTreatment = (opt) => {
-		this.props.customer_list.map(item => {
-			if (item.label.contactId == opt) {
-				this.formRef.current.setFieldValue('taxTreatmentId', item.label.taxTreatment.taxTreatment, true);
-			}
-		});
-	}
-	getInvoiceDetails = (value) => {
-		if (value) {
-			this.props.debitNotesActions
-				.getInvoiceById(value).then((response) => {
-					if (response.status = 200) {
-						const custmerName = {
-							label: response.data.organisationName === '' ? response.data.name : response.data.organisationName,
-							value: response.data.contactId,
-						}
-						this.setState({
-							receiptDate: response.data.receiptDate ? new Date(dayjs(response.data.receiptDate, 'YYYY-MM-DD').format()) : new Date(),
-							option: custmerName,
-							isReverseChargeEnabled: response.data.isReverseChargeEnabled,
-							data: response.data.invoiceLineItems ? response.data.invoiceLineItems : [],
-							taxType: response.data.taxType ? response.data.taxType : false,
-							totalAmount: response.data.totalAmount,
-							remainingInvoiceAmount: response.data.remainingInvoiceAmount,
-							shippingCharges: response.data.shippingCharges ? response.data.shippingCharges : 0,
-							customer_currency_symbol: response.data.currencyIsoCode ? response.data.currencyIsoCode : '',
-							initValue: {
-								...this.state.initValue,
-								...{
-									currency: response.data.currencyCode ? response.data.currencyCode : '',
-									lineItemsString: response.data.invoiceLineItems ? response.data.invoiceLineItems : [],
-									totalAmount: response.data.totalAmount,
-									totalDiscount: response.data.discount,
-									taxTreatmentId: response.data.taxTreatment ? response.data.taxTreatment : '',
-									exchangeRate: response.data.exchangeRate ? response.data.exchangeRate : 1,
-								},
-							},
-
-						}, () => {
-							this.formRef.current.setFieldValue(
-								'lineItemsString',
-								this.state.data,
-								true,
-							);
-							this.formRef.current.setFieldTouched(
-								`lineItemsString[${this.state.data.length - 1}]`,
-								false,
-								true,
-							);
-						},);
-						this.updateAmount(this.state.data)
-						this.formRef.current.setFieldValue('contactId', custmerName, true);
-						this.formRef.current.setFieldValue('remainingInvoiceAmount', this.state.remainingInvoiceAmount, true);
-						this.formRef.current.setFieldValue('currency', this.state.customer_currency, true);
-						this.formRef.current.setFieldValue('taxTreatmentId', response.data.taxTreatment ? response.data.taxTreatment : '', true);
-						this.formRef.current.setFieldValue('exchangeRate', response.data.exchangeRate ? response.data.exchangeRate : '', true);
-						this.formRef.current.setFieldValue('currency', response.data.currencyCode ? response.data.currencyCode : '', true);
-						this.getTaxTreatment(custmerName.value)
-						this.getCurrency(custmerName.value)
-					}
-				});
-		}
-	}
-	render() {
-		strings.setLanguage(this.state.language);
-		const { data, loadingMsg, initValue, loading, dialog, isCreatedWithoutInvoice, isReverseChargeEnabled } = this.state;
-
-		const { tax_treatment_list, invoice_list, currency_convert_list, customer_list, universal_currency_list, company_details } = this.props;
-		let tmpCustomer_list = []
-		const { isRegisteredVat, isDesignatedZone } = company_details;
-
-		customer_list.map(item => {
-			let obj = { label: item.label.contactName, value: item.value }
-			tmpCustomer_list.push(obj)
-		})
-
-		return (
-			loading == true ? <Loader loadingMsg={loadingMsg} /> : <div>
-				<div className="detail-customer-invoice-screen">
-					<div className="animated fadeIn">
-						<Row>
-							<Col lg={12} className="mx-auto">
-								<Card>
-									<CardHeader>
-										<Row>
-											<Col lg={12}>
-												<div className="h4 mb-0 d-flex align-items-center">
-													<i className="fa fa-credit-card" />
-													<span className="ml-2">Update Debit Note</span>
-												</div>
-											</Col>
-										</Row>
-									</CardHeader>
-									<CardBody>
-										{dialog}
-										{loading ? (
-											<Loader />
-										) : (
-											<Row>
-												<Col lg={12}>
-													<Formik
-														initialValues={this.state.initValue}
-														ref={this.formRef}
-														onSubmit={(values, { resetForm }) => {
-															this.handleSubmit(values);
-														}}
-														validate={(values) => {
-															let errors = {};
-
-															if (!isCreatedWithoutInvoice && !values.invoiceNumber) {
-																errors.invoiceNumber = 'Invoice number is Required';
-															}
-
-															if (isCreatedWithoutInvoice == true && !values.debitAmount)
-																errors.debitAmount = 'Credit Amount is Required';
-
-															if (this.state.invoiceSelected && (parseFloat(initValue.totalAmount) > parseFloat(this.state.remainingInvoiceAmount))) {
-																errors.totalAmount = 'Invoice Total Amount Cannot be greater than  Remaining Invoice Amount';
-															}
-															if (this.state.invoiceSelected && this.state.isDNWIWithoutProduct && values.debitAmount && parseFloat(values.debitAmount) > parseFloat(this.state.remainingInvoiceAmount)) {
-																errors.debitAmount = strings.AmountCannotBeGreaterThanTheInvoiceamount;
-															}
-															return errors;
-														}}
-														validationSchema={Yup.object().shape({
-
-															debitNoteNumber: Yup.string().required(strings.Debit_Note_Number_Is_Required,),
-															contactId: Yup.string().required('Customer Name is Required',),
-															invoiceDate: Yup.string().required(strings.invoiceDateIsRequired,),
-															lineItemsString: Yup.array().of(
-																Yup.object().shape({
-																	quantity: Yup.string().test(
-																		'quantity',
-																		strings.QuantityGreaterThan0,
-																		(value) => {
-																			if (value > 0) {
-																				return true;
-																			} else {
-																				return false;
-																			}
-																		},
-																	).required(strings.QuatityIsRequired),
-																}),
-															),
-														})}
-													>
-														{(props) => (
-															<Form onSubmit={props.handleSubmit}>
-																{!isCreatedWithoutInvoice && (<Row>
-																	<Col lg={3}>
-																		<FormGroup className="mb-3">
-																			<Label htmlFor="invoiceNumber"><span className="text-danger">* </span>
-																				{strings.InvoiceNumber}
-																			</Label>
-																			<Select
-																				isDisabled
-																				id="invoiceNumber"
-																				name="invoiceNumber"
-																				placeholder={strings.Select + strings.InvoiceNumber}
-																				options={
-																					invoice_list ? selectOptionsFactory.renderOptions(
-																						'label',
-																						'value',
-																						invoice_list,
-																						'Invoice Number',
-																					) : []
-																				}
-																				value={props.values.invoiceNumber?.value ? props.values.invoiceNumber : invoice_list && selectOptionsFactory.renderOptions(
-																					'label',
-																					'value',
-																					invoice_list,
-																					'Invoice Number',).find(obj => obj.value === props.values.invoiceNumber)
-																				}
-																				onChange={(option) => {
-																					if (option && option.value) {
-																						this.setState({ invoiceSelected: true }, () => {
-																							props.handleChange('invoiceNumber')(option);
-																							props.handleChange('referenceNumber')(option.label);
-																							this.getInvoiceDetails(option.value)
-																						})
-																					} else {
-																						this.setState({ invoiceSelected: false }, () => {
-																							props.handleChange('invoiceNumber')('');
-																							props.handleChange('referenceNumber')('');
-																						})
-																					}
-																				}}
-																				className={
-																					props.errors.invoiceNumber &&
-																						props.touched.invoiceNumber
-																						? 'is-invalid'
-																						: ''
-																				}
-																			/>
-																			{props.errors.invoiceNumber &&
-																				props.touched.invoiceNumber && (
-																					<div className="invalid-feedback">
-																						{props.errors.invoiceNumber}
-																					</div>
-																				)}
-																		</FormGroup>
-																	</Col>
-																</Row>)}
-																<Row>
-																	<Col lg={3}>
-																		<FormGroup className="mb-3">
-																			<Label htmlFor="debitNoteNumber">
-																				<span className="text-danger">* </span>
-																				{strings.DebitNoteNumber}
-																			</Label>
-																			<Input
-																				disabled
-																				maxLength="50"
-																				type="text"
-																				id="debitNoteNumber"
-																				name="debitNoteNumber"
-																				placeholder={strings.DebitNoteNumber}
-																				value={props.values.debitNoteNumber}
-																				//onBlur={props.handleBlur('debitNoteNumber')}
-																				onChange={(option) => {
-																					if (option?.target?.value === '')
-																						props.handleChange('debitNoteNumber')('');
-																					else if (this.regExDNNum.test(option?.target?.value)) {
-																						props.handleChange('debitNoteNumber')(option?.target?.value);
-																					}
-																				}}
-																				className={
-																					props.errors.debitNoteNumber &&
-																						props.touched.debitNoteNumber
-																						? 'is-invalid'
-																						: ''
-																				}
-																			/>
-																			{props.errors.debitNoteNumber &&
-																				props.touched.debitNoteNumber && (
-																					<div className="invalid-feedback">
-																						{props.errors.debitNoteNumber}
-																					</div>
-																				)}
-																		</FormGroup>
-																	</Col>
-																	<Col lg={3}>
-																		<FormGroup className="mb-3">
-																			<Label htmlFor="contactId">
-																				<span className="text-danger">* </span>
-																				{strings.SupplierName}
-																			</Label>
-																			<Select
-																				id="contactId"
-																				name="contactId"
-																				placeholder={strings.Select + strings.SupplierName}
-																				options={tmpCustomer_list ? tmpCustomer_list : []}
-																				value={props.values.contactId?.values ? props.values.contactId : tmpCustomer_list && tmpCustomer_list.find(obj => obj.value === props.values.contactId)}
-
-																				isDisabled={this.state.invoiceSelected}
-																				onChange={(option) => {
-																					if (option && option.value) {
-																						this.formRef.current.setFieldValue('currency', this.getCurrency(option.value), true);
-																						this.getTaxTreatment(option.value);
-																						props.handleChange('contactId')(option);
-																					} else {
-																						props.handleChange('contactId')('');
-																					}
-																				}}
-																				className={
-																					props.errors.contactId &&
-																						props.touched.contactId
-																						? 'is-invalid'
-																						: ''
-																				}
-																			/>
-																			{props.errors.contactId &&
-																				props.touched.contactId && (
-																					<div className="invalid-feedback">
-																						{props.errors.contactId}
-																					</div>
-																				)}
-																		</FormGroup>
-																	</Col>
-																	{isRegisteredVat &&
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="taxTreatmentId">
-																					{strings.TaxTreatment}
-																				</Label>
-																				<Select
-																					options={
-																						tax_treatment_list
-																							? selectOptionsFactory.renderOptions(
-																								'name',
-																								'id',
-																								tax_treatment_list,
-																								'Tax Treatment',
-																							)
-																							: []
-																					}
-																					isDisabled={true}
-																					id="taxTreatmentId"
-																					name="taxTreatmentId"
-																					placeholder={strings.Select + strings.TaxTreatment}
-																					value={props.values.taxTreatmentId?.value ? props.values.taxTreatmentId :
-																						tax_treatment_list &&
-																						selectOptionsFactory
-																							.renderOptions(
-																								'name',
-																								'id',
-																								tax_treatment_list,
-																								'Tax Treatment',
-																							)
-																							.find(
-																								(option) =>
-																									option.label === props.values.taxTreatmentId,
-																							)
-																					}
-																					onChange={(option) => {
-																						props.handleChange('taxTreatmentId')(
-																							option,
-																						);
-																					}}
-																					className={
-																						props.errors.taxTreatmentId &&
-																							props.touched.taxTreatmentId
-																							? 'is-invalid'
-																							: ''
-																					}
-																				/>
-																				{props.errors.taxTreatmentId &&
-																					props.touched.taxTreatmentId && (
-																						<div className="invalid-feedback">
-																							{props.errors.taxTreatmentId}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
-																	}
-																</Row>
-																<Row>
-
-																	<Col lg={3}>
-																		<FormGroup className="mb-3">
-																			<Label htmlFor="invoiceDate">
-																				<span className="text-danger">* </span>
-																				Debit Note Date
-																			</Label>
-																			<DatePicker
-																				id="invoiceDate"
-																				name="invoiceDate"
-																				placeholderText={strings.Enter + strings.DebitNote + strings.Date}
-																				showMonthDropdown
-																				showYearDropdown
-																				dateFormat="dd-MM-yyyy"
-																				dropdownMode="select"
-																				// value={dayjs(props.values.invoiceDate).format('DD-MM-YYYY')}
-																				minDate={this.state.receiptDate}
-																				selected={props.values.invoiceDate}
-																				onChange={(value) => {
-																					props.handleChange('invoiceDate')(value);
-																				}}
-																				className={`form-control ${props.errors.invoiceDate &&
-																					props.touched.invoiceDate
-																					? 'is-invalid'
-																					: ''
-																					}`}
-																			/>
-																			{props.errors.invoiceDate &&
-																				props.touched.invoiceDate && (
-																					<div className="invalid-feedback">
-																						{props.errors.invoiceDate.includes("nullable()") ? strings.Debit_Note_Date_Is_Required : props.errors.invoiceDate}
-																					</div>
-																				)}
-																		</FormGroup>
-																	</Col>
-
-																	<Col lg={3}>
-																		<FormGroup className="mb-3">
-																			<Label htmlFor="currency">
-																				<span className="text-danger">* </span>
-																				{strings.Currency}
-																			</Label>
-																			<Select
-																				isDisabled={true}
-																				styles={customStyles}
-																				placeholder={strings.Select + strings.Currency}
-																				options={
-																					currency_convert_list
-																						? selectCurrencyFactory.renderOptions(
-																							'currencyName',
-																							'currencyCode',
-																							currency_convert_list,
-																							'Currency',
-																						)
-																						: []
-																				}
-																				id="currency"
-																				name="currency"
-																				value={props.values.currency?.value ? props.values.currency :
-																					currency_convert_list && selectCurrencyFactory.renderOptions(
-																						'currencyName',
-																						'currencyCode',
-																						currency_convert_list,
-																						'Currency',
-																					).find((option) => option.value === props.values.currency)
-																				}
-																				className={
-																					props.errors.currency &&
-																						props.touched.currency
-																						? 'is-invalid'
-																						: ''
-																				}
-																				onChange={(option) => {
-																					props.handleChange('currency')(option);
-																				}}
-
-																			/>
-																			{props.errors.currency &&
-																				props.touched.currency && (
-																					<div className="invalid-feedback">
-																						{props.errors.currency}
-																					</div>
-																				)}
-																		</FormGroup>
-																	</Col>
-																	{(this.state.invoiceSelected) && (<Col lg={3}>
-																		<FormGroup className="mb-3">
-																			<Label htmlFor="remainingInvoiceAmount">
-																				Remaining Invoice Amount
-																			</Label>
-																			<Input
-																				type="text"
-																				id="remainingInvoiceAmount"
-																				name="remainingInvoiceAmount"
-																				placeholder='Remaining invoice Amount'
-																				disabled={true}
-																				value={this.state.remainingInvoiceAmount}
-																			/>
-																			{props.errors.remainingInvoiceAmount &&
-																				(
-																					<div className="text-danger">
-																						{props.errors.remainingInvoiceAmount}
-																					</div>
-																				)}
-																		</FormGroup>
-																	</Col>)}
-
-																	{this.state.isDNWIWithoutProduct === true && (
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="debitAmount"><span className="text-danger">* </span>
-																					Debit Amount
-																				</Label>
-																				<Input
-																					type="text"
-																					id="debitAmount"
-																					name="debitAmount"
-																					placeholder={strings.Enter + " Debit Amount"}
-																					value={props.values.debitAmount}
-																					onChange={(value) => {
-																						if ((value.target.value === '' || this.regDecimal.test(value.target.value))
-																							&& parseFloat(value.target.value) !== 0)
-																							props.handleChange('debitAmount')(value,);
-																					}}
-																					className={
-																						props.errors.debitAmount &&
-																							props.touched.debitAmount
-																							? 'is-invalid'
-																							: ''
-																					}
-																				/>
-																				{props.errors.debitAmount &&
-																					props.touched.debitAmount &&
-																					(<div className="invalid-feedback">
-																						{props.errors.debitAmount}
-																					</div>)}
-																			</FormGroup>
-																		</Col>
-																	)}
-
-																</Row>
-																<hr />
-																{!isCreatedWithoutInvoice && !this.state.isDNWIWithoutProduct && (
-																	<Row>
-																		<Col lg={8} className="mb-3">
-																		</Col>
-																		<Col>
-																			{this.state.taxType === false ?
-																				<span style={{ color: "#0069d9" }} className='mr-4'><b>{strings.Exclusive}</b></span> :
-																				<span className='mr-4'>{strings.Exclusive}</span>}
-																			<Switch
-																				value={props.values.taxType}
-																				checked={this.state.taxType}
-																				disabled
-																				onChange={(taxType) => {
-																					props.handleChange('taxType')(taxType);
-																					this.setState({ taxType }, () => {
-																						this.updateAmount(
-																							this.state.data,
-																							props
-																						)
-																					});
-																				}}
-
-																				onColor="#2064d8"
-																				onHandleColor="#2693e6"
-																				handleDiameter={25}
-																				uncheckedIcon={false}
-																				checkedIcon={false}
-																				boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
-																				activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
-																				height={20}
-																				width={48}
-																				className="react-switch "
-																			/>
-																			{this.state.taxType === true ?
-																				<span style={{ color: "#0069d9" }} className='ml-4'><b>{strings.Inclusive}</b></span>
-																				: <span className='ml-4'>{strings.Inclusive}</span>
-																			}
-																		</Col>
-																	</Row>)}
-																{this.state.isDNWIWithoutProduct === false && data && data.length > 0 && (<Row>
-																	{props.errors.lineItemsString &&
-																		typeof props.errors.lineItemsString ===
-																		'string' && (
-																			<div
-																				className={
-																					props.errors.lineItemsString
-																						? 'is-invalid'
-																						: ''
-																				}
-																			>
-																				<div className="invalid-feedback">
-																					{props.errors.lineItemsString}
-																				</div>
-																			</div>
-																		)}
-																	<Col lg={12}>
-																		<BootstrapTable
-																			options={this.options}
-																			data={data}
-																			version="4"
-																			hover
-																			keyField="id"
-																			className="invoice-create-table"
-																		>
-																			<TableHeaderColumn
-																				width="3%"
-																				dataAlign="center"
-																				dataFormat={(cell, rows) =>
-																					this.renderActions(cell, rows, props)
-																				}
-																			></TableHeaderColumn>
-																			<TableHeaderColumn
-																				//width="20%"
-																				dataField="product"
-																				dataFormat={(cell, rows) =>
-																					this.renderProduct(cell, rows, props)
-																				}
-																			>
-																				{strings.PRODUCT}
-																			</TableHeaderColumn>
-																			<TableHeaderColumn
-																				width="11%"
-																				dataField="account"
-																				dataFormat={(cell, rows) =>
-																					this.renderAccount(cell, rows, props)
-																				}
-																			>
-																				{strings.Account}
-																			</TableHeaderColumn>
-																			<TableHeaderColumn
-																				dataField="quantity"
-																				dataFormat={(cell, rows) =>
-																					this.renderQuantity(cell, rows, props)
-																				}
-																			>
-																				{strings.QUANTITY}
-																			</TableHeaderColumn>
-																			<TableHeaderColumn
-																				dataField="unitPrice"
-																				dataFormat={(cell, rows) =>
-																					this.renderUnitPrice(cell, rows, props)
-																				}
-																			>
-																				{strings.UNITPRICE}
-																				<i
-																					id="UnitPriceTooltip"
-																					className="fa fa-question-circle ml-1"
-																				></i>
-																				<UncontrolledTooltip
-																					placement="right"
-																					target="UnitPriceTooltip"
-																				>
-																					Unit Price – Price of a single product or
-																					service
-																				</UncontrolledTooltip>
-																			</TableHeaderColumn>
-																			{initValue.totalDiscount != 0 &&
-																				<TableHeaderColumn
-																					dataField="discount"
-																					dataFormat={(cell, rows) =>
-																						this.renderDiscount(cell, rows, props)
-																					}
-																				>
-																					Discount Type
-																				</TableHeaderColumn>
-																			}
-																			{initValue.total_excise != 0 &&
-																				<TableHeaderColumn
-																					//	width="10%"
-																					dataField="exciseTaxId"
-																					dataFormat={(cell, rows) =>
-																						this.renderExcise(cell, rows, props)
-																					}
-																				>
-																					{strings.Excises}
-																					<i
-																						id="ExiseTooltip"
-																						className="fa fa-question-circle ml-1"
-																					></i>
-																					<UncontrolledTooltip
-																						placement="right"
-																						target="ExiseTooltip"
-																					>
-																						Excise dropdown will be enabled only for the excise products
-																					</UncontrolledTooltip>
-																				</TableHeaderColumn>
-																			}
-																			{isRegisteredVat &&
-																				<TableHeaderColumn
-																			     	// width={ "250px" }
-																					dataField="vat"
-																					dataFormat={(cell, rows) =>
-																						this.renderVat(cell, rows, props)
-																					}
-																				>
-																					{strings.VAT}
-																				</TableHeaderColumn>
-																			}
-																			{isRegisteredVat &&
-																				<TableHeaderColumn
-																					dataField="vat_amount"
-																					dataFormat={this.renderVatAmount}
-																					className="text-right"
-																					columnClassName="text-right"
-																					formatExtraData={universal_currency_list}
-																				>
-																					{strings.VATAMOUNT}
-																				</TableHeaderColumn>
-																			}
-																			<TableHeaderColumn
-																				dataField="sub_total"
-																				dataFormat={this.renderSubTotal}
-																				className="text-right"
-																				columnClassName="text-right"
-																				formatExtraData={universal_currency_list}
-																			>
-																				{strings.SUBTOTAL}
-																			</TableHeaderColumn>
-																		</BootstrapTable>
-																	</Col>
-																</Row>)}
-																{this.state.isDNWIWithoutProduct === false && data && data.length > 0 && isRegisteredVat && <Row>
-																	<Col className="ml-4">
-																		{this.state.isReverseChargeEnabled === true
-																			// && (isDesignatedZone && props.values.taxTreatmentId !== 'UAE NON-VAT REGISTERED' && props.values.taxTreatmentId !== 'UAE NON-VAT REGISTERED FREEZONE' && props.values.taxTreatmentId !== 'UAE VAT REGISTERED' && props.values.taxTreatmentId !== 'UAE VAT REGISTERED FREEZONE')
-																			// || (!isDesignatedZone && props.values.taxTreatmentId !== 'UAE VAT REGISTERED FREEZONE')
-																			? <FormGroup className="mb-3">
-																				<Input
-																					type="checkbox"
-																					id="isReverseChargeEnabled"
-																					checked={this.state.isReverseChargeEnabled}
-																					value={this.state.isReverseChargeEnabled}
-																					onChange={(e) => {
-																						this.setState({
-																							isReverseChargeEnabled: isReverseChargeEnabled,
-																						})
-																					}}
-																				/>
-																				<Label>{strings.IsReverseCharge}</Label>
-																			</FormGroup> : ''}
-																	</Col>
-																</Row>}
-																<Row>
-																	<Col lg={7}>
-																		<Col lg={6}>
-																			{!isCreatedWithoutInvoice && <FormGroup className="mb-3">
-																				<Label htmlFor="referenceNumber">
-																					{strings.ReferenceNumber}
-																				</Label>
-																				<Input
-																					type="text"
-																					maxLength="20"
-																					id="referenceNumber"
-																					name="referenceNumber"
-																					value={props.values.referenceNumber}
-																					placeholder={strings.ReceiptNumber}
-																					onChange={(value) => {
-																						props.handleChange('referenceNumber')(value);
-
-																					}}
-																					className={props.errors.referenceNumber && props.touched.referenceNumber ? "is-invalid" : " "}
-																				/>
-																				{props.errors.referenceNumber && props.touched.referenceNumber && (
-																					<div className="invalid-feedback">{props.errors.referenceNumber}</div>
-																				)}
-																			</FormGroup>}
-																			<FormGroup className="py-2">
-																				<Label htmlFor="notes">
-																					{strings.Notes}
-																				</Label><br />
-																				<TextField
-																					type="textarea"
-																					multiline
-																					style={{ width: "500px" }}
-																					className="textarea"
-																					inputProps={{ maxLength: 255 }}
-																					name="notes"
-																					id="notes"
-																					maxRows={4}
-																					placeholder={strings.DeliveryNotes}
-																					onChange={(option) =>
-																						props.handleChange('notes')(option)
-																					}
-																					value={props.values.notes}
-																				/>
-																			</FormGroup>
-																		</Col>
-																	</Col>
-																	{this.state.isDNWIWithoutProduct === false && (<Col lg={5}>
-																		<div className="">
-																			{initValue.total_excise != 0 && (
-																				<div className="total-item p-2" >
-																					<Row>
-																						<Col lg={6}>
-																							<h5 className="mb-0 text-right">
-																								{strings.TotalExcise}
-																							</h5>
-																						</Col>
-																						<Col lg={6} className="text-right">
-																							<label className="mb-0">
-																								{this.state.customer_currency_symbol} &nbsp;
-																								{initValue.total_excise.toLocaleString(navigator.language, { minimumFractionDigits: 2 })}
-																							</label>
-																						</Col>
-																					</Row>
-																				</div>
-																			)}
-																			{initValue.totalDiscount != 0 && (
-																				<div className="total-item p-2">
-																					<Row>
-																						<Col lg={6}>
-																							<h5 className="mb-0 text-right">
-																								{strings.Discount}
-																							</h5>
-																						</Col>
-																						<Col lg={6} className="text-right">
-																							<label className="mb-0">
-																								{this.state.customer_currency_symbol} &nbsp;
-																								{initValue.totalDiscount ? initValue.totalDiscount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) : '0.00'}
-																							</label>
-																						</Col>
-																					</Row>
-																				</div>
-																			)}
-																			<div className="total-item p-2">
-																				<Row>
-																					<Col lg={6}>
-																						<h5 className="mb-0 text-right">
-																							{strings.TotalNet}
-																						</h5>
-																					</Col>
-																					<Col lg={6} className="text-right">
-																						<label className="mb-0">
-																							{this.state.customer_currency_symbol} &nbsp;
-																							{initValue.totalNet ? initValue.totalNet.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) : '0.00'}
-
-																						</label>
-																					</Col>
-																				</Row>
-																			</div>
-																			{isRegisteredVat &&
-																				<div className="total-item p-2">
-																					<Row>
-																						<Col lg={6}>
-																							<h5 className="mb-0 text-right">
-																								{strings.TotalVat}
-																							</h5>
-																						</Col>
-																						<Col lg={6} className="text-right">
-																							<label className="mb-0">
-																								{this.state.customer_currency_symbol} &nbsp;
-																								{initValue.totalVatAmount ? initValue.totalVatAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) : '0.00'}
-																							</label>
-																						</Col>
-																					</Row>
-																				</div>
-																			}
-																			<div className="total-item p-2">
-																				<Row>
-																					<Col lg={6}>
-																						<h5 className="mb-0 text-right">
-																							{strings.Total}
-																						</h5>
-																					</Col>
-																					<Col lg={6} className="text-right">
-																						<label className="mb-0">
-																							{this.state.customer_currency_symbol} &nbsp;
-																							{initValue.totalAmount ? initValue.totalAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) : '0.00'}
-																						</label>
-																					</Col>
-																					{props.errors.totalAmount &&
-																						props.touched.totalAmount &&
-																						<Col className="invalid-feedback d-block text-right">
-																							{props.errors.totalAmount}
-																						</Col>}
-																				</Row>
-																			</div>
-																		</div>
-																	</Col>)}
-																</Row>
-																<Row>
-																	<Col
-																		lg={12}
-																		className="mt-5 d-flex flex-wrap align-items-center justify-content-between"
-																	>
-																		<FormGroup>
-																			<Button
-																				type="button"
-																				color="danger"
-																				className="btn-square"
-																				disabled1={this.state.disabled1}
-																				onClick={this.deleteDebitNote}
-																			>
-																				<i className="fa fa-trash"></i> {' '} {this.state.disabled1
-																					? 'Deleting...'
-																					: strings.Delete}
-																			</Button>
-																		</FormGroup>
-																		<FormGroup className="text-right">
-																			<Button
-																				type="submit"
-																				color="primary"
-																				className="btn-square mr-3"
-																				disabled={this.state.disabled}
-																				onClick={() => {
-																					//	added validation popup	msg
-																					console.log(props.errors, "ERROR")
-																					props.handleBlur();
-																					if (props.errors && Object.keys(props.errors).length != 0)
-																						this.props.commonActions.fillManDatoryDetails();
-																				}}
-																			>
-																				<i className="fa fa-dot-circle-o"></i> {this.state.disabled
-																					? 'Updating...'
-																					: strings.Update}
-																				{/* { {this.state.disabled }
+                                  {this.state.isDNWIWithoutProduct === true && (
+                                    <Col lg={3}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="debitAmount">
+                                          <span className="text-danger">* </span>
+                                          Debit Amount
+                                        </Label>
+                                        <Input
+                                          type="text"
+                                          id="debitAmount"
+                                          name="debitAmount"
+                                          placeholder={strings.Enter + ' Debit Amount'}
+                                          value={props.values.debitAmount}
+                                          onChange={value => {
+                                            if (
+                                              (value.target.value === '' ||
+                                                this.regDecimal.test(value.target.value)) &&
+                                              parseFloat(value.target.value) !== 0
+                                            )
+                                              props.handleChange('debitAmount')(value);
+                                          }}
+                                          className={
+                                            props.errors.debitAmount && props.touched.debitAmount
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                        />
+                                        {props.errors.debitAmount && props.touched.debitAmount && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.debitAmount}
+                                          </div>
+                                        )}
+                                      </FormGroup>
+                                    </Col>
+                                  )}
+                                </Row>
+                                <hr />
+                                {!isCreatedWithoutInvoice && !this.state.isDNWIWithoutProduct && (
+                                  <Row>
+                                    <Col lg={8} className="mb-3"></Col>
+                                    <Col>
+                                      {this.state.taxType === false ? (
+                                        <span style={{ color: '#0069d9' }} className="mr-4">
+                                          <b>{strings.Exclusive}</b>
+                                        </span>
+                                      ) : (
+                                        <span className="mr-4">{strings.Exclusive}</span>
+                                      )}
+                                      <Switch
+                                        value={props.values.taxType}
+                                        checked={this.state.taxType}
+                                        disabled
+                                        onChange={taxType => {
+                                          props.handleChange('taxType')(taxType);
+                                          this.setState({ taxType }, () => {
+                                            this.updateAmount(this.state.data, props);
+                                          });
+                                        }}
+                                        onColor="#2064d8"
+                                        onHandleColor="#2693e6"
+                                        handleDiameter={25}
+                                        uncheckedIcon={false}
+                                        checkedIcon={false}
+                                        boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+                                        activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+                                        height={20}
+                                        width={48}
+                                        className="react-switch "
+                                      />
+                                      {this.state.taxType === true ? (
+                                        <span style={{ color: '#0069d9' }} className="ml-4">
+                                          <b>{strings.Inclusive}</b>
+                                        </span>
+                                      ) : (
+                                        <span className="ml-4">{strings.Inclusive}</span>
+                                      )}
+                                    </Col>
+                                  </Row>
+                                )}
+                                {this.state.isDNWIWithoutProduct === false &&
+                                  data &&
+                                  data.length > 0 && (
+                                    <Row>
+                                      {props.errors.lineItemsString &&
+                                        typeof props.errors.lineItemsString === 'string' && (
+                                          <div
+                                            className={
+                                              props.errors.lineItemsString ? 'is-invalid' : ''
+                                            }
+                                          >
+                                            <div className="invalid-feedback">
+                                              {props.errors.lineItemsString}
+                                            </div>
+                                          </div>
+                                        )}
+                                      <Col lg={12}>
+                                        <BootstrapTable
+                                          options={this.options}
+                                          data={data}
+                                          version="4"
+                                          hover
+                                          keyField="id"
+                                          className="invoice-create-table"
+                                        >
+                                          <TableHeaderColumn
+                                            width="3%"
+                                            dataAlign="center"
+                                            dataFormat={(cell, rows) =>
+                                              this.renderActions(cell, rows, props)
+                                            }
+                                          ></TableHeaderColumn>
+                                          <TableHeaderColumn
+                                            //width="20%"
+                                            dataField="product"
+                                            dataFormat={(cell, rows) =>
+                                              this.renderProduct(cell, rows, props)
+                                            }
+                                          >
+                                            {strings.PRODUCT}
+                                          </TableHeaderColumn>
+                                          <TableHeaderColumn
+                                            width="11%"
+                                            dataField="account"
+                                            dataFormat={(cell, rows) =>
+                                              this.renderAccount(cell, rows, props)
+                                            }
+                                          >
+                                            {strings.Account}
+                                          </TableHeaderColumn>
+                                          <TableHeaderColumn
+                                            dataField="quantity"
+                                            dataFormat={(cell, rows) =>
+                                              this.renderQuantity(cell, rows, props)
+                                            }
+                                          >
+                                            {strings.QUANTITY}
+                                          </TableHeaderColumn>
+                                          <TableHeaderColumn
+                                            dataField="unitPrice"
+                                            dataFormat={(cell, rows) =>
+                                              this.renderUnitPrice(cell, rows, props)
+                                            }
+                                          >
+                                            {strings.UNITPRICE}
+                                            <i
+                                              id="UnitPriceTooltip"
+                                              className="fa fa-question-circle ml-1"
+                                            ></i>
+                                            <UncontrolledTooltip
+                                              placement="right"
+                                              target="UnitPriceTooltip"
+                                            >
+                                              Unit Price – Price of a single product or service
+                                            </UncontrolledTooltip>
+                                          </TableHeaderColumn>
+                                          {initValue.totalDiscount != 0 && (
+                                            <TableHeaderColumn
+                                              dataField="discount"
+                                              dataFormat={(cell, rows) =>
+                                                this.renderDiscount(cell, rows, props)
+                                              }
+                                            >
+                                              Discount Type
+                                            </TableHeaderColumn>
+                                          )}
+                                          {initValue.total_excise != 0 && (
+                                            <TableHeaderColumn
+                                              //	width="10%"
+                                              dataField="exciseTaxId"
+                                              dataFormat={(cell, rows) =>
+                                                this.renderExcise(cell, rows, props)
+                                              }
+                                            >
+                                              {strings.Excises}
+                                              <i
+                                                id="ExiseTooltip"
+                                                className="fa fa-question-circle ml-1"
+                                              ></i>
+                                              <UncontrolledTooltip
+                                                placement="right"
+                                                target="ExiseTooltip"
+                                              >
+                                                Excise dropdown will be enabled only for the excise
+                                                products
+                                              </UncontrolledTooltip>
+                                            </TableHeaderColumn>
+                                          )}
+                                          {isRegisteredVat && (
+                                            <TableHeaderColumn
+                                              // width={ "250px" }
+                                              dataField="vat"
+                                              dataFormat={(cell, rows) =>
+                                                this.renderVat(cell, rows, props)
+                                              }
+                                            >
+                                              {strings.VAT}
+                                            </TableHeaderColumn>
+                                          )}
+                                          {isRegisteredVat && (
+                                            <TableHeaderColumn
+                                              dataField="vat_amount"
+                                              dataFormat={this.renderVatAmount}
+                                              className="text-right"
+                                              columnClassName="text-right"
+                                              formatExtraData={universal_currency_list}
+                                            >
+                                              {strings.VATAMOUNT}
+                                            </TableHeaderColumn>
+                                          )}
+                                          <TableHeaderColumn
+                                            dataField="sub_total"
+                                            dataFormat={this.renderSubTotal}
+                                            className="text-right"
+                                            columnClassName="text-right"
+                                            formatExtraData={universal_currency_list}
+                                          >
+                                            {strings.SUBTOTAL}
+                                          </TableHeaderColumn>
+                                        </BootstrapTable>
+                                      </Col>
+                                    </Row>
+                                  )}
+                                {this.state.isDNWIWithoutProduct === false &&
+                                  data &&
+                                  data.length > 0 &&
+                                  isRegisteredVat && (
+                                    <Row>
+                                      <Col className="ml-4">
+                                        {this.state.isReverseChargeEnabled === true ? (
+                                          // && (isDesignatedZone && props.values.taxTreatmentId !== 'UAE NON-VAT REGISTERED' && props.values.taxTreatmentId !== 'UAE NON-VAT REGISTERED FREEZONE' && props.values.taxTreatmentId !== 'UAE VAT REGISTERED' && props.values.taxTreatmentId !== 'UAE VAT REGISTERED FREEZONE')
+                                          // || (!isDesignatedZone && props.values.taxTreatmentId !== 'UAE VAT REGISTERED FREEZONE')
+                                          <FormGroup className="mb-3">
+                                            <Input
+                                              type="checkbox"
+                                              id="isReverseChargeEnabled"
+                                              checked={this.state.isReverseChargeEnabled}
+                                              value={this.state.isReverseChargeEnabled}
+                                              onChange={e => {
+                                                this.setState({
+                                                  isReverseChargeEnabled: isReverseChargeEnabled,
+                                                });
+                                              }}
+                                            />
+                                            <Label>{strings.IsReverseCharge}</Label>
+                                          </FormGroup>
+                                        ) : (
+                                          ''
+                                        )}
+                                      </Col>
+                                    </Row>
+                                  )}
+                                <Row>
+                                  <Col lg={7}>
+                                    <Col lg={6}>
+                                      {!isCreatedWithoutInvoice && (
+                                        <FormGroup className="mb-3">
+                                          <Label htmlFor="referenceNumber">
+                                            {strings.ReferenceNumber}
+                                          </Label>
+                                          <Input
+                                            type="text"
+                                            maxLength="20"
+                                            id="referenceNumber"
+                                            name="referenceNumber"
+                                            value={props.values.referenceNumber}
+                                            placeholder={strings.ReceiptNumber}
+                                            onChange={value => {
+                                              props.handleChange('referenceNumber')(value);
+                                            }}
+                                            className={
+                                              props.errors.referenceNumber &&
+                                              props.touched.referenceNumber
+                                                ? 'is-invalid'
+                                                : ' '
+                                            }
+                                          />
+                                          {props.errors.referenceNumber &&
+                                            props.touched.referenceNumber && (
+                                              <div className="invalid-feedback">
+                                                {props.errors.referenceNumber}
+                                              </div>
+                                            )}
+                                        </FormGroup>
+                                      )}
+                                      <FormGroup className="py-2">
+                                        <Label htmlFor="notes">{strings.Notes}</Label>
+                                        <br />
+                                        <TextField
+                                          type="textarea"
+                                          multiline
+                                          style={{ width: '500px' }}
+                                          className="textarea"
+                                          inputProps={{ maxLength: 255 }}
+                                          name="notes"
+                                          id="notes"
+                                          maxRows={4}
+                                          placeholder={strings.DeliveryNotes}
+                                          onChange={option => props.handleChange('notes')(option)}
+                                          value={props.values.notes}
+                                        />
+                                      </FormGroup>
+                                    </Col>
+                                  </Col>
+                                  {this.state.isDNWIWithoutProduct === false && (
+                                    <Col lg={5}>
+                                      <div className="">
+                                        {initValue.total_excise != 0 && (
+                                          <div className="total-item p-2">
+                                            <Row>
+                                              <Col lg={6}>
+                                                <h5 className="mb-0 text-right">
+                                                  {strings.TotalExcise}
+                                                </h5>
+                                              </Col>
+                                              <Col lg={6} className="text-right">
+                                                <label className="mb-0">
+                                                  {this.state.customer_currency_symbol} &nbsp;
+                                                  {initValue.total_excise.toLocaleString(
+                                                    navigator.language,
+                                                    { minimumFractionDigits: 2 }
+                                                  )}
+                                                </label>
+                                              </Col>
+                                            </Row>
+                                          </div>
+                                        )}
+                                        {initValue.totalDiscount != 0 && (
+                                          <div className="total-item p-2">
+                                            <Row>
+                                              <Col lg={6}>
+                                                <h5 className="mb-0 text-right">
+                                                  {strings.Discount}
+                                                </h5>
+                                              </Col>
+                                              <Col lg={6} className="text-right">
+                                                <label className="mb-0">
+                                                  {this.state.customer_currency_symbol} &nbsp;
+                                                  {initValue.totalDiscount
+                                                    ? initValue.totalDiscount.toLocaleString(
+                                                        navigator.language,
+                                                        { minimumFractionDigits: 2 }
+                                                      )
+                                                    : '0.00'}
+                                                </label>
+                                              </Col>
+                                            </Row>
+                                          </div>
+                                        )}
+                                        <div className="total-item p-2">
+                                          <Row>
+                                            <Col lg={6}>
+                                              <h5 className="mb-0 text-right">
+                                                {strings.TotalNet}
+                                              </h5>
+                                            </Col>
+                                            <Col lg={6} className="text-right">
+                                              <label className="mb-0">
+                                                {this.state.customer_currency_symbol} &nbsp;
+                                                {initValue.totalNet
+                                                  ? initValue.totalNet.toLocaleString(
+                                                      navigator.language,
+                                                      { minimumFractionDigits: 2 }
+                                                    )
+                                                  : '0.00'}
+                                              </label>
+                                            </Col>
+                                          </Row>
+                                        </div>
+                                        {isRegisteredVat && (
+                                          <div className="total-item p-2">
+                                            <Row>
+                                              <Col lg={6}>
+                                                <h5 className="mb-0 text-right">
+                                                  {strings.TotalVat}
+                                                </h5>
+                                              </Col>
+                                              <Col lg={6} className="text-right">
+                                                <label className="mb-0">
+                                                  {this.state.customer_currency_symbol} &nbsp;
+                                                  {initValue.totalVatAmount
+                                                    ? initValue.totalVatAmount.toLocaleString(
+                                                        navigator.language,
+                                                        { minimumFractionDigits: 2 }
+                                                      )
+                                                    : '0.00'}
+                                                </label>
+                                              </Col>
+                                            </Row>
+                                          </div>
+                                        )}
+                                        <div className="total-item p-2">
+                                          <Row>
+                                            <Col lg={6}>
+                                              <h5 className="mb-0 text-right">{strings.Total}</h5>
+                                            </Col>
+                                            <Col lg={6} className="text-right">
+                                              <label className="mb-0">
+                                                {this.state.customer_currency_symbol} &nbsp;
+                                                {initValue.totalAmount
+                                                  ? initValue.totalAmount.toLocaleString(
+                                                      navigator.language,
+                                                      { minimumFractionDigits: 2 }
+                                                    )
+                                                  : '0.00'}
+                                              </label>
+                                            </Col>
+                                            {props.errors.totalAmount &&
+                                              props.touched.totalAmount && (
+                                                <Col className="invalid-feedback d-block text-right">
+                                                  {props.errors.totalAmount}
+                                                </Col>
+                                              )}
+                                          </Row>
+                                        </div>
+                                      </div>
+                                    </Col>
+                                  )}
+                                </Row>
+                                <Row>
+                                  <Col
+                                    lg={12}
+                                    className="mt-5 d-flex flex-wrap align-items-center justify-content-between"
+                                  >
+                                    <FormGroup>
+                                      <Button
+                                        type="button"
+                                        color="danger"
+                                        className="btn-square"
+                                        disabled1={this.state.disabled1}
+                                        onClick={this.deleteDebitNote}
+                                      >
+                                        <i className="fa fa-trash"></i>{' '}
+                                        {this.state.disabled1 ? 'Deleting...' : strings.Delete}
+                                      </Button>
+                                    </FormGroup>
+                                    <FormGroup className="text-right">
+                                      <Button
+                                        type="submit"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        disabled={this.state.disabled}
+                                        onClick={() => {
+                                          //	added validation popup	msg
+                                          console.log(props.errors, 'ERROR');
+                                          props.handleBlur();
+                                          if (props.errors && Object.keys(props.errors).length != 0)
+                                            this.props.commonActions.fillManDatoryDetails();
+                                        }}
+                                      >
+                                        <i className="fa fa-dot-circle-o"></i>{' '}
+                                        {this.state.disabled ? 'Updating...' : strings.Update}
+                                        {/* { {this.state.disabled }
 																				? 'Updating...'
 																				{ : 'Update'} } */}
-																			</Button>
-																			<Button
-																				color="secondary"
-																				className="btn-square"
-																				onClick={() => {
-																					if (this.props?.location?.state?.renderURL) {
-																						this.props.history.push(
-																							`${this.props?.location?.state?.renderURL}`, 
-																							{ id: this.props?.location?.state?.renderID,
-																							isCNWithoutProduct: this.props?.location?.state?.isCNWithoutProduct,
-																							},);
-																					} else
-																						this.props.history.push(
-																							'/admin/expense/debit-notes',
-																						);
-																				}}
-																			>
-																				<i className="fa fa-ban"></i> {strings.Cancel}
-																			</Button>
-																		</FormGroup>
-																	</Col>
-																</Row>
-															</Form>
-														)}
-													</Formik>
-												</Col>
-											</Row>
-										)}
-									</CardBody>
-								</Card>
-							</Col>
-						</Row>
-					</div>
-
-				</div>
-				{this.state.disableLeavePage ? "" : <LeavePage />}
-
-			</div>
-		);
-	}
+                                      </Button>
+                                      <Button
+                                        color="secondary"
+                                        className="btn-square"
+                                        onClick={() => {
+                                          if (this.props?.location?.state?.renderURL) {
+                                            this.props.history.push(
+                                              `${this.props?.location?.state?.renderURL}`,
+                                              {
+                                                id: this.props?.location?.state?.renderID,
+                                                isCNWithoutProduct:
+                                                  this.props?.location?.state?.isCNWithoutProduct,
+                                              }
+                                            );
+                                          } else
+                                            this.props.history.push('/admin/expense/debit-notes');
+                                        }}
+                                      >
+                                        <i className="fa fa-ban"></i> {strings.Cancel}
+                                      </Button>
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                              </Form>
+                            )}
+                          </Formik>
+                        </Col>
+                      </Row>
+                    )}
+                  </CardBody>
+                </Card>
+              </Col>
+            </Row>
+          </div>
+        </div>
+        {this.state.disableLeavePage ? '' : <LeavePage />}
+      </div>
+    );
+  }
 }
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps,
-)(DetailDebitNote);
+export default connect(mapStateToProps, mapDispatchToProps)(DetailDebitNote);

--- a/apps/frontend/src/screens/debitNotes/screens/view/screen.js
+++ b/apps/frontend/src/screens/debitNotes/screens/view/screen.js
@@ -12,197 +12,201 @@ import './style.scss';
 import { PDFExport } from '@progress/kendo-react-pdf';
 import './style.scss';
 import { DebitNoteTemplate } from './sections';
-import { data } from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 import ActionButtons from 'components/view_actions_buttons';
 import { StatusActionList } from 'utils';
 
-const mapStateToProps = (state) => {
-	return {
-		profile: state.auth.profile,
-	};
+const mapStateToProps = state => {
+  return {
+    profile: state.auth.profile,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		debitNoteActions: bindActionCreators(DebitNoteActions, dispatch,),
-		debitNoteViewActions: bindActionCreators(DebitNoteViewActions, dispatch,),
-		commonActions: bindActionCreators(CommonActions, dispatch),
-	};
+const mapDispatchToProps = dispatch => {
+  return {
+    debitNoteActions: bindActionCreators(DebitNoteActions, dispatch),
+    debitNoteViewActions: bindActionCreators(DebitNoteViewActions, dispatch),
+    commonActions: bindActionCreators(CommonActions, dispatch),
+  };
 };
 let strings = new LocalizedStrings(data);
 class ViewDebitNote extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			language: window['localStorage'].getItem('language'),
-			debitNoteDataList: [],
-			applyToInvoiceData: [],
-			debitNoteData: {},
-			totalNet: 0,
-			invoiceStatus: '',
-			currencyData: {},
-			id: this.props.location?.state?.id,
-			isCNWithoutProduct: this.props?.location?.state?.isCNWithoutProduct
-		};
-		this.formRef = React.createRef();
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: window['localStorage'].getItem('language'),
+      debitNoteDataList: [],
+      applyToInvoiceData: [],
+      debitNoteData: {},
+      totalNet: 0,
+      invoiceStatus: '',
+      currencyData: {},
+      id: this.props.location?.state?.id,
+      isCNWithoutProduct: this.props?.location?.state?.isCNWithoutProduct,
+    };
+    this.formRef = React.createRef();
+  }
 
-	componentDidMount = () => {
-		this.initializeData();
-	};
+  componentDidMount = () => {
+    this.initializeData();
+  };
 
-	initializeData = () => {
-		this.props.commonActions.getCompanyDetails().then((res) => {
-			if (res.status === 200) {
+  initializeData = () => {
+    this.props.commonActions.getCompanyDetails().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        this.setState({ companyData: action.payload });
+      }
+    });
+    if (this.props.location.state && this.props.location.state.id) {
+      this.props.debitNoteActions
+        .getDebitNoteById(
+          this.props.location.state.id,
+          this.props.location.state.isCNWithoutProduct
+        )
+        .then(res => {
+          let val = 0;
+          if (res.status === 200) {
+            res.data.invoiceLineItems &&
+              res.data.invoiceLineItems.map(item => {
+                val = val + item.subTotal;
+                return item;
+              });
+            const invoiceData = res.data;
+            const invoiceStatus =
+              invoiceData.status === 'Partially Paid' ? 'Partially Debited' : invoiceData.status;
+            var actionList = StatusActionList.DebitNoteStatusActionList;
+            if (invoiceStatus && actionList && actionList.length > 0) {
+              const statuslist = actionList.find(obj => obj.status === invoiceStatus);
+              actionList = statuslist ? statuslist.list : [];
+            }
+            this.setState(
+              {
+                debitNoteData: res.data,
+                totalNet: val,
+                id: this.props.location.state.id,
+                invoiceData: res.data,
+                invoiceStatus: invoiceStatus,
+                actionList: actionList,
+              },
+              () => {
+                if (this.state.debitNoteData.currencyCode) {
+                  this.props.debitNoteActions.getCurrencyList().then(res => {
+                    if (res.status === 200) {
+                      const temp = res.data.filter(
+                        item => item.currencyCode === this.state.debitNoteData.currencyCode
+                      );
+                      this.setState({
+                        currencyData: temp,
+                      });
+                    }
+                  });
+                }
+                if (this.state.debitNoteData.contactId) {
+                  this.props.debitNoteViewActions
+                    .getContactById(this.state.debitNoteData.contactId)
+                    .then(res => {
+                      if (res.status === 200) {
+                        this.setState({
+                          contactData: res.data,
+                        });
+                      }
+                    });
+                }
+              }
+            );
+          }
+        });
 
-				this.setState({ companyData: res.data, });
-			}
-		});
-		if (this.props.location.state && this.props.location.state.id) {
-			this.props.debitNoteActions
-				.getDebitNoteById(this.props.location.state.id, this.props.location.state.isCNWithoutProduct)
-				.then((res) => {
-					let val = 0;
-					if (res.status === 200) {
-						res.data.invoiceLineItems &&
-							res.data.invoiceLineItems.map((item) => {
-								val = val + item.subTotal;
-								return item;
-							});
-							const invoiceData = res.data;
-							const invoiceStatus = invoiceData.status === 'Partially Paid' ? 'Partially Debited' : invoiceData.status;
-							var actionList = StatusActionList.DebitNoteStatusActionList;
-							if (invoiceStatus && actionList && actionList.length > 0) {
-								const statuslist = actionList.find(obj => obj.status === invoiceStatus);
-								actionList = statuslist ? statuslist.list : [];
-							}
-						this.setState(
-							{
-								debitNoteData: res.data,
-								totalNet: val,
-								id: this.props.location.state.id,
-								invoiceData: res.data,
-						invoiceStatus: invoiceStatus,
-						actionList: actionList,
-							},
-							() => {
-								if (this.state.debitNoteData.currencyCode) {
-									this.props.debitNoteActions
-										.getCurrencyList()
-										.then((res) => {
-											if (res.status === 200) {
-												const temp = res.data.filter(
-													(item) =>
-														item.currencyCode ===
-														this.state.debitNoteData.currencyCode,
-												);
-												this.setState({
-													currencyData: temp,
-												});
-											}
-										});
-								}
-								if (this.state.debitNoteData.contactId) {
-									this.props.debitNoteViewActions
-										.getContactById(this.state.debitNoteData.contactId)
-										.then((res) => {
-											if (res.status === 200) {
-												this.setState({
-													contactData: res.data,
-												});
-											}
-										});
-								}
-							},
-						);
-					}
-				});
+      this.props.debitNoteViewActions
+        .getInvoicesForCNById(this.props.location.state.id)
+        .then(res => {
+          if (res.status === 200) {
+            this.setState(
+              {
+                debitNoteDataList: res.data,
 
-			this.props.debitNoteViewActions
-				.getInvoicesForCNById(this.props.location.state.id)
-				.then((res) => {
+                id: this.props.location.state.id,
+              },
+              () => {}
+            );
+          }
+        });
+      this.props.debitNoteViewActions
+        .getAppliedToInvoiceDetails(this.props.location.state.id)
+        .then(res => {
+          if (res.status === 200) {
+            this.setState(
+              {
+                applyToInvoiceData: res.data,
 
-					if (res.status === 200) {
-						this.setState(
-							{
-								debitNoteDataList: res.data,
-
-								id: this.props.location.state.id,
-							},
-							() => {
-
-							},
-						);
-					}
-				})
-			this.props.debitNoteViewActions
-				.getAppliedToInvoiceDetails(this.props.location.state.id)
-				.then((res) => {
-
-					if (res.status === 200) {
-						this.setState(
-							{
-								applyToInvoiceData: res.data,
-
-								id: this.props.location.state.id,
-							},
-							() => {
-
-							},
-						);
-					}
-				})
-		}
-	};
-	redirectToSupplierIncoive = (invoice) => {
-		if (!(invoice.transactionType && invoice.transactionType === 'Refund'))	{
-			const commonParams = {
-				id: invoice.invoiceId,
-				status: invoice.status,
-				DN_Id: this.props.location.state.id,
-				DN_WithoutPRoduct: this.props.location.state.isCNWithoutProduct,
-				DN_Status: this.props.location.state.status,
-			}
-			if (this.props.location.state && this.props.location.state.gotoReports) {
-				commonParams.gotoReports = true;
-			}
-			// this.props.history.push('/admin/expense/debit-notes/view', commonParams)
-			this.props.history.push('/admin/expense/supplier-invoice/view', commonParams)
-		}
-	}
-	exportPDFWithComponent = () => {
-		this.pdfExportComponent.save();
-	};
-	render() {
-		strings.setLanguage(this.state.language);
-		const { debitNoteData, currencyData,   invoiceData, debitNoteDataList, contactData, invoiceStatus, id, actionList, isCNWithoutProduct} = this.state;
-		const { profile } = this.props;
-		const uniquedebitNoteData = {};
-		const filtereddebitNoteData = [];
-		return (
-			<div className="view-invoice-screen">
-				<div className="animated fadeIn">
-					<Row>
-						<Col lg={12} className="mx-auto">
-						<div className="pull-left">
-								<ActionButtons
-									id={this.props.location.state.id}
-									history={this.props.history}
-									URL={'/admin/expense/debit-notes'}
-									invoiceData={invoiceData}
-									postingRefType={'DEBIT_NOTE'}
-									initializeData={() => {
-										this.initializeData();
-									}}
-									actionList={actionList}
-									invoiceStatus={invoiceStatus}
-									isCNWithoutProduct={isCNWithoutProduct}
-									documentTitle={strings.DebitNote}
-									documentCreated={false} // Any Further document against this document is created(e.g.  CN,DN,CI,...)
-								/>
-							</div>
-							<div className="pull-right">
-								{/* <Button
+                id: this.props.location.state.id,
+              },
+              () => {}
+            );
+          }
+        });
+    }
+  };
+  redirectToSupplierIncoive = invoice => {
+    if (!(invoice.transactionType && invoice.transactionType === 'Refund')) {
+      const commonParams = {
+        id: invoice.invoiceId,
+        status: invoice.status,
+        DN_Id: this.props.location.state.id,
+        DN_WithoutPRoduct: this.props.location.state.isCNWithoutProduct,
+        DN_Status: this.props.location.state.status,
+      };
+      if (this.props.location.state && this.props.location.state.gotoReports) {
+        commonParams.gotoReports = true;
+      }
+      // this.props.history.push('/admin/expense/debit-notes/view', commonParams)
+      this.props.history.push('/admin/expense/supplier-invoice/view', commonParams);
+    }
+  };
+  exportPDFWithComponent = () => {
+    this.pdfExportComponent.save();
+  };
+  render() {
+    strings.setLanguage(this.state.language);
+    const {
+      debitNoteData,
+      currencyData,
+      invoiceData,
+      debitNoteDataList,
+      contactData,
+      invoiceStatus,
+      id,
+      actionList,
+      isCNWithoutProduct,
+    } = this.state;
+    const { profile } = this.props;
+    const uniquedebitNoteData = {};
+    const filtereddebitNoteData = [];
+    return (
+      <div className="view-invoice-screen">
+        <div className="animated fadeIn">
+          <Row>
+            <Col lg={12} className="mx-auto">
+              <div className="pull-left">
+                <ActionButtons
+                  id={this.props.location.state.id}
+                  history={this.props.history}
+                  URL={'/admin/expense/debit-notes'}
+                  invoiceData={invoiceData}
+                  postingRefType={'DEBIT_NOTE'}
+                  initializeData={() => {
+                    this.initializeData();
+                  }}
+                  actionList={actionList}
+                  invoiceStatus={invoiceStatus}
+                  isCNWithoutProduct={isCNWithoutProduct}
+                  documentTitle={strings.DebitNote}
+                  documentCreated={false} // Any Further document against this document is created(e.g.  CN,DN,CI,...)
+                />
+              </div>
+              <div className="pull-right">
+                {/* <Button
 									className="btn btn-sm edit-btn"
 									onClick={() => {
 										this.props.history.push(
@@ -213,194 +217,213 @@ class ViewDebitNote extends React.Component {
 								>
 									<i className="fa fa-pencil"></i>
 								</Button> */}
-								<Button
-									className="btn-lg mb-1 print-btn-cont"
-									onClick={() => {
-										this.exportPDFWithComponent();
-									}}
-								>
-									<i className="fa fa-file-pdf-o"></i>
-								</Button>
-								<ReactToPrint
-									trigger={() => (
-										<Button type="button" className="ml-1 mb-1 mr-1 print-btn-cont btn-lg">
-											<i className="fa fa-print"></i>
-										</Button>
-									)}
-									content={() => this.componentRef}
-								/>
-								<Button
-									type="button"
-									className="close-btn mb-1 btn-lg print-btn-cont"
+                <Button
+                  className="btn-lg mb-1 print-btn-cont"
+                  onClick={() => {
+                    this.exportPDFWithComponent();
+                  }}
+                >
+                  <i className="fa fa-file-pdf-o"></i>
+                </Button>
+                <ReactToPrint
+                  trigger={() => (
+                    <Button type="button" className="ml-1 mb-1 mr-1 print-btn-cont btn-lg">
+                      <i className="fa fa-print"></i>
+                    </Button>
+                  )}
+                  content={() => this.componentRef}
+                />
+                <Button
+                  type="button"
+                  className="close-btn mb-1 btn-lg print-btn-cont"
+                  onClick={() => {
+                    if (
+                      this.props.location &&
+                      this.props.location.state &&
+                      this.props.location.state.gotoReports
+                    )
+                      this.props.history.push('/admin/report/debit-note-details');
+                    // else if (this.props.location && this.props.location.state && this.props.location.state.gotoReports)
+                    // 	this.props.history.push('/admin/report/debit-note-details');
+                    else if (this.props.location.state.SUP_id)
+                      this.props.history.push('/admin/expense/supplier-invoice/view', {
+                        id: this.props.location.state.SUP_id,
+                        status: this.props.location.state.SUP_status,
+                      });
+                    else this.props.history.push('/admin/expense/debit-notes');
+                  }}
+                >
+                  <i className="fas fa-times"></i>
+                </Button>
+              </div>
+              <div>
+                <PDFExport
+                  ref={component => (this.pdfExportComponent = component)}
+                  scale={0.8}
+                  paperSize="A3"
+                  fileName={this.state.debitNoteData.creditNoteNumber + '.pdf'}
+                >
+                  <DebitNoteTemplate
+                    debitNoteData={debitNoteData}
+                    currencyData={currencyData}
+                    status={this.props.location.state.status}
+                    ref={el => (this.componentRef = el)}
+                    totalNet={this.state.totalNet}
+                    companyData={this.state && this.state.companyData ? this.state.companyData : ''}
+                    contactData={contactData}
+                    isCNWithoutProduct={
+                      this.props.location.state.isCNWithoutProduct &&
+                      this.props.location.state.isCNWithoutProduct == true
+                        ? true
+                        : false
+                    }
+                  />
+                </PDFExport>
+              </div>
+            </Col>
+          </Row>
+          <div style={{ display: this.state.debitNoteDataList.length === 0 ? 'none' : '' }}>
+            <strong>{strings.DebitNoteIssuedOnTheSupplierInvoice}</strong>
+          </div>
 
-									onClick={() => {
+          <Card>
+            <div style={{ display: this.state.debitNoteDataList.length === 0 ? 'none' : '' }}>
+              <Table>
+                <thead style={{ backgroundColor: '#2064d8', color: 'white' }}>
+                  <tr>
+                    <th className="center" style={{ padding: '0.5rem' }}>
+                      #
+                    </th>
+                    {/* <th style={{ padding: '0.5rem' }}>Item</th> */}
+                    <th style={{ padding: '0.5rem' }}>{strings.InvoiceNumber}</th>
+                    <th style={{ padding: '0.5rem' }}>{strings.SupplierName}</th>
 
-										if (this.props.location && this.props.location.state && this.props.location.state.gotoReports)
-											this.props.history.push('/admin/report/debit-note-details')
-
-
-										// else if (this.props.location && this.props.location.state && this.props.location.state.gotoReports)
-										// 	this.props.history.push('/admin/report/debit-note-details');
-										else if (this.props.location.state.SUP_id)
-											this.props.history.push('/admin/expense/supplier-invoice/view', {
-												id: this.props.location.state.SUP_id,
-												status: this.props.location.state.SUP_status,
-											})
-										else
-											this.props.history.push('/admin/expense/debit-notes');
-									}}
-								>
-									<i className="fas fa-times"></i>
-								</Button>
-							</div>
-							<div>
-								<PDFExport
-									ref={(component) => (this.pdfExportComponent = component)}
-									scale={0.8}
-									paperSize="A3"
-									fileName={this.state.debitNoteData.creditNoteNumber + ".pdf"}
-								>
-
-									<DebitNoteTemplate
-										debitNoteData={debitNoteData}
-										currencyData={currencyData}
-										status={this.props.location.state.status}
-										ref={(el) => (this.componentRef = el)}
-										totalNet={this.state.totalNet}
-										companyData={this.state && this.state.companyData ? this.state.companyData : ''}
-										contactData={contactData}
-										isCNWithoutProduct={this.props.location.state.isCNWithoutProduct && this.props.location.state.isCNWithoutProduct == true ? true : false}
-									/>
-								</PDFExport>
-							</div>
-						</Col>
-					</Row>
-					<div style={{ display: this.state.debitNoteDataList.length === 0 ? 'none' : '' }}><strong>{strings.DebitNoteIssuedOnTheSupplierInvoice}</strong></div>
-
-					<Card>
-
-						<div style={{ display: this.state.debitNoteDataList.length === 0 ? 'none' : '' }} >
-							<Table  >
-								<thead style={{ backgroundColor: '#2064d8', color: 'white' }}>
-									<tr>
-										<th className="center" style={{ padding: '0.5rem' }}>
-											#
-										</th>
-										{/* <th style={{ padding: '0.5rem' }}>Item</th> */}
-										<th style={{ padding: '0.5rem' }}>{strings.InvoiceNumber}</th>
-										<th style={{ padding: '0.5rem' }}>{strings.SupplierName}</th>
-
-										{/* <th className="center" style={{ padding: '0.5rem' }}>
+                    {/* <th className="center" style={{ padding: '0.5rem' }}>
 										Invoice Date
 									</th>
 									<th className="center" style={{ padding: '0.5rem' }}>
 									Invoice Due Date
 									</th> */}
-										<th style={{ padding: '0.5rem', textAlign: 'right' }}>
-											{strings.Total + " " + strings.Amount}
-										</th>
-										<th style={{ padding: '0.5rem', textAlign: 'right' }}>
-											{strings.TotalVat + " " + strings.Amount}
-										</th>
+                    <th style={{ padding: '0.5rem', textAlign: 'right' }}>
+                      {strings.Total + ' ' + strings.Amount}
+                    </th>
+                    <th style={{ padding: '0.5rem', textAlign: 'right' }}>
+                      {strings.TotalVat + ' ' + strings.Amount}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className=" table-bordered table-hover">
+                  {debitNoteDataList &&
+                    (debitNoteDataList.length
+                      ? (debitNoteDataList.map(item => {
+                          if (!uniquedebitNoteData[item.invoiceNumber]) {
+                            uniquedebitNoteData[item.invoiceNumber] = item;
+                            filtereddebitNoteData.push(item);
+                          }
+                        }),
+                        filtereddebitNoteData.map((item, index) => {
+                          return (
+                            <tr
+                              key={index}
+                              onClick={() => {
+                                this.redirectToSupplierIncoive(item);
+                              }}
+                            >
+                              <td className="center">{index + 1}</td>
+                              <td style={{ color: 'blue' }}>{item.invoiceNumber}</td>
+                              <td>{item.contactName}</td>
 
-									</tr>
-								</thead>
-								<tbody className=" table-bordered table-hover">
-									{debitNoteDataList &&
-										(debitNoteDataList.length ? (
-											debitNoteDataList.map((item) => {
-												if (!uniquedebitNoteData[item.invoiceNumber]) {
-													uniquedebitNoteData[item.invoiceNumber] = item;
-													filtereddebitNoteData.push(item);
-												}
-											}),
-											filtereddebitNoteData.map((item, index) => {
-												return (
-													<tr key={index} onClick={() => {
-														this.redirectToSupplierIncoive(item);
-													}}>
-														<td className="center">{index + 1}</td>
-														<td style={{color:'blue'}}>{item.invoiceNumber}</td>
-														<td>{item.contactName}</td>
+                              <td align="right">
+                                {item.totalAmount ? (
+                                  <Currency
+                                    value={item.totalAmount}
+                                    currencySymbol={
+                                      currencyData[0] ? currencyData[0].currencyIsoCode : 'USD'
+                                    }
+                                  />
+                                ) : (
+                                  0
+                                )}
+                              </td>
 
-														<td align="right">{item.totalAmount ? <Currency
-															value={item.totalAmount}
-															currencySymbol={
-																currencyData[0]
-																	? currencyData[0].currencyIsoCode
-																	: 'USD'
-															}
-														/> : 0}</td>
+                              <td align="right">
+                                {currencyData?.currencyIsoCode} AED{' '}
+                                {item.totalVatAmount.toLocaleString(navigator.language, {
+                                  minimumFractionDigits: 2,
+                                  maximumFractionDigits: 2,
+                                })}
+                              </td>
+                            </tr>
+                          );
+                        }))
+                      : null)}
+                </tbody>
+              </Table>
+            </div>
+          </Card>
+          <div style={{ display: this.state.applyToInvoiceData?.length === 0 ? 'none' : '' }}>
+            <strong>{strings.DebitNoteAmountUsedSummary}</strong>
+          </div>
 
-														<td align="right">{currencyData?.currencyIsoCode} AED {item.totalVatAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-
-													</tr>
-												);
-											})) : null)}
-								</tbody>
-							</Table>
-						</div>
-					</Card>
-					<div style={{ display: this.state.applyToInvoiceData?.length === 0 ? 'none' : '' }}><strong>{strings.DebitNoteAmountUsedSummary}</strong></div>
-
-					<Card>
-						<div style={{ display: this.state.applyToInvoiceData?.length === 0 ? 'none' : '' }} >
-							<Table  >
-								<thead style={{ backgroundColor: '#2064d8', color: 'white' }}>
-									<tr>
-										<th className="center" style={{ padding: '0.5rem' }}>
-											#
-										</th>
-										<th style={{ padding: '0.5rem' }}>{strings.TransactionType}</th>
-										<th style={{ padding: '0.5rem' }}>{strings.InvoiceNumber}</th>
-										<th style={{ padding: '0.5rem', textAlign: 'right' }}>
-											{strings.Amount}
-										</th>
-
-									</tr>
-								</thead>
-								<tbody className=" table-bordered table-hover">
-									{this.state.applyToInvoiceData &&
-										this.state.applyToInvoiceData.length && (
-											this.state.applyToInvoiceData.map((item, index) => {
-												return (
-													<tr key={index} onClick={() => {
-														this.redirectToSupplierIncoive(item);
-													}}>
-														<td className="center">{index + 1}</td>
-														<td>{item.transactionType}</td>
-														<td>{item.invoiceNumber}</td>
-														<td align="right">{item.totalAmount ? <Currency
-															value={ item.totalAmount}
-															currencySymbol={
-																currencyData[0]
-																	? currencyData[0].currencyIsoCode
-																	: 'USD'
-															}
-														/> : 0}</td>
-													</tr>
-												);
-											}))}
-								</tbody>
-							</Table>
-						</div>
-					</Card>
-					{invoiceStatus && invoiceStatus !== 'Draft' &&
-						<InvoiceViewJournalEntries
-							history={this.props.history}
-							invoiceURL={'/admin/expense/debit-notes/view'}
-							invoiceId={id}
-							invoiceType={5}
-							isCNWithoutProduct={isCNWithoutProduct}
-						/>
-					}
-				</div>
-			</div>
-		);
-	}
+          <Card>
+            <div style={{ display: this.state.applyToInvoiceData?.length === 0 ? 'none' : '' }}>
+              <Table>
+                <thead style={{ backgroundColor: '#2064d8', color: 'white' }}>
+                  <tr>
+                    <th className="center" style={{ padding: '0.5rem' }}>
+                      #
+                    </th>
+                    <th style={{ padding: '0.5rem' }}>{strings.TransactionType}</th>
+                    <th style={{ padding: '0.5rem' }}>{strings.InvoiceNumber}</th>
+                    <th style={{ padding: '0.5rem', textAlign: 'right' }}>{strings.Amount}</th>
+                  </tr>
+                </thead>
+                <tbody className=" table-bordered table-hover">
+                  {this.state.applyToInvoiceData &&
+                    this.state.applyToInvoiceData.length &&
+                    this.state.applyToInvoiceData.map((item, index) => {
+                      return (
+                        <tr
+                          key={index}
+                          onClick={() => {
+                            this.redirectToSupplierIncoive(item);
+                          }}
+                        >
+                          <td className="center">{index + 1}</td>
+                          <td>{item.transactionType}</td>
+                          <td>{item.invoiceNumber}</td>
+                          <td align="right">
+                            {item.totalAmount ? (
+                              <Currency
+                                value={item.totalAmount}
+                                currencySymbol={
+                                  currencyData[0] ? currencyData[0].currencyIsoCode : 'USD'
+                                }
+                              />
+                            ) : (
+                              0
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+              </Table>
+            </div>
+          </Card>
+          {invoiceStatus && invoiceStatus !== 'Draft' && (
+            <InvoiceViewJournalEntries
+              history={this.props.history}
+              invoiceURL={'/admin/expense/debit-notes/view'}
+              invoiceId={id}
+              invoiceType={5}
+              isCNWithoutProduct={isCNWithoutProduct}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
 }
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps,
-)(ViewDebitNote);
+export default connect(mapStateToProps, mapDispatchToProps)(ViewDebitNote);

--- a/apps/frontend/src/screens/expense/screens/create/screen.js
+++ b/apps/frontend/src/screens/expense/screens/create/screen.js
@@ -3,16 +3,16 @@ import { connect } from 'react-redux';
 import { LeavePage, Loader } from 'components';
 import { bindActionCreators } from 'redux';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Row,
-	Col,
-	Form,
-	FormGroup,
-	Input,
-	Label,
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Input,
+  Label,
 } from 'reactstrap';
 import Select from 'react-select';
 import DatePicker from 'react-datepicker';
@@ -26,1076 +26,1057 @@ import * as CurrencyConvertActions from '../../../currencyConvert/actions';
 import 'react-datepicker/dist/react-datepicker.css';
 import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
 import './style.scss';
-import { data } from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 import { Checkbox } from '@material-ui/core';
-import Switch from "react-switch";
+import Switch from 'react-switch';
 import { TextareaAutosize } from '@material-ui/core';
 import { getCustomerInvoicesCountForDelete } from 'screens/customer_invoice/actions';
 
-const SortExpenseCategory = (list) => {
-	if (list.length !== 0) {
-		const COAList = ['Admin Expense', 'Current Asset', 'COGS', 'Fixed Asset', 'Other Current Asset', 'Other Current Liability', 'Other Expense', 'Other Liability'];
-		let expenseCategory = [];
-		COAList.map(transactionCategoryDescription => {
-			let expenseSubCategoryList = [];
-			let sub_Cat = list.filter((subCat) => subCat.transactionCategoryDescription === transactionCategoryDescription);
-			expenseSubCategoryList = selectOptionsFactory.renderOptions('transactionCategoryName', 'transactionCategoryId', sub_Cat, 'Expense Category',);
-			expenseSubCategoryList = expenseSubCategoryList.filter((obj) => obj.label !== 'Select Expense Category');
-			let expenseSubCategory = { label: transactionCategoryDescription, options: expenseSubCategoryList };
-			expenseCategory.push(expenseSubCategory);
-		})
-		return expenseCategory;
-	} else {
-		return list;
-	}
+const SortExpenseCategory = list => {
+  if (list.length !== 0) {
+    const COAList = [
+      'Admin Expense',
+      'Current Asset',
+      'COGS',
+      'Fixed Asset',
+      'Other Current Asset',
+      'Other Current Liability',
+      'Other Expense',
+      'Other Liability',
+    ];
+    let expenseCategory = [];
+    COAList.map(transactionCategoryDescription => {
+      let expenseSubCategoryList = [];
+      let sub_Cat = list.filter(
+        subCat => subCat.transactionCategoryDescription === transactionCategoryDescription
+      );
+      expenseSubCategoryList = selectOptionsFactory.renderOptions(
+        'transactionCategoryName',
+        'transactionCategoryId',
+        sub_Cat,
+        'Expense Category'
+      );
+      expenseSubCategoryList = expenseSubCategoryList.filter(
+        obj => obj.label !== 'Select Expense Category'
+      );
+      let expenseSubCategory = {
+        label: transactionCategoryDescription,
+        options: expenseSubCategoryList,
+      };
+      expenseCategory.push(expenseSubCategory);
+    });
+    return expenseCategory;
+  } else {
+    return list;
+  }
 };
-const mapStateToProps = (state) => {
-	const expenseCategoryList = SortExpenseCategory(state?.expense?.expense_categories_list);
-	return {
-		currency_list: state.expense.currency_list,
-		project_list: state.expense.project_list,
-		employee_list: state.expense.employee_list,
-		vat_list: state.expense.vat_list,
-		expense_categories_list_Sorted: expenseCategoryList,
-		expense_categories_list: state.expense.expense_categories_list,
-		bank_list: state.expense.bank_list,
-		pay_mode_list: state.expense.pay_mode_list,
-		user_list: state.expense.user_list,
-		profile: state.auth.profile,
-		currency_convert_list: state.common.currency_convert_list,
-		pay_to_list: state.expense.pay_to_list,
-	};
+const mapStateToProps = state => {
+  const expenseCategoryList = SortExpenseCategory(state?.expense?.expense_categories_list);
+  return {
+    currency_list: state.expense.currency_list,
+    project_list: state.expense.project_list,
+    employee_list: state.expense.employee_list,
+    vat_list: state.expense.vat_list,
+    expense_categories_list_Sorted: expenseCategoryList,
+    expense_categories_list: state.expense.expense_categories_list,
+    bank_list: state.expense.bank_list,
+    pay_mode_list: state.expense.pay_mode_list,
+    user_list: state.expense.user_list,
+    profile: state.auth.profile,
+    currency_convert_list: state.common.currency_convert_list,
+    pay_to_list: state.expense.pay_to_list,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		commonActions: bindActionCreators(CommonActions, dispatch),
-		expenseActions: bindActionCreators(ExpenseActions, dispatch),
-		expenseCreateActions: bindActionCreators(ExpenseCreateActions, dispatch),
-		currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
-	};
+const mapDispatchToProps = dispatch => {
+  return {
+    commonActions: bindActionCreators(CommonActions, dispatch),
+    expenseActions: bindActionCreators(ExpenseActions, dispatch),
+    expenseCreateActions: bindActionCreators(ExpenseCreateActions, dispatch),
+    currencyConvertActions: bindActionCreators(CurrencyConvertActions, dispatch),
+  };
 };
 
 let strings = new LocalizedStrings(data);
 class CreateExpense extends React.Component {
-	_isMounted = false;
-	constructor(props) {
-		super(props);
-		this.state = {
-			loading: false,
-			disableLeavePage: false,
-			createMore: false,
-			disabled: false,
-			initValue: {
-				payee: { label: 'Company Expense', value: 'Company Expense' },
-				placeOfSupplyId: '',
-				expenseDate: new Date(),
-				currencyCode: 150,
-				project: '',
-				exchangeRate: 1,
-				expenseCategory: '',
-				expenseAmount: '',
-				expenseDescription: '',
-				receiptNumber: '',
-				attachmentFile: '',
-				employee: '',
-				receiptAttachmentDescription: '',
-				notes: '',
-				vatCategoryId: '',
-				payMode: { label: 'Petty Cash', value: 'CASH' },
-				bankAccountId: '',
-				exclusiveVat: true,
-				exist: false,
-				taxTreatmentId: '',
-				expenseType: false,
-			},
-			count: 0,
-			expenseType: false,
-			isVatClaimable: true,
-			taxTreatmentId: '',
-			isReverseChargeEnabled: false,
-			currentData: {},
-			fileName: '',
-			payMode: '',
-			expenseDateForVatValidation: new Date(),
-			isRegisteredVat: false,
-			companyVATRegistrationDate: new Date(),
-			basecurrency: [],
-			// disabled: false,
-			language: window['localStorage'].getItem('language'),
-			taxTreatmentList: [],
-			placelist: [
-				{ label: 'Abu Dhabi', value: '1' },
-				{ label: 'Dubai', value: '2' },
-				{ label: 'Sharjah', value: '3' },
-				{ label: 'Ajman', value: '4' },
-				{ label: 'Umm Al Quwain', value: '5' },
-				{ label: 'Ras Al-Khaimah', value: '6' },
-				{ label: 'Fujairah', value: '7' },
-			],
-			showPlacelist: false,
-			lockPlacelist: false,
-			loadingMsg: "Loading...",
-			userStateName: ''
-		};
-		this.formRef = React.createRef();
-		this.options = {
-			paginationPosition: 'top',
-		};
-
-		this.regEx = /^[0-9\b]+$/;
-		this.regExInvNum = /[a-zA-Z0-9-/]+$/;
-		this.regExAlpha = /^[a-zA-Z0-9!@#$&()-\\`.+,/\"]+$/;
-		this.regExBoth = /[a-zA-Z0-9]+$/;
-		this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
-		this.file_size = 1024000;
-		this.supported_format = [
-			'image/png',
-			'image/jpeg',
-			'text/plain',
-			'application/pdf',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-			'application/vnd.ms-excel',
-			'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		];
-
-		this.payMode = [
-			{ label: 'CASH', value: 'CASH' },
-			{ label: 'BANK', value: 'BANK' },
-		];
-
-	}
-	getParentExpenseDetails = (parentId) => {
-		this.props.expenseCreateActions
-			.getExpenseDetail(parentId)
-			.then((res) => {
-				if (res.status === 200) {
-					this.getCompanyCurrency();
-					const { vat_list } = this.props
-					let vatCategoryId =
-						vat_list ?
-							selectOptionsFactory
-								.renderOptions(
-									'name',
-									'id',
-									vat_list,
-									'Tax',
-								)
-								.find(
-									(option) =>
-										option.value ===
-										+res.data.vatCategoryId,
-								) : ""
-					this.setState(
-						{
-
-							loading: false,
-							current_expense_id: this.props.location.state.expenseId,
-							initValue: {
-								expenseNumber: res.data.expenseNumber,
-								payee: res.data.payee ? res.data.payee : '',
-								expenseDate: res.data.expenseDate ? res.data.expenseDate : '',
-								currencyCode: res.data.currencyCode ? res.data.currencyCode : '',
-								currencyCode: res.data.currencyCode ? res.data.currencyCode : '',
-								currencyName: res.data.currencyName ? res.data.currencyName : '',
-								expenseCategory: res.data.expenseCategory
-									? res.data.expenseCategory
-									: '',
-								expenseAmount: res.data.expenseAmount,
-								vatCategoryId: vatCategoryId ? vatCategoryId : '',
-								payMode: res.data.payMode ? res.data.payMode : '',
-								bankAccountId: res.data.bankAccountId
-									? res.data.bankAccountId
-									: '',
-								exclusiveVat: res.data.exclusiveVat && res.data.exclusiveVat != null ? res.data.exclusiveVat : '',
-								exchangeRate: res.data.exchangeRate ? res.data.exchangeRate : '',
-								expenseDescription: res.data.expenseDescription,
-								receiptNumber: res.data.receiptNumber,
-								attachmentFile: res.data.attachmentFile,
-								receiptAttachmentDescription:
-									res.data.receiptAttachmentDescription,
-								fileName: res.data.fileName ? res.data.fileName : '',
-								filePath: res.data.receiptAttachmentPath
-									? res.data.receiptAttachmentPath
-									: '',
-								isReverseChargeEnabled: res.data.isReverseChargeEnabled ? res.data.isReverseChargeEnabled : false,
-								placeOfSupplyId: res.data.placeOfSupplyId ? res.data.placeOfSupplyId : '',
-								taxTreatmentId: res.data.taxTreatmentId ? res.data.taxTreatmentId : '',
-								notes: res.data.notes
-									? res.data.notes
-									: '',
-
-							},
-							payee: res.data.payee ? res.data.payee : '',
-							expenseType: res.data.expenseType ? true : false,
-							isVatClaimable: res.data.isVatClaimable ? res.data.isVatClaimable : false,
-							showPlacelist: res.data.taxTreatmentId !== 8 ? true : false,
-							lockPlacelist: res.data.taxTreatmentId === 7 ? true : false,
-							taxTreatmentId: res.data.taxTreatmentId ? res.data.taxTreatmentId : '',
-							isReverseChargeEnabled: res.data.isReverseChargeEnabled ? res.data.isReverseChargeEnabled : false,
-							exclusiveVat: res.data.exclusiveVat == true ? true : false,
-							expenseDateForVatValidation: new Date(res.data.expenseDate),
-							view:
-								this.props.location.state && this.props.location.state.view
-									? true
-									: false,
-						},
-						() => {
-
-							if (
-								this.props.location.state &&
-								this.props.location.state.view
-							) {
-								this.setState({ loading: false });
-							} else {
-								this.setState({ loading: false });
-							}
-
-							let tax = selectOptionsFactory.renderOptions('name', 'id', this.state.taxTreatmentList, 'Tax Treatment',).find((option) => option.value == res.data.taxTreatmentId)
-							this.formRef.current.setFieldValue('taxTreatmentId', tax, true);
-
-							this.placelistSetting(tax, undefined)
-							let placelist = [
-								{ label: 'Abu Dhabi', value: '1' },
-								{ label: 'Dubai', value: '2' },
-								{ label: 'Sharjah', value: '3' },
-								{ label: 'Ajman', value: '4' },
-								{ label: 'Umm Al Quwain', value: '5' },
-								{ label: 'Ras Al-Khaimah', value: '6' },
-								{ label: 'Fujairah', value: '7' },
-								{ label: 'BAHRAIN', value: '8' },
-								{ label: 'SAUDI ARABIA', value: '9' },
-								{ label: 'OMAN', value: '10' },
-								{ label: 'KUWAIT', value: '11' },
-								{ label: 'QATAR', value: '12' },
-							]
-							let placeofSupply = placelist.find((option) => option.value == res.data.placeOfSupplyId,)
-							this.formRef.current.setFieldValue('placeOfSupplyId', placeofSupply, true);
-
-							let expenseCategory = selectOptionsFactory.renderOptions('transactionCategoryName', 'transactionCategoryId', this.props.expense_categories_list, 'Expense Category',)
-								.find((option) => option.value == res.data.expenseCategory);
-							this.formRef.current.setFieldValue('expenseCategory', expenseCategory, true);
-							this.formRef.current.setFieldValue('expenseDate', new Date(res.data.expenseDate), true);
-							this.formRef.current.setFieldValue('currencyCode', res.data.currencyCode ?? '', true);
-							this.formRef.current.setFieldValue('exchangeRate', res.data.exchangeRate ?? '', true);
-							this.formRef.current.setFieldValue('currencyName', res.data.currencyName ?? '', true);
-							let payMode = selectOptionsFactory.renderOptions('label', 'value', this.props.pay_mode_list, '',)
-								.find((option) => option.value == res.data.payMode)
-							this.formRef.current.setFieldValue('payMode', payMode, true);
-							this.formRef.current.setFieldValue('expenseAmount', res.data.expenseAmount, true);
-							let vat = selectOptionsFactory.renderOptions(
-								'name',
-								'id',
-								this.props.vat_list,
-								'VAT',
-							).find((option) => option.value == res.data.vatCategoryId)
-							if (res.data.vatCategoryId === 10) {
-								vat = {};
-								vat.label = "N/A";
-								vat.value = "10";
-							}
-							this.formRef.current.setFieldValue('vatCategoryId', vat, true);
-							this.formRef.current.setFieldValue('expenseDescription', res.data.expenseDescription, true);
-							this.formRef.current.setFieldValue('receiptNumber', res.data.receiptNumber, true);
-							// this.formRef.current.setFieldValue('receiptAttachmentDescription', res.data.receiptAttachmentDescription, true);
-							// this.formRef.current.setFieldValue('notes',  res.data.notes, true);
-
-							let payee = selectOptionsFactory.renderOptions('label', 'value', this.props.pay_to_list, 'Payee',)
-								.find((option) => option.label == res.data.payee)
-							this.formRef.current.setFieldValue('payee', payee, true);
-						},
-					);
-					this.ReverseChargeSetting(res.data.taxTreatmentId, "")
-				}
-
-			})
-			.catch((err) => {
-				this.setState({ loading: false });
-			});
-	}
-
-
-	componentDidMount = () => {
-		this._isMounted = true;
-		this.initializeData();
-		this.getExpenseNumber();
-		// this.savestate()
-		if (this.props.location.state && this.props.location.state.parentId)
-			this.getParentExpenseDetails(this.props.location.state.parentId);
-		this.getDefaultNotes()
-	};
-	getDefaultNotes = () => {
-		this.props.commonActions.getNoteSettingsInfo().then((res) => {
-			if (res.status === 200) {
-				this.formRef.current.setFieldValue('notes', res.data.defaultNotes, true);
-				this.formRef.current.setFieldValue('footNote', res.data.defaultFootNotes, true);
-
-			}
-		})
-	}
-	initializeData = () => {
-		this.props.expenseCreateActions.getPaytoList();
-		this.props.expenseActions.getVatList();
-		this.props.expenseActions.getExpenseCategoriesList();
-		this.props.commonActions.getCurrencyConversionList().then((response) => {
-			this.setState({
-				initValue: {
-					...this.state.initValue,
-					...{
-						currency: response.data
-							? parseInt(response.data[0].currencyCode)
-							: '',
-					},
-				},
-			});
-		});
-		this.props.expenseActions.getBankList();
-		this.props.expenseActions.getPaymentMode();
-		this.props.expenseActions.getUserForDropdown();
-		this.getCompanyCurrency();
-		this.getTaxTreatmentList();
-		this.getcurentCompanyUser()
-	};
-	getcurentCompanyUser = () => {
-		this.props.expenseCreateActions.checkAuthStatus().then((response) => {
-			let userStateName = response.data.company.companyStateCode.stateName ? response.data.company.companyStateCode.stateName : '';
-			let isDesignatedZone = response.data.company.isDesignatedZone ? response.data.company.isDesignatedZone : false;
-
-			this.setState({
-				userStateName: userStateName,
-				isDesignatedZone: isDesignatedZone,
-				isRegisteredVat: response.data.company.isRegisteredVat,
-				companyVATRegistrationDate: new Date(response.data.company.vatRegistrationDate),
-			})
-
-		});
-	}
-	getTaxTreatmentList = () => {
-		this.props.expenseActions
-			.getTaxTreatment()
-			.then((res) => {
-
-				if (res.status === 200) {
-					this.setState({ taxTreatmentList: res.data });
-				}
-			})
-			.catch((err) => {
-
-				this.setState({ disabled: false });
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err.data ? err.data.message : 'ERROR',
-				);
-			});
-	}
-	handleSubmit = (data, resetForm) => {
-		this.setState({
-			disabled: true,
-			disableLeavePage: true
-		});
-		const {
-			expenseNumber,
-			payee,
-			placeOfSupplyId,
-			expenseDate,
-			currencyCode,
-			project,
-			expenseCategory,
-			expenseAmount,
-			exchangeRate,
-			employee,
-			expenseDescription,
-			receiptNumber,
-			// attachmentFile,
-			receiptAttachmentDescription,
-			vatCategoryId,
-			payMode,
-			bankAccountId,
-			exclusiveVat,
-			taxTreatmentId,
-			expenseType,
-			notes,
-			footNote
-		} = data;
-		let formData = new FormData();
-
-		formData.append('isVatClaimable', this.state.isVatClaimable);
-
-		formData.append('delivaryNotes', notes);
-		formData.append('footNote', footNote ? footNote : '')
-		formData.append('expenseNumber', expenseNumber ? expenseNumber : '');
-		if (payee)
-			formData.append('payee', payee.value ? payee.value : '');
-		formData.append('expenseDate', expenseDate !== null ? expenseDate : '');
-		formData.append('expenseDescription', expenseDescription);
-		formData.append('receiptNumber', receiptNumber);
-		formData.append('receiptAttachmentDescription', receiptAttachmentDescription,);
-		formData.append('expenseAmount', expenseAmount);
-		formData.append('payMode', payee?.value === 'Company Expense' || payee === 'Company Expense' ? payMode?.value ? payMode.value : payMode : '');
-		if (expenseCategory && expenseCategory.value) {
-			formData.append('expenseCategory', expenseCategory.value);
-		}
-		if (employee && employee.value) {
-			formData.append('employeeId', employee.value);
-		}
-		if (placeOfSupplyId) {
-			formData.append('placeOfSupplyId', placeOfSupplyId.value ? placeOfSupplyId.value : placeOfSupplyId);
-		}
-		if (!this.state.isRegisteredVat) {
-			formData.append('taxTreatmentId', '');
-			formData.append('vatCategoryId', 10);
-			// formData.append("isReverseChargeEnabled",'')
-			// formData.append('expenseType', '' );
-			formData.append("isReverseChargeEnabled", false)
-			formData.append('expenseType', false);
-		}
-		else {
-			if (this.state.isRegisteredVat && taxTreatmentId) {
-				formData.append('taxTreatmentId', taxTreatmentId.value ? taxTreatmentId.value : taxTreatmentId);
-			}
-			if (vatCategoryId) {
-				formData.append('vatCategoryId', vatCategoryId.value ? vatCategoryId.value : vatCategoryId);
-				if (this.state.exclusiveVat !== undefined) {
-					formData.append('exclusiveVat', this.state.exclusiveVat);
-				}
-			}
-			formData.append("isReverseChargeEnabled", this.state.isReverseChargeEnabled)
-			formData.append('expenseType', this.state.expenseType);
-
-		}
-		if (exchangeRate) {
-			formData.append('exchangeRate', exchangeRate);
-		}
-		formData.append('currencyCode', currencyCode ? currencyCode.value ?? currencyCode : '');
-
-		if (bankAccountId && bankAccountId.value && payMode.value === 'BANK') {
-			formData.append('bankAccountId', bankAccountId.value);
-		}
-		if (project && project.value) {
-			formData.append('projectId', project.value);
-		}
-		if (this.uploadFile?.files?.[0]) {
-			formData.append('attachmentFile', this.uploadFile?.files?.[0]);
-		}
-		this.setState({ loading: true, loadingMsg: "Creating Expense..." });
-		this.props.expenseCreateActions
-			.createExpense(formData)
-			.then((res) => {
-				if (res.status === 200) {
-					this.props.commonActions.tostifyAlert(
-						'success',
-						res.data ? res.data.message : 'Expense Created Successfully'
-					);
-					if (this.state.createMore) {
-						resetForm(this.state.initValue);
-						this.setState({
-							createMore: false,
-							loading: false,
-							disableLeavePage: false,
-							expenseDateForVatValidation: new Date(),
-							disabled: false,
-						});
-						this.getExpenseNumber()
-					} else {
-						this.props.history.push('/admin/expense/expense');
-						this.setState({ disabled: false, loading: false, });
-					}
-				}
-			})
-			.catch((err) => {
-				this.setState({ disabled: false, loading: false, });
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err.data ? err.data.message : 'Expense Created Unsuccessfully'
-				);
-			});
-	};
-
-	getCompanyCurrency = (basecurrency) => {
-		this.props.currencyConvertActions
-			.getCompanyCurrency()
-			.then((res) => {
-				if (res.status === 200) {
-					this.setState({ basecurrency: res.data });
-				}
-			})
-			.catch((err) => {
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err && err.data ? err.data.message : 'Something Went Wrong',
-				);
-				this.setState({ loading: false });
-			});
-	};
-	setExchange = (value) => {
-		if (this.props.currency_convert_list) {
-			let result = this.props.currency_convert_list.filter((obj) => {
-				return obj.currencyCode === value;
-			});
-			if (result && result[0] && result[0].exchangeRate)
-				this.formRef.current.setFieldValue('exchangeRate', result[0].exchangeRate, true);
-		}
-	};
-
-	setCurrency = (value) => {
-		if (this.props.currency_convert_list) {
-			let result = this.props.currency_convert_list.filter((obj) => {
-				return obj.currencyCode === value;
-			});
-			if (result[0] && result[0].currencyName) {
-				this.formRef.current.setFieldValue('currencyName', result[0].currencyName, true);
-			}
-		}
-	};
-
-	handleFileChange = (e, props) => {
-		e.preventDefault();
-		let reader = new FileReader();
-		let file = e.target.files[0];
-		if (file) {
-			reader.onloadend = () => { };
-			reader.readAsDataURL(file);
-			props.setFieldValue('attachmentFile', file, true);
-		}
-	};
-	getExpenseNumber = () => {
-
-		this.props.expenseCreateActions.getExpenseNumber().then((res) => {
-			if (res.status === 200) {
-				this.setState({
-					initValue: {
-						...this.state.initValue,
-						...{ expenseNumber: res.data },
-					},
-				});
-
-				if (res.data && res.data != null) {
-					this.formRef.current.setFieldValue('expenseNumber', res.data, true, true);
-					this.expenseValidationCheck(res.data);
-				}
-				// this.validationCheck(res.data)
-
-			}
-		});
-
-	}
-
-
-	expenseValidationCheck = (value) => {
-		const data = {
-			moduleType: 18,
-			name: value,
-		};
-		this.props.expenseCreateActions
-			.checkExpenseCodeValidation(data)
-			.then((response) => {
-				if (response.data === 'Expense Number Already Exists') {
-					this.setState({
-						exist: true,
-					},
-
-						() => { },
-					);
-				} else {
-					this.setState({
-						exist: false,
-					});
-				}
-			});
-	};
-	placelistSetting = (option, props) => {
-
-		this.setState({ showPlacelist: true, lockPlacelist: false })
-		if (option?.value === 6)
-			this.setState({
-				placelist:
-					[
-						{ label: 'Abu Dhabi', value: '1' },
-						{ label: 'Dubai', value: '2' },
-						{ label: 'Sharjah', value: '3' },
-						{ label: 'Ajman', value: '4' },
-						{ label: 'Umm Al Quwain', value: '5' },
-						{ label: 'Ras Al-Khaimah', value: '6' },
-						{ label: 'Fujairah', value: '7' },
-						{ label: 'BAHRAIN', value: '8' },
-						{ label: 'SAUDI ARABIA', value: '9' },
-						{ label: 'OMAN', value: '10' },
-						{ label: 'KUWAIT', value: '11' },
-						{ label: 'QATAR', value: '12' },
-					]
-			})
-		else
-			if (option?.value === 5)
-				this.setState({
-					placelist:
-						[
-							{ label: 'Abu Dhabi', value: '1' },
-							{ label: 'Dubai', value: '2' },
-							{ label: 'Sharjah', value: '3' },
-							{ label: 'Ajman', value: '4' },
-							{ label: 'Umm Al Quwain', value: '5' },
-							{ label: 'Ras Al-Khaimah', value: '6' },
-							{ label: 'Fujairah', value: '7' },
-							{ label: 'BAHRAIN', value: '8' },
-							{ label: 'SAUDI ARABIA', value: '9' },
-							{ label: 'OMAN', value: '10' },
-							// { label: 'KUWAIT', value: '11' },
-							// { label: 'QATAR', value: '12' },
-						]
-				})
-			else
-				if (option?.value === 8) {
-					if (props)
-						props.handleChange('placeOfSupplyId')('')
-					else
-						this.formRef.current.setFieldValue('placeOfSupplyId', "", true);
-					this.setState({ showPlacelist: false })
-				} else
-					if (option?.value === 7) {
-						let placeOfSupplyId = this.state.placelist.find(
-							(option) =>
-								option.label === this.state.userStateName,
-						);
-						if (props)
-							props.handleChange('placeOfSupplyId')(placeOfSupplyId)
-						else
-							this.formRef.current.setFieldValue('placeOfSupplyId', placeOfSupplyId, true);
-						this.setState({ lockPlacelist: true })
-					}
-					else
-						this.setState({
-							placelist:
-								[
-									{ label: 'Abu Dhabi', value: '1' },
-									{ label: 'Dubai', value: '2' },
-									{ label: 'Sharjah', value: '3' },
-									{ label: 'Ajman', value: '4' },
-									{ label: 'Umm Al Quwain', value: '5' },
-									{ label: 'Ras Al-Khaimah', value: '6' },
-									{ label: 'Fujairah', value: '7' },
-									// { label: 'BAHRAIN', value: '8' },
-									// { label: 'SAUDI ARABIA', value: '9' },
-									// { label: 'OMAN', value: '10' },
-									// { label: 'KUWAIT', value: '11' },
-									// { label: 'QATAR', value: '12' },
-								]
-						})
-
-	}
-
-	ReverseChargeSetting = (option, props) => {
-		if (this.state.isDesignatedZone == true) {
-			if ((option >= 1 && option <= 4) || option === 8) {
-				this.setState({
-					showReverseCharge: false,
-				})
-			}
-			else {
-				this.setState({
-					showReverseCharge: true,
-				})
-			}
-		}
-		// switch(option){
-
-		// 	case 1: 
-		// 	case 2: 
-		// 	case 3: 
-		// 	case 4: 
-		// 	case 8: 
-		// 	this.setState({
-		// 		showReverseCharge:false,
-		// 	})
-		// 	break;
-
-		// 	case 5: 
-		// 	case 6: 
-		// 	case 7: 
-		// 	this.setState({
-		// 		showReverseCharge:true,
-		// 	})
-		// 	break;
-
-
-		// }
-		else {
-			//Not Designated Zone		
-			if (this.state.isDesignatedZone == false) {
-				if (option === 3 || option === 8) {
-					this.setState({
-						showReverseCharge: false,
-					})
-				}
-				else {
-					this.setState({
-						showReverseCharge: true,
-					})
-				}
-				// switch(option.value){
-
-				// 	case 1: 
-				// 	case 2: 
-				// 	case 4: 
-				// 	case 5: 
-				// 	case 6: 
-				// 	case 7: 
-				// 	this.setState({
-				// 		showReverseCharge:true,
-				// 	})
-				// 			break;
-
-				// 	case 3: 
-				// 	case 8: 
-				// 	this.setState({
-				// 		showReverseCharge:false,
-				// 	})
-				// 			break;
-			}
-		}
-
-	}
-
-	renderVat = (props) => {
-		let vat_list = []
-		let vatIds = []
-		if (this.state.isRegisteredVat && (this.state.expenseDateForVatValidation > this.state.companyVATRegistrationDate)) {
-			if (this.state.isDesignatedZone && this.state.isDesignatedZone != null && this.state.isDesignatedZone == true) {
-				switch (props.values.taxTreatmentId && props.values.taxTreatmentId.value ? props.values.taxTreatmentId.value : '') {
-
-					case 1:
-					case 3:
-						if (this.state.isReverseChargeEnabled == false)
-							vatIds = [1, 2, 3]
-
-						break;
-
-					case 2:
-					case 4:
-					case 8:
-						if (this.state.isReverseChargeEnabled == false)
-							vatIds = [4]
-
-						break;
-
-					case 5:
-					case 6:
-					case 7:
-						if (this.state.isReverseChargeEnabled == false)
-							vatIds = [3]
-						else if (this.state.isReverseChargeEnabled == true)
-							vatIds = [1, 2]
-						break;
-
-					case 8:
-						if (this.state.isReverseChargeEnabled == false)
-							vatIds = [4]
-
-						break;
-				}
-			}
-			else
-				//Not Designated Zone		
-				if (this.state.isDesignatedZone == false)
-					switch (props.values.taxTreatmentId && props.values.taxTreatmentId.value ? props.values.taxTreatmentId.value : '') {
-
-						case 1:
-							if (this.state.isReverseChargeEnabled == false)
-								vatIds = [1, 2, 3]
-							else if (this.state.isReverseChargeEnabled == true)
-								vatIds = [1, 2]
-							break;
-
-						case 3:
-							if (this.state.isReverseChargeEnabled == false)
-								vatIds = [1, 2, 3]
-
-							break;
-
-						case 2:
-						case 4:
-						case 5:
-						case 6:
-						case 7:
-							if (this.state.isReverseChargeEnabled == false)
-								vatIds = [3]
-							else if (this.state.isReverseChargeEnabled == true)
-								vatIds = [1, 2]
-							break;
-
-						case 8:
-							if (this.state.isReverseChargeEnabled == false)
-								vatIds = [4]
-
-							break;
-					}
-		} else {
-			vatIds = [10]
-		}
-
-		vat_list = this.getVatListByIds(vatIds)
-		//vat column
-		return (
-			<Col lg={3}>
-				<FormGroup className="mb-3">
-					<Label htmlFor="vatCategoryId"><span className="text-danger">* </span>{strings.VAT}</Label>
-					<Select
-						// styles={customStyles}
-						// className="select-default-width"
-
-						options={
-							vat_list
-								? selectOptionsFactory.renderOptions(
-									'name',
-									'id',
-									vat_list,
-									'VAT',
-								)
-								: []
-						}
-						value={props.values.vatCategoryId}
-						onChange={(option) => {
-							if (option && option.value) {
-								props.handleChange('vatCategoryId')(
-									option,
-								);
-							} else {
-								props.handleChange('vatCategoryId')('');
-							}
-						}}
-
-						placeholder={strings.Select + strings.VAT}
-						id="vatCategoryId"
-						name="vatCategoryId"
-						className={
-							props.errors.vatCategoryId &&
-								props.touched.vatCategoryId
-								? 'is-invalid'
-								: ''
-						}
-					/>
-					{props.errors.vatCategoryId &&
-						props.touched.vatCategoryId && (
-							<div className="invalid-feedback">
-								{props.errors.vatCategoryId}
-							</div>
-						)}
-
-				</FormGroup>
-			</Col>
-		)
-	}
-	getVatListByIds = (vatIds) => {
-		const { vat_list } = this.props
-
-		let array = []
-
-		vat_list.map((row) => {
-			vatIds.map((id) => {
-				if (row.id === id) {
-					array.push(row)
-				}
-			})
-		})
-		if (vatIds[0] === 10) {
-			array.push({
-				"id": 10,
-				"vat": 0,
-				"name": "N/A"
-			})
-		}
-
-		return array;
-	}
-
-	//added by mudassar to unmount the asyn call 
-	componentWillUnmount() {
-		this._isMounted = false;
-	}
-
-	render() {
-		strings.setLanguage(this.state.language);
-		const { initValue, payMode, exist, taxTreatmentList, placelist, vat_list, loading, loadingMsg } = this.state;
-		const {
-			// currency_list,
-			expense_categories_list,
-			expense_categories_list_Sorted,
-			// vat_list,
-			// profile,
-			// user_list,
-			pay_mode_list,
-			bank_list,
-			currency_convert_list,
-			pay_to_list,
-		} = this.props;
-		const customStyles = {
-			control: (base, state) => ({
-				...base,
-				borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-				boxShadow: state.isFocused ? null : null,
-				'&:hover': {
-					borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-				},
-			}),
-		};
-		return (
-			loading == true ? <Loader loadingMsg={loadingMsg} /> :
-				<div>
-					<div className="create-expense-screen">
-						<div className="animated fadeIn">
-							<Row>
-								<Col lg={12} className="mx-auto">
-									<Card>
-										<CardHeader>
-											<Row>
-												<Col lg={12}>
-													<div className="h4 mb-0 d-flex align-items-center">
-														<i className="fab fa-stack-exchange" />
-														<span className="ml-2">{strings.CreateExpense}  </span>
-													</div>
-												</Col>
-											</Row>
-										</CardHeader>
-										<CardBody>
-											{loading ? (
-												<Row>
-													<Col lg={12}>
-														<Loader />
-													</Col>
-												</Row>
-											) : (
-												<Row>
-													<Col lg={12}>
-														<Formik
-															initialValues={initValue}
-															ref={this.formRef}
-															onSubmit={(values, { resetForm }) => {
-																this.handleSubmit(values, resetForm);
-
-																// this.setState({
-																//   selectedCurrency: null,
-																//   selectedProject: null,
-																//   selectedBankAccount: null,
-																//   selectedCustomer: null
-
-																// })
-															}}
-															validate={(values) => {
-																let errors = {};
-																// if (
-																// 	values.payMode.value === 'BANK' &&
-																// 	!values.bankAccountId
-																// ) {
-																// 	errors.bankAccountId = 'Bank account is required';
-																// }
-																if (values.payee.value === 'Company Expense') {
-																	if (values.payMode.value != "CASH") {
-																		errors.payMode = 'Pay through is required'
-																	}
-
-																}
-																// if(values.payMode.value === "CASH"){
-																// 	errors.payMode = 'Pay through is required'
-																// }
-
-																if (values.expenseNumber && exist === true) {
-																	errors.expenseNumber = 'Expense number already exists'
-																}
-																if (this.state.isRegisteredVat && !values.vatCategoryId &&
-																	values.expenseCategory && values.expenseCategory.value !== 34) {
-																	errors.vatCategoryId = strings.VATIsRequired;
-																}
-																if (this.state.isRegisteredVat && !values.taxTreatmentId &&
-																	values.expenseCategory && values.expenseCategory.value !== 34) {
-																	errors.taxTreatmentId = strings.TaxTreatmentRequired;
-																}
-																if (!values.placeOfSupplyId && values.taxTreatmentId.value !== 8 && this.state.showPlacelist == true) {
-																	errors.placeOfSupplyId = 'Place of supply is required';
-																}
-																return errors;
-															}}
-															validationSchema={Yup.object().shape({
-																expenseNumber: Yup.string().required(
-																	strings.Expense_Number_Required
-																),
-																expenseCategory: Yup.string().required(
-																	strings.Expense_Category_Required
-																),
-																expenseDate: Yup.date().required(
-																	'Expense date is required',
-																),
-																currencyCode: Yup.string().required(
-																	strings.CurrencyIsRequired
-																),
-																payee: Yup.string().required(
-																	strings.PaidByRequired
-																),
-																expenseAmount: Yup.string().required(
-																	strings.AmountIsRequired
-																)
-																	.matches(
-																		/^[0-9][0-9]*[.]?[0-9]{0,2}$$/,
-																		'Enter a valid amount',
-																	)
-																	.test(
-																		'Expense Amount',
-																		'Expense amount should be greater than 1',
-																		(value) => {
-																			if (value > 0) {
-																				return true;
-																			} else {
-																				return false;
-																			}
-																		},
-																	),
-
-																payMode: Yup.string().required(
-																	strings.PayThroughIsRequired
-																),
-																attachmentFile: Yup.mixed()
-																	.test(
-																		'fileType',
-																		'*Unsupported File Format',
-																		(value) => {
-																			value &&
-																				this.setState({
-																					fileName: value.name,
-																				});
-																			if (
-																				!value ||
-																				(value &&
-																					this.supported_format.includes(value.type))
-																			) {
-																				return true;
-																			} else {
-																				return false;
-																			}
-																		},
-																	)
-																	.test(
-																		'fileSize',
-																		'*File Size is too large',
-																		(value) => {
-																			if (
-																				!value ||
-																				(value && value.size <= this.file_size)
-																			) {
-																				return true;
-																			} else {
-																				return false;
-																			}
-																		},
-																	),
-															})}
-														>
-															{(props) => (
-																<Form onSubmit={props.handleSubmit}>
-																	<Row>
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="expenseNumber">
-																					<span className="text-danger">* </span>
-																					{strings.ExpenseNumber}
-																					{/* <i
+  _isMounted = false;
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: false,
+      disableLeavePage: false,
+      createMore: false,
+      disabled: false,
+      initValue: {
+        payee: { label: 'Company Expense', value: 'Company Expense' },
+        placeOfSupplyId: '',
+        expenseDate: new Date(),
+        currencyCode: 150,
+        project: '',
+        exchangeRate: 1,
+        expenseCategory: '',
+        expenseAmount: '',
+        expenseDescription: '',
+        receiptNumber: '',
+        attachmentFile: '',
+        employee: '',
+        receiptAttachmentDescription: '',
+        notes: '',
+        vatCategoryId: '',
+        payMode: { label: 'Petty Cash', value: 'CASH' },
+        bankAccountId: '',
+        exclusiveVat: true,
+        exist: false,
+        taxTreatmentId: '',
+        expenseType: false,
+      },
+      count: 0,
+      expenseType: false,
+      isVatClaimable: true,
+      taxTreatmentId: '',
+      isReverseChargeEnabled: false,
+      currentData: {},
+      fileName: '',
+      payMode: '',
+      expenseDateForVatValidation: new Date(),
+      isRegisteredVat: false,
+      companyVATRegistrationDate: new Date(),
+      basecurrency: [],
+      // disabled: false,
+      language: window['localStorage'].getItem('language'),
+      taxTreatmentList: [],
+      placelist: [
+        { label: 'Abu Dhabi', value: '1' },
+        { label: 'Dubai', value: '2' },
+        { label: 'Sharjah', value: '3' },
+        { label: 'Ajman', value: '4' },
+        { label: 'Umm Al Quwain', value: '5' },
+        { label: 'Ras Al-Khaimah', value: '6' },
+        { label: 'Fujairah', value: '7' },
+      ],
+      showPlacelist: false,
+      lockPlacelist: false,
+      loadingMsg: 'Loading...',
+      userStateName: '',
+    };
+    this.formRef = React.createRef();
+    this.options = {
+      paginationPosition: 'top',
+    };
+
+    this.regEx = /^[0-9\b]+$/;
+    this.regExInvNum = /[a-zA-Z0-9-/]+$/;
+    this.regExAlpha = /^[a-zA-Z0-9!@#$&()-\\`.+,/\"]+$/;
+    this.regExBoth = /[a-zA-Z0-9]+$/;
+    this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
+    this.file_size = 1024000;
+    this.supported_format = [
+      'image/png',
+      'image/jpeg',
+      'text/plain',
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ];
+
+    this.payMode = [
+      { label: 'CASH', value: 'CASH' },
+      { label: 'BANK', value: 'BANK' },
+    ];
+  }
+  getParentExpenseDetails = parentId => {
+    this.props.expenseCreateActions
+      .getExpenseDetail(parentId)
+      .then(res => {
+        if (res.status === 200) {
+          this.getCompanyCurrency();
+          const { vat_list } = this.props;
+          let vatCategoryId = vat_list
+            ? selectOptionsFactory
+                .renderOptions('name', 'id', vat_list, 'Tax')
+                .find(option => option.value === +res.data.vatCategoryId)
+            : '';
+          this.setState(
+            {
+              loading: false,
+              current_expense_id: this.props.location.state.expenseId,
+              initValue: {
+                expenseNumber: res.data.expenseNumber,
+                payee: res.data.payee ? res.data.payee : '',
+                expenseDate: res.data.expenseDate ? res.data.expenseDate : '',
+                currencyCode: res.data.currencyCode ? res.data.currencyCode : '',
+                currencyCode: res.data.currencyCode ? res.data.currencyCode : '',
+                currencyName: res.data.currencyName ? res.data.currencyName : '',
+                expenseCategory: res.data.expenseCategory ? res.data.expenseCategory : '',
+                expenseAmount: res.data.expenseAmount,
+                vatCategoryId: vatCategoryId ? vatCategoryId : '',
+                payMode: res.data.payMode ? res.data.payMode : '',
+                bankAccountId: res.data.bankAccountId ? res.data.bankAccountId : '',
+                exclusiveVat:
+                  res.data.exclusiveVat && res.data.exclusiveVat != null
+                    ? res.data.exclusiveVat
+                    : '',
+                exchangeRate: res.data.exchangeRate ? res.data.exchangeRate : '',
+                expenseDescription: res.data.expenseDescription,
+                receiptNumber: res.data.receiptNumber,
+                attachmentFile: res.data.attachmentFile,
+                receiptAttachmentDescription: res.data.receiptAttachmentDescription,
+                fileName: res.data.fileName ? res.data.fileName : '',
+                filePath: res.data.receiptAttachmentPath ? res.data.receiptAttachmentPath : '',
+                isReverseChargeEnabled: res.data.isReverseChargeEnabled
+                  ? res.data.isReverseChargeEnabled
+                  : false,
+                placeOfSupplyId: res.data.placeOfSupplyId ? res.data.placeOfSupplyId : '',
+                taxTreatmentId: res.data.taxTreatmentId ? res.data.taxTreatmentId : '',
+                notes: res.data.notes ? res.data.notes : '',
+              },
+              payee: res.data.payee ? res.data.payee : '',
+              expenseType: res.data.expenseType ? true : false,
+              isVatClaimable: res.data.isVatClaimable ? res.data.isVatClaimable : false,
+              showPlacelist: res.data.taxTreatmentId !== 8 ? true : false,
+              lockPlacelist: res.data.taxTreatmentId === 7 ? true : false,
+              taxTreatmentId: res.data.taxTreatmentId ? res.data.taxTreatmentId : '',
+              isReverseChargeEnabled: res.data.isReverseChargeEnabled
+                ? res.data.isReverseChargeEnabled
+                : false,
+              exclusiveVat: res.data.exclusiveVat == true ? true : false,
+              expenseDateForVatValidation: new Date(res.data.expenseDate),
+              view: this.props.location.state && this.props.location.state.view ? true : false,
+            },
+            () => {
+              if (this.props.location.state && this.props.location.state.view) {
+                this.setState({ loading: false });
+              } else {
+                this.setState({ loading: false });
+              }
+
+              let tax = selectOptionsFactory
+                .renderOptions('name', 'id', this.state.taxTreatmentList, 'Tax Treatment')
+                .find(option => option.value == res.data.taxTreatmentId);
+              this.formRef.current.setFieldValue('taxTreatmentId', tax, true);
+
+              this.placelistSetting(tax, undefined);
+              let placelist = [
+                { label: 'Abu Dhabi', value: '1' },
+                { label: 'Dubai', value: '2' },
+                { label: 'Sharjah', value: '3' },
+                { label: 'Ajman', value: '4' },
+                { label: 'Umm Al Quwain', value: '5' },
+                { label: 'Ras Al-Khaimah', value: '6' },
+                { label: 'Fujairah', value: '7' },
+                { label: 'BAHRAIN', value: '8' },
+                { label: 'SAUDI ARABIA', value: '9' },
+                { label: 'OMAN', value: '10' },
+                { label: 'KUWAIT', value: '11' },
+                { label: 'QATAR', value: '12' },
+              ];
+              let placeofSupply = placelist.find(
+                option => option.value == res.data.placeOfSupplyId
+              );
+              this.formRef.current.setFieldValue('placeOfSupplyId', placeofSupply, true);
+
+              let expenseCategory = selectOptionsFactory
+                .renderOptions(
+                  'transactionCategoryName',
+                  'transactionCategoryId',
+                  this.props.expense_categories_list,
+                  'Expense Category'
+                )
+                .find(option => option.value == res.data.expenseCategory);
+              this.formRef.current.setFieldValue('expenseCategory', expenseCategory, true);
+              this.formRef.current.setFieldValue(
+                'expenseDate',
+                new Date(res.data.expenseDate),
+                true
+              );
+              this.formRef.current.setFieldValue('currencyCode', res.data.currencyCode ?? '', true);
+              this.formRef.current.setFieldValue('exchangeRate', res.data.exchangeRate ?? '', true);
+              this.formRef.current.setFieldValue('currencyName', res.data.currencyName ?? '', true);
+              let payMode = selectOptionsFactory
+                .renderOptions('label', 'value', this.props.pay_mode_list, '')
+                .find(option => option.value == res.data.payMode);
+              this.formRef.current.setFieldValue('payMode', payMode, true);
+              this.formRef.current.setFieldValue('expenseAmount', res.data.expenseAmount, true);
+              let vat = selectOptionsFactory
+                .renderOptions('name', 'id', this.props.vat_list, 'VAT')
+                .find(option => option.value == res.data.vatCategoryId);
+              if (res.data.vatCategoryId === 10) {
+                vat = {};
+                vat.label = 'N/A';
+                vat.value = '10';
+              }
+              this.formRef.current.setFieldValue('vatCategoryId', vat, true);
+              this.formRef.current.setFieldValue(
+                'expenseDescription',
+                res.data.expenseDescription,
+                true
+              );
+              this.formRef.current.setFieldValue('receiptNumber', res.data.receiptNumber, true);
+              // this.formRef.current.setFieldValue('receiptAttachmentDescription', res.data.receiptAttachmentDescription, true);
+              // this.formRef.current.setFieldValue('notes',  res.data.notes, true);
+
+              let payee = selectOptionsFactory
+                .renderOptions('label', 'value', this.props.pay_to_list, 'Payee')
+                .find(option => option.label == res.data.payee);
+              this.formRef.current.setFieldValue('payee', payee, true);
+            }
+          );
+          this.ReverseChargeSetting(res.data.taxTreatmentId, '');
+        }
+      })
+      .catch(err => {
+        this.setState({ loading: false });
+      });
+  };
+
+  componentDidMount = () => {
+    this._isMounted = true;
+    this.initializeData();
+    this.getExpenseNumber();
+    // this.savestate()
+    if (this.props.location.state && this.props.location.state.parentId)
+      this.getParentExpenseDetails(this.props.location.state.parentId);
+    this.getDefaultNotes();
+  };
+  getDefaultNotes = () => {
+    this.props.commonActions.getNoteSettingsInfo().then(res => {
+      if (res.status === 200) {
+        this.formRef.current.setFieldValue('notes', res.data.defaultNotes, true);
+        this.formRef.current.setFieldValue('footNote', res.data.defaultFootNotes, true);
+      }
+    });
+  };
+  initializeData = () => {
+    this.props.expenseCreateActions.getPaytoList();
+    this.props.expenseActions.getVatList();
+    this.props.expenseActions.getExpenseCategoriesList();
+    this.props.commonActions.getCurrencyConversionList().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        this.setState({
+          initValue: {
+            ...this.state.initValue,
+            ...{
+              currency: action.payload ? parseInt(action.payload[0].currencyCode) : '',
+            },
+          },
+        });
+      }
+    });
+    this.props.expenseActions.getBankList();
+    this.props.expenseActions.getPaymentMode();
+    this.props.expenseActions.getUserForDropdown();
+    this.getCompanyCurrency();
+    this.getTaxTreatmentList();
+    this.getcurentCompanyUser();
+  };
+  getcurentCompanyUser = () => {
+    this.props.expenseCreateActions.checkAuthStatus().then(response => {
+      let userStateName = response.data.company.companyStateCode.stateName
+        ? response.data.company.companyStateCode.stateName
+        : '';
+      let isDesignatedZone = response.data.company.isDesignatedZone
+        ? response.data.company.isDesignatedZone
+        : false;
+
+      this.setState({
+        userStateName: userStateName,
+        isDesignatedZone: isDesignatedZone,
+        isRegisteredVat: response.data.company.isRegisteredVat,
+        companyVATRegistrationDate: new Date(response.data.company.vatRegistrationDate),
+      });
+    });
+  };
+  getTaxTreatmentList = () => {
+    this.props.expenseActions
+      .getTaxTreatment()
+      .then(res => {
+        if (res.status === 200) {
+          this.setState({ taxTreatmentList: res.data });
+        }
+      })
+      .catch(err => {
+        this.setState({ disabled: false });
+        this.props.commonActions.tostifyAlert('error', err.data ? err.data.message : 'ERROR');
+      });
+  };
+  handleSubmit = (data, resetForm) => {
+    this.setState({
+      disabled: true,
+      disableLeavePage: true,
+    });
+    const {
+      expenseNumber,
+      payee,
+      placeOfSupplyId,
+      expenseDate,
+      currencyCode,
+      project,
+      expenseCategory,
+      expenseAmount,
+      exchangeRate,
+      employee,
+      expenseDescription,
+      receiptNumber,
+      // attachmentFile,
+      receiptAttachmentDescription,
+      vatCategoryId,
+      payMode,
+      bankAccountId,
+      exclusiveVat,
+      taxTreatmentId,
+      expenseType,
+      notes,
+      footNote,
+    } = data;
+    let formData = new FormData();
+
+    formData.append('isVatClaimable', this.state.isVatClaimable);
+
+    formData.append('delivaryNotes', notes);
+    formData.append('footNote', footNote ? footNote : '');
+    formData.append('expenseNumber', expenseNumber ? expenseNumber : '');
+    if (payee) formData.append('payee', payee.value ? payee.value : '');
+    formData.append('expenseDate', expenseDate !== null ? expenseDate : '');
+    formData.append('expenseDescription', expenseDescription);
+    formData.append('receiptNumber', receiptNumber);
+    formData.append('receiptAttachmentDescription', receiptAttachmentDescription);
+    formData.append('expenseAmount', expenseAmount);
+    formData.append(
+      'payMode',
+      payee?.value === 'Company Expense' || payee === 'Company Expense'
+        ? payMode?.value
+          ? payMode.value
+          : payMode
+        : ''
+    );
+    if (expenseCategory && expenseCategory.value) {
+      formData.append('expenseCategory', expenseCategory.value);
+    }
+    if (employee && employee.value) {
+      formData.append('employeeId', employee.value);
+    }
+    if (placeOfSupplyId) {
+      formData.append(
+        'placeOfSupplyId',
+        placeOfSupplyId.value ? placeOfSupplyId.value : placeOfSupplyId
+      );
+    }
+    if (!this.state.isRegisteredVat) {
+      formData.append('taxTreatmentId', '');
+      formData.append('vatCategoryId', 10);
+      // formData.append("isReverseChargeEnabled",'')
+      // formData.append('expenseType', '' );
+      formData.append('isReverseChargeEnabled', false);
+      formData.append('expenseType', false);
+    } else {
+      if (this.state.isRegisteredVat && taxTreatmentId) {
+        formData.append(
+          'taxTreatmentId',
+          taxTreatmentId.value ? taxTreatmentId.value : taxTreatmentId
+        );
+      }
+      if (vatCategoryId) {
+        formData.append('vatCategoryId', vatCategoryId.value ? vatCategoryId.value : vatCategoryId);
+        if (this.state.exclusiveVat !== undefined) {
+          formData.append('exclusiveVat', this.state.exclusiveVat);
+        }
+      }
+      formData.append('isReverseChargeEnabled', this.state.isReverseChargeEnabled);
+      formData.append('expenseType', this.state.expenseType);
+    }
+    if (exchangeRate) {
+      formData.append('exchangeRate', exchangeRate);
+    }
+    formData.append('currencyCode', currencyCode ? (currencyCode.value ?? currencyCode) : '');
+
+    if (bankAccountId && bankAccountId.value && payMode.value === 'BANK') {
+      formData.append('bankAccountId', bankAccountId.value);
+    }
+    if (project && project.value) {
+      formData.append('projectId', project.value);
+    }
+    if (this.uploadFile?.files?.[0]) {
+      formData.append('attachmentFile', this.uploadFile?.files?.[0]);
+    }
+    this.setState({ loading: true, loadingMsg: 'Creating Expense...' });
+    this.props.expenseCreateActions
+      .createExpense(formData)
+      .then(res => {
+        if (res.status === 200) {
+          this.props.commonActions.tostifyAlert(
+            'success',
+            res.data ? res.data.message : 'Expense Created Successfully'
+          );
+          if (this.state.createMore) {
+            resetForm(this.state.initValue);
+            this.setState({
+              createMore: false,
+              loading: false,
+              disableLeavePage: false,
+              expenseDateForVatValidation: new Date(),
+              disabled: false,
+            });
+            this.getExpenseNumber();
+          } else {
+            this.props.history.push('/admin/expense/expense');
+            this.setState({ disabled: false, loading: false });
+          }
+        }
+      })
+      .catch(err => {
+        this.setState({ disabled: false, loading: false });
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err.data ? err.data.message : 'Expense Created Unsuccessfully'
+        );
+      });
+  };
+
+  getCompanyCurrency = basecurrency => {
+    this.props.currencyConvertActions
+      .getCompanyCurrency()
+      .then(res => {
+        if (res.status === 200) {
+          this.setState({ basecurrency: res.data });
+        }
+      })
+      .catch(err => {
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err && err.data ? err.data.message : 'Something Went Wrong'
+        );
+        this.setState({ loading: false });
+      });
+  };
+  setExchange = value => {
+    if (this.props.currency_convert_list) {
+      let result = this.props.currency_convert_list.filter(obj => {
+        return obj.currencyCode === value;
+      });
+      if (result && result[0] && result[0].exchangeRate)
+        this.formRef.current.setFieldValue('exchangeRate', result[0].exchangeRate, true);
+    }
+  };
+
+  setCurrency = value => {
+    if (this.props.currency_convert_list) {
+      let result = this.props.currency_convert_list.filter(obj => {
+        return obj.currencyCode === value;
+      });
+      if (result[0] && result[0].currencyName) {
+        this.formRef.current.setFieldValue('currencyName', result[0].currencyName, true);
+      }
+    }
+  };
+
+  handleFileChange = (e, props) => {
+    e.preventDefault();
+    let reader = new FileReader();
+    let file = e.target.files[0];
+    if (file) {
+      reader.onloadend = () => {};
+      reader.readAsDataURL(file);
+      props.setFieldValue('attachmentFile', file, true);
+    }
+  };
+  getExpenseNumber = () => {
+    this.props.expenseCreateActions.getExpenseNumber().then(res => {
+      if (res.status === 200) {
+        this.setState({
+          initValue: {
+            ...this.state.initValue,
+            ...{ expenseNumber: res.data },
+          },
+        });
+
+        if (res.data && res.data != null) {
+          this.formRef.current.setFieldValue('expenseNumber', res.data, true, true);
+          this.expenseValidationCheck(res.data);
+        }
+        // this.validationCheck(res.data)
+      }
+    });
+  };
+
+  expenseValidationCheck = value => {
+    const data = {
+      moduleType: 18,
+      name: value,
+    };
+    this.props.expenseCreateActions.checkExpenseCodeValidation(data).then(response => {
+      if (response.data === 'Expense Number Already Exists') {
+        this.setState(
+          {
+            exist: true,
+          },
+
+          () => {}
+        );
+      } else {
+        this.setState({
+          exist: false,
+        });
+      }
+    });
+  };
+  placelistSetting = (option, props) => {
+    this.setState({ showPlacelist: true, lockPlacelist: false });
+    if (option?.value === 6)
+      this.setState({
+        placelist: [
+          { label: 'Abu Dhabi', value: '1' },
+          { label: 'Dubai', value: '2' },
+          { label: 'Sharjah', value: '3' },
+          { label: 'Ajman', value: '4' },
+          { label: 'Umm Al Quwain', value: '5' },
+          { label: 'Ras Al-Khaimah', value: '6' },
+          { label: 'Fujairah', value: '7' },
+          { label: 'BAHRAIN', value: '8' },
+          { label: 'SAUDI ARABIA', value: '9' },
+          { label: 'OMAN', value: '10' },
+          { label: 'KUWAIT', value: '11' },
+          { label: 'QATAR', value: '12' },
+        ],
+      });
+    else if (option?.value === 5)
+      this.setState({
+        placelist: [
+          { label: 'Abu Dhabi', value: '1' },
+          { label: 'Dubai', value: '2' },
+          { label: 'Sharjah', value: '3' },
+          { label: 'Ajman', value: '4' },
+          { label: 'Umm Al Quwain', value: '5' },
+          { label: 'Ras Al-Khaimah', value: '6' },
+          { label: 'Fujairah', value: '7' },
+          { label: 'BAHRAIN', value: '8' },
+          { label: 'SAUDI ARABIA', value: '9' },
+          { label: 'OMAN', value: '10' },
+          // { label: 'KUWAIT', value: '11' },
+          // { label: 'QATAR', value: '12' },
+        ],
+      });
+    else if (option?.value === 8) {
+      if (props) props.handleChange('placeOfSupplyId')('');
+      else this.formRef.current.setFieldValue('placeOfSupplyId', '', true);
+      this.setState({ showPlacelist: false });
+    } else if (option?.value === 7) {
+      let placeOfSupplyId = this.state.placelist.find(
+        option => option.label === this.state.userStateName
+      );
+      if (props) props.handleChange('placeOfSupplyId')(placeOfSupplyId);
+      else this.formRef.current.setFieldValue('placeOfSupplyId', placeOfSupplyId, true);
+      this.setState({ lockPlacelist: true });
+    } else
+      this.setState({
+        placelist: [
+          { label: 'Abu Dhabi', value: '1' },
+          { label: 'Dubai', value: '2' },
+          { label: 'Sharjah', value: '3' },
+          { label: 'Ajman', value: '4' },
+          { label: 'Umm Al Quwain', value: '5' },
+          { label: 'Ras Al-Khaimah', value: '6' },
+          { label: 'Fujairah', value: '7' },
+          // { label: 'BAHRAIN', value: '8' },
+          // { label: 'SAUDI ARABIA', value: '9' },
+          // { label: 'OMAN', value: '10' },
+          // { label: 'KUWAIT', value: '11' },
+          // { label: 'QATAR', value: '12' },
+        ],
+      });
+  };
+
+  ReverseChargeSetting = (option, props) => {
+    if (this.state.isDesignatedZone == true) {
+      if ((option >= 1 && option <= 4) || option === 8) {
+        this.setState({
+          showReverseCharge: false,
+        });
+      } else {
+        this.setState({
+          showReverseCharge: true,
+        });
+      }
+    }
+    // switch(option){
+
+    // 	case 1:
+    // 	case 2:
+    // 	case 3:
+    // 	case 4:
+    // 	case 8:
+    // 	this.setState({
+    // 		showReverseCharge:false,
+    // 	})
+    // 	break;
+
+    // 	case 5:
+    // 	case 6:
+    // 	case 7:
+    // 	this.setState({
+    // 		showReverseCharge:true,
+    // 	})
+    // 	break;
+
+    // }
+    else {
+      //Not Designated Zone
+      if (this.state.isDesignatedZone == false) {
+        if (option === 3 || option === 8) {
+          this.setState({
+            showReverseCharge: false,
+          });
+        } else {
+          this.setState({
+            showReverseCharge: true,
+          });
+        }
+        // switch(option.value){
+
+        // 	case 1:
+        // 	case 2:
+        // 	case 4:
+        // 	case 5:
+        // 	case 6:
+        // 	case 7:
+        // 	this.setState({
+        // 		showReverseCharge:true,
+        // 	})
+        // 			break;
+
+        // 	case 3:
+        // 	case 8:
+        // 	this.setState({
+        // 		showReverseCharge:false,
+        // 	})
+        // 			break;
+      }
+    }
+  };
+
+  renderVat = props => {
+    let vat_list = [];
+    let vatIds = [];
+    if (
+      this.state.isRegisteredVat &&
+      this.state.expenseDateForVatValidation > this.state.companyVATRegistrationDate
+    ) {
+      if (
+        this.state.isDesignatedZone &&
+        this.state.isDesignatedZone != null &&
+        this.state.isDesignatedZone == true
+      ) {
+        switch (
+          props.values.taxTreatmentId && props.values.taxTreatmentId.value
+            ? props.values.taxTreatmentId.value
+            : ''
+        ) {
+          case 1:
+          case 3:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [1, 2, 3];
+
+            break;
+
+          case 2:
+          case 4:
+          case 8:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [4];
+
+            break;
+
+          case 5:
+          case 6:
+          case 7:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [3];
+            else if (this.state.isReverseChargeEnabled == true) vatIds = [1, 2];
+            break;
+
+          case 8:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [4];
+
+            break;
+        }
+      } else if (this.state.isDesignatedZone == false)
+        //Not Designated Zone
+        switch (
+          props.values.taxTreatmentId && props.values.taxTreatmentId.value
+            ? props.values.taxTreatmentId.value
+            : ''
+        ) {
+          case 1:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [1, 2, 3];
+            else if (this.state.isReverseChargeEnabled == true) vatIds = [1, 2];
+            break;
+
+          case 3:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [1, 2, 3];
+
+            break;
+
+          case 2:
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [3];
+            else if (this.state.isReverseChargeEnabled == true) vatIds = [1, 2];
+            break;
+
+          case 8:
+            if (this.state.isReverseChargeEnabled == false) vatIds = [4];
+
+            break;
+        }
+    } else {
+      vatIds = [10];
+    }
+
+    vat_list = this.getVatListByIds(vatIds);
+    //vat column
+    return (
+      <Col lg={3}>
+        <FormGroup className="mb-3">
+          <Label htmlFor="vatCategoryId">
+            <span className="text-danger">* </span>
+            {strings.VAT}
+          </Label>
+          <Select
+            // styles={customStyles}
+            // className="select-default-width"
+
+            options={
+              vat_list ? selectOptionsFactory.renderOptions('name', 'id', vat_list, 'VAT') : []
+            }
+            value={props.values.vatCategoryId}
+            onChange={option => {
+              if (option && option.value) {
+                props.handleChange('vatCategoryId')(option);
+              } else {
+                props.handleChange('vatCategoryId')('');
+              }
+            }}
+            placeholder={strings.Select + strings.VAT}
+            id="vatCategoryId"
+            name="vatCategoryId"
+            className={
+              props.errors.vatCategoryId && props.touched.vatCategoryId ? 'is-invalid' : ''
+            }
+          />
+          {props.errors.vatCategoryId && props.touched.vatCategoryId && (
+            <div className="invalid-feedback">{props.errors.vatCategoryId}</div>
+          )}
+        </FormGroup>
+      </Col>
+    );
+  };
+  getVatListByIds = vatIds => {
+    const { vat_list } = this.props;
+
+    let array = [];
+
+    vat_list.map(row => {
+      vatIds.map(id => {
+        if (row.id === id) {
+          array.push(row);
+        }
+      });
+    });
+    if (vatIds[0] === 10) {
+      array.push({
+        id: 10,
+        vat: 0,
+        name: 'N/A',
+      });
+    }
+
+    return array;
+  };
+
+  //added by mudassar to unmount the asyn call
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  render() {
+    strings.setLanguage(this.state.language);
+    const {
+      initValue,
+      payMode,
+      exist,
+      taxTreatmentList,
+      placelist,
+      vat_list,
+      loading,
+      loadingMsg,
+    } = this.state;
+    const {
+      // currency_list,
+      expense_categories_list,
+      expense_categories_list_Sorted,
+      // vat_list,
+      // profile,
+      // user_list,
+      pay_mode_list,
+      bank_list,
+      currency_convert_list,
+      pay_to_list,
+    } = this.props;
+    const customStyles = {
+      control: (base, state) => ({
+        ...base,
+        borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+        boxShadow: state.isFocused ? null : null,
+        '&:hover': {
+          borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+        },
+      }),
+    };
+    return loading == true ? (
+      <Loader loadingMsg={loadingMsg} />
+    ) : (
+      <div>
+        <div className="create-expense-screen">
+          <div className="animated fadeIn">
+            <Row>
+              <Col lg={12} className="mx-auto">
+                <Card>
+                  <CardHeader>
+                    <Row>
+                      <Col lg={12}>
+                        <div className="h4 mb-0 d-flex align-items-center">
+                          <i className="fab fa-stack-exchange" />
+                          <span className="ml-2">{strings.CreateExpense} </span>
+                        </div>
+                      </Col>
+                    </Row>
+                  </CardHeader>
+                  <CardBody>
+                    {loading ? (
+                      <Row>
+                        <Col lg={12}>
+                          <Loader />
+                        </Col>
+                      </Row>
+                    ) : (
+                      <Row>
+                        <Col lg={12}>
+                          <Formik
+                            initialValues={initValue}
+                            ref={this.formRef}
+                            onSubmit={(values, { resetForm }) => {
+                              this.handleSubmit(values, resetForm);
+
+                              // this.setState({
+                              //   selectedCurrency: null,
+                              //   selectedProject: null,
+                              //   selectedBankAccount: null,
+                              //   selectedCustomer: null
+
+                              // })
+                            }}
+                            validate={values => {
+                              let errors = {};
+                              // if (
+                              // 	values.payMode.value === 'BANK' &&
+                              // 	!values.bankAccountId
+                              // ) {
+                              // 	errors.bankAccountId = 'Bank account is required';
+                              // }
+                              if (values.payee.value === 'Company Expense') {
+                                if (values.payMode.value != 'CASH') {
+                                  errors.payMode = 'Pay through is required';
+                                }
+                              }
+                              // if(values.payMode.value === "CASH"){
+                              // 	errors.payMode = 'Pay through is required'
+                              // }
+
+                              if (values.expenseNumber && exist === true) {
+                                errors.expenseNumber = 'Expense number already exists';
+                              }
+                              if (
+                                this.state.isRegisteredVat &&
+                                !values.vatCategoryId &&
+                                values.expenseCategory &&
+                                values.expenseCategory.value !== 34
+                              ) {
+                                errors.vatCategoryId = strings.VATIsRequired;
+                              }
+                              if (
+                                this.state.isRegisteredVat &&
+                                !values.taxTreatmentId &&
+                                values.expenseCategory &&
+                                values.expenseCategory.value !== 34
+                              ) {
+                                errors.taxTreatmentId = strings.TaxTreatmentRequired;
+                              }
+                              if (
+                                !values.placeOfSupplyId &&
+                                values.taxTreatmentId.value !== 8 &&
+                                this.state.showPlacelist == true
+                              ) {
+                                errors.placeOfSupplyId = 'Place of supply is required';
+                              }
+                              return errors;
+                            }}
+                            validationSchema={Yup.object().shape({
+                              expenseNumber: Yup.string().required(strings.Expense_Number_Required),
+                              expenseCategory: Yup.string().required(
+                                strings.Expense_Category_Required
+                              ),
+                              expenseDate: Yup.date().required('Expense date is required'),
+                              currencyCode: Yup.string().required(strings.CurrencyIsRequired),
+                              payee: Yup.string().required(strings.PaidByRequired),
+                              expenseAmount: Yup.string()
+                                .required(strings.AmountIsRequired)
+                                .matches(/^[0-9][0-9]*[.]?[0-9]{0,2}$$/, 'Enter a valid amount')
+                                .test(
+                                  'Expense Amount',
+                                  'Expense amount should be greater than 1',
+                                  value => {
+                                    if (value > 0) {
+                                      return true;
+                                    } else {
+                                      return false;
+                                    }
+                                  }
+                                ),
+
+                              payMode: Yup.string().required(strings.PayThroughIsRequired),
+                              attachmentFile: Yup.mixed()
+                                .test('fileType', '*Unsupported File Format', value => {
+                                  value &&
+                                    this.setState({
+                                      fileName: value.name,
+                                    });
+                                  if (
+                                    !value ||
+                                    (value && this.supported_format.includes(value.type))
+                                  ) {
+                                    return true;
+                                  } else {
+                                    return false;
+                                  }
+                                })
+                                .test('fileSize', '*File Size is too large', value => {
+                                  if (!value || (value && value.size <= this.file_size)) {
+                                    return true;
+                                  } else {
+                                    return false;
+                                  }
+                                }),
+                            })}
+                          >
+                            {props => (
+                              <Form onSubmit={props.handleSubmit}>
+                                <Row>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="expenseNumber">
+                                        <span className="text-danger">* </span>
+                                        {strings.ExpenseNumber}
+                                        {/* <i
 																				id="ProductCodeTooltip"
 																				className="fa fa-question-circle ml-1"
 																			></i>
@@ -1106,626 +1087,661 @@ class CreateExpense extends React.Component {
 																				Product Code - Unique identifier code
 																				for the product
 																			</UncontrolledTooltip> */}
-																				</Label>
-																				<Input
-																					type="text"
-																					maxLength="50"
-																					id="expenseNumber"
-																					name="expenseNumber"
-																					placeholder={strings.Enter + " Expense Number"}
-																					onChange={(option) => {
-																						if (
-																							option.target.value === '' ||
-																							this.regExInvNum.test(
-																								option.target.value,
-																							)
-																						) {
-																							props.handleChange('expenseNumber')(
-																								option,
-																							);
-																						}
-																						this.expenseValidationCheck(
-																							option.target.value,
-																						);
-																					}}
-																					// onBlur={handleBlur}
-																					value={props.values.expenseNumber}
-																					className={
-																						props.errors.expenseNumber &&
-																							props.touched.expenseNumber
-																							? 'is-invalid'
-																							: ''
-																					}
-																				/>
-																				{props.errors.expenseNumber &&
-																					props.touched.expenseNumber && (
-																						<div className="invalid-feedback">
-																							{props.errors.expenseNumber}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="expenseCategoryId">
-																					<span className="text-danger">* </span>
-																					{strings.ExpenseCategory}
-																				</Label>
-																				<Select
-																					options={
-																						expense_categories_list && expense_categories_list_Sorted
-																							? expense_categories_list_Sorted
-																							: []
-																					}
-																					value={props.values.expenseCategory}
-																					onChange={(option) => {
-																						if (option && option.value) {
-																							props.handleChange('expenseCategory')(option,);
-																							if (option.value === 34) {
-																								props.handleChange('payee')({ label: 'Company Expense', value: 'Company Expense' });
-																								props.handleChange('taxTreatmentId')('');
-																								props.handleChange('vatCategoryId')('');
-																								props.handleChange('placeOfSupplyId')('');
-																								this.setState({ showPlacelist: false })
-																							}
-																						} else {
-																							props.handleChange('expenseCategory')('');
-																						}
-																					}}
-																					placeholder={strings.Select + strings.ExpenseCategory}
-																					id="expenseCategory"
-																					name="expenseCategory"
+                                      </Label>
+                                      <Input
+                                        type="text"
+                                        maxLength="50"
+                                        id="expenseNumber"
+                                        name="expenseNumber"
+                                        placeholder={strings.Enter + ' Expense Number'}
+                                        onChange={option => {
+                                          if (
+                                            option.target.value === '' ||
+                                            this.regExInvNum.test(option.target.value)
+                                          ) {
+                                            props.handleChange('expenseNumber')(option);
+                                          }
+                                          this.expenseValidationCheck(option.target.value);
+                                        }}
+                                        // onBlur={handleBlur}
+                                        value={props.values.expenseNumber}
+                                        className={
+                                          props.errors.expenseNumber && props.touched.expenseNumber
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.expenseNumber &&
+                                        props.touched.expenseNumber && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.expenseNumber}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="expenseCategoryId">
+                                        <span className="text-danger">* </span>
+                                        {strings.ExpenseCategory}
+                                      </Label>
+                                      <Select
+                                        options={
+                                          expense_categories_list && expense_categories_list_Sorted
+                                            ? expense_categories_list_Sorted
+                                            : []
+                                        }
+                                        value={props.values.expenseCategory}
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('expenseCategory')(option);
+                                            if (option.value === 34) {
+                                              props.handleChange('payee')({
+                                                label: 'Company Expense',
+                                                value: 'Company Expense',
+                                              });
+                                              props.handleChange('taxTreatmentId')('');
+                                              props.handleChange('vatCategoryId')('');
+                                              props.handleChange('placeOfSupplyId')('');
+                                              this.setState({ showPlacelist: false });
+                                            }
+                                          } else {
+                                            props.handleChange('expenseCategory')('');
+                                          }
+                                        }}
+                                        placeholder={strings.Select + strings.ExpenseCategory}
+                                        id="expenseCategory"
+                                        name="expenseCategory"
+                                        className={
+                                          props.errors.expenseCategory &&
+                                          props.touched.expenseCategory
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                        // onChange={(option) =>
+                                        // 	props.handleChange('expenseCategory')(
+                                        // 		option,
+                                        // 	)
+                                        // }
+                                      />
+                                      {props.errors.expenseCategory &&
+                                        props.touched.expenseCategory && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.expenseCategory}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="expense_date">
+                                        <span className="text-danger">* </span>
+                                        {strings.ExpenseDate}
+                                      </Label>
+                                      <DatePicker
+                                        id="date"
+                                        name="expenseDate"
+                                        className={`form-control ${
+                                          props.errors.expenseDate && props.touched.expenseDate
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
+                                        placeholderText={strings.ExpenseDate}
+                                        selected={props.values.expenseDate}
+                                        value={props.values.expenseDate}
+                                        showMonthDropdown
+                                        showYearDropdown
+                                        dropdownMode="select"
+                                        dateFormat="dd-MM-yyyy"
+                                        //minDate={new Date()}
+                                        onChange={value => {
+                                          if (
+                                            (this.state.expenseDateForVatValidation <
+                                              this.state.companyVATRegistrationDate &&
+                                              value > this.state.companyVATRegistrationDate) ||
+                                            (value < this.state.companyVATRegistrationDate &&
+                                              this.state.expenseDateForVatValidation >
+                                                this.state.companyVATRegistrationDate)
+                                          ) {
+                                            props.handleChange('vatCategoryId')('');
+                                          }
+                                          this.setState({ expenseDateForVatValidation: value });
+                                          props.handleChange('expenseDate')(value);
+                                        }}
+                                      />
+                                      {props.errors.expenseDate && props.touched.expenseDate && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.expenseDate.includes('final value was:')
+                                            ? strings.ExpenseDateRequired
+                                            : props.errors.expenseDate}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  {this.state.isRegisteredVat &&
+                                    props.values.expenseCategory &&
+                                    (props.values?.expenseCategory?.value
+                                      ? props.values?.expenseCategory?.value !== 34
+                                      : props.values?.expenseCategory !== 34) && (
+                                      <Col lg={3}>
+                                        <FormGroup className="mb-3">
+                                          <Label htmlFor="taxTreatmentId">
+                                            <span className="text-danger">* </span>
+                                            {strings.TaxTreatment}
+                                          </Label>
+                                          <Select
+                                            options={
+                                              taxTreatmentList
+                                                ? selectOptionsFactory.renderOptions(
+                                                    'name',
+                                                    'id',
+                                                    taxTreatmentList,
+                                                    'Tax Treatment'
+                                                  )
+                                                : []
+                                            }
+                                            id="taxTreatmentId"
+                                            name="taxTreatmentId"
+                                            placeholder={strings.Select + strings.TaxTreatment}
+                                            value={props.values.taxTreatmentId}
+                                            onChange={option => {
+                                              // this.setState({
+                                              //   selectedVatCategory: option.value
+                                              // })
+                                              if (option && option.value) {
+                                                props.handleChange('taxTreatmentId')(option);
+                                                props.handleChange('placeOfSupplyId')('');
+                                                // for resetting Vat
+                                                props.handleChange('vatCategoryId')('');
+                                                //placelist Setup
+                                                this.placelistSetting(option, props);
+                                                // ReverseCharge setup
+                                                this.ReverseChargeSetting(option.value, props);
+                                                this.setState({
+                                                  isReverseChargeEnabled: false,
+                                                  exclusiveVat: true,
+                                                });
+                                                this.setState({ taxTreatmentId: option.value });
+                                              } else {
+                                                props.handleChange('taxTreatmentId')('');
+                                              }
+                                            }}
+                                            className={
+                                              props.errors.taxTreatmentId &&
+                                              props.touched.taxTreatmentId
+                                                ? 'is-invalid'
+                                                : ''
+                                            }
+                                          />
+                                          {props.errors.taxTreatmentId &&
+                                            props.touched.taxTreatmentId && (
+                                              <div className="invalid-feedback">
+                                                {props.errors.taxTreatmentId}
+                                              </div>
+                                            )}
+                                        </FormGroup>
+                                      </Col>
+                                    )}
+                                  {this.state.showPlacelist == true &&
+                                    props.values.expenseCategory &&
+                                    (props.values?.expenseCategory?.value
+                                      ? props.values?.expenseCategory?.value !== 34
+                                      : props.values?.expenseCategory !== 34) && (
+                                      <Col lg={3}>
+                                        <FormGroup className="mb-3">
+                                          <Label htmlFor="placeOfSupplyId">
+                                            <span className="text-danger">*</span>
+                                            {strings.PlaceofSupply}
+                                          </Label>
+                                          <Select
+                                            isDisabled={this.state.lockPlacelist}
+                                            id="placeOfSupplyId"
+                                            name="placeOfSupplyId"
+                                            placeholder={strings.Select + strings.PlaceofSupply}
+                                            options={
+                                              placelist
+                                                ? selectOptionsFactory.renderOptions(
+                                                    'label',
+                                                    'value',
+                                                    placelist,
+                                                    'Place Of Supply'
+                                                  )
+                                                : []
+                                            }
+                                            value={props.values.placeOfSupplyId}
+                                            className={
+                                              props.errors.placeOfSupplyId &&
+                                              props.touched.placeOfSupplyId
+                                                ? 'is-invalid'
+                                                : ''
+                                            }
+                                            onChange={option => {
+                                              if (option.value != '')
+                                                props.handleChange('placeOfSupplyId')(option);
+                                              else props.handleChange('placeOfSupplyId')('');
+                                            }}
+                                          />
+                                          {props.errors.placeOfSupplyId &&
+                                            props.touched.placeOfSupplyId && (
+                                              <div className="invalid-feedback">
+                                                {props.errors.placeOfSupplyId}
+                                              </div>
+                                            )}
+                                        </FormGroup>
+                                      </Col>
+                                    )}
+                                  {this.state.isRegisteredVat &&
+                                    props.values.expenseCategory &&
+                                    (props.values?.expenseCategory?.value
+                                      ? props.values?.expenseCategory?.value !== 34
+                                      : props.values?.expenseCategory !== 34) && (
+                                      <Col className="mb-2" lg={3}>
+                                        <Label htmlFor="inline-radio3">
+                                          <span className="text-danger">* </span>
+                                          {strings.ExpenseType}
+                                        </Label>
+                                        <div style={{ display: 'flex' }}>
+                                          {this.state.isVatClaimable === false ? (
+                                            <span style={{ color: '#0069d9' }} className="mr-4">
+                                              <b>{strings.NonClaimable}</b>
+                                            </span>
+                                          ) : (
+                                            <span className="mr-4">{strings.NonClaimable}</span>
+                                          )}
 
-																					className={
-																						props.errors.expenseCategory &&
-																							props.touched.expenseCategory
-																							? 'is-invalid'
-																							: ''
-																					}
-																				// onChange={(option) =>
-																				// 	props.handleChange('expenseCategory')(
-																				// 		option,
-																				// 	)
-																				// }
-																				/>
-																				{props.errors.expenseCategory &&
-																					props.touched.expenseCategory && (
-																						<div className="invalid-feedback">
-																							{props.errors.expenseCategory}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="expense_date">
-																					<span className="text-danger">* </span>
-																					{strings.ExpenseDate}
-																				</Label>
-																				<DatePicker
-																					id="date"
-																					name="expenseDate"
-																					className={`form-control ${props.errors.expenseDate &&
-																						props.touched.expenseDate
-																						? 'is-invalid'
-																						: ''
-																						}`}
-																					placeholderText={strings.ExpenseDate}
-																					selected={props.values.expenseDate}
-																					value={props.values.expenseDate}
-																					showMonthDropdown
-																					showYearDropdown
-																					dropdownMode="select"
-																					dateFormat="dd-MM-yyyy"
-																					//minDate={new Date()}
-																					onChange={(value) => {
-																						if ((this.state.expenseDateForVatValidation < this.state.companyVATRegistrationDate && value > this.state.companyVATRegistrationDate) || (value < this.state.companyVATRegistrationDate && this.state.expenseDateForVatValidation > this.state.companyVATRegistrationDate)) {
-																							props.handleChange('vatCategoryId')('');
-																						}
-																						this.setState({ expenseDateForVatValidation: value });
-																						props.handleChange('expenseDate')(value);
-																					}}
-																				/>
-																				{props.errors.expenseDate &&
-																					props.touched.expenseDate && (
-																						<div className="invalid-feedback">
-																							{props.errors.expenseDate.includes("final value was:") ? strings.ExpenseDateRequired : props.errors.expenseDate}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
+                                          <Switch
+                                            checked={this.state.isVatClaimable}
+                                            onChange={expenseType => {
+                                              props.handleChange('expenseType')(expenseType);
 
-																	</Row>
-																	<Row>
-																		{this.state.isRegisteredVat && props.values.expenseCategory && (props.values?.expenseCategory?.value ? props.values?.expenseCategory?.value !== 34 : props.values?.expenseCategory !== 34) && (
-																			<Col lg={3}>
-																				<FormGroup className="mb-3">
-																					<Label htmlFor="taxTreatmentId">
-																						<span className="text-danger">* </span>{strings.TaxTreatment}
-																					</Label>
-																					<Select
-																						options={
-																							taxTreatmentList
-																								? selectOptionsFactory.renderOptions(
-																									'name',
-																									'id',
-																									taxTreatmentList,
-																									'Tax Treatment',
-																								)
-																								: []
-																						}
-																						id="taxTreatmentId"
-																						name="taxTreatmentId"
-																						placeholder={strings.Select + strings.TaxTreatment}
-																						value={props.values.taxTreatmentId}
-																						onChange={(option) => {
-																							// this.setState({
-																							//   selectedVatCategory: option.value
-																							// })
-																							if (option && option.value) {
+                                              this.setState({ expenseType }, () => {});
+                                              if (this.state.isVatClaimable === true) {
+                                                this.setState({ isVatClaimable: false });
+                                              } else {
+                                                this.setState({ isVatClaimable: true });
+                                              }
+                                              // if (this.state.expenseType == true)
+                                              // 	this.setState({ expenseType: true })
+                                            }}
+                                            onColor="#2064d8"
+                                            onHandleColor="#2693e6"
+                                            handleDiameter={25}
+                                            uncheckedIcon={false}
+                                            checkedIcon={false}
+                                            boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+                                            activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+                                            height={20}
+                                            width={48}
+                                            className="react-switch"
+                                          />
+                                          {this.state.isVatClaimable === true ? (
+                                            <span style={{ color: '#0069d9' }} className="ml-4">
+                                              <b>{strings.Claimable}</b>
+                                            </span>
+                                          ) : (
+                                            <span className="ml-4">{strings.Claimable}</span>
+                                          )}
+                                        </div>
+                                      </Col>
+                                    )}
 
-																								props.handleChange('taxTreatmentId')(
-																									option,
-																								);
-																								props.handleChange('placeOfSupplyId')('');
-																								// for resetting Vat
-																								props.handleChange('vatCategoryId')('');
-																								//placelist Setup
-																								this.placelistSetting(option, props)
-																								// ReverseCharge setup
-																								this.ReverseChargeSetting(option.value, props)
-																								this.setState({ isReverseChargeEnabled: false, exclusiveVat: true })
-																								this.setState({ taxTreatmentId: option.value })
-																							} else {
-																								props.handleChange('taxTreatmentId')(
-																									'',
-																								);
-																							}
-																						}}
-																						className={
-																							props.errors.taxTreatmentId &&
-																								props.touched.taxTreatmentId
-																								? 'is-invalid'
-																								: ''
-																						}
-																					/>
-																					{props.errors.taxTreatmentId &&
-																						props.touched.taxTreatmentId && (
-																							<div className="invalid-feedback">
-																								{props.errors.taxTreatmentId}
-																							</div>
-																						)}
-																				</FormGroup>
-																			</Col>)}
-																		{this.state.showPlacelist == true && props.values.expenseCategory && (props.values?.expenseCategory?.value ? props.values?.expenseCategory?.value !== 34 : props.values?.expenseCategory !== 34) && (<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="placeOfSupplyId">
-																					<span className="text-danger">*</span>
-																					{strings.PlaceofSupply}
-																				</Label>
-																				<Select
-																					isDisabled={this.state.lockPlacelist}
-																					id="placeOfSupplyId"
-																					name="placeOfSupplyId"
-																					placeholder={strings.Select + strings.PlaceofSupply}
-																					options={
-																						placelist
-																							? selectOptionsFactory.renderOptions(
-																								'label',
-																								'value',
-																								placelist,
-																								'Place Of Supply',
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="payee">
+                                        <span className="text-danger">* </span>
+                                        {strings.PaidBy}
+                                      </Label>
+                                      <Select
+                                        isDisabled={
+                                          props.values?.expenseCategory?.value === 34 ||
+                                          props.values?.expenseCategory === 34
+                                        }
+                                        options={
+                                          pay_to_list
+                                            ? selectOptionsFactory.renderOptions(
+                                                'label',
+                                                'value',
+                                                pay_to_list,
+                                                'Payee'
+                                              )
+                                            : []
+                                        }
+                                        value={props.values.payee}
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('payee')(option);
+                                            this.setState({
+                                              payee: option ? option : option.value,
+                                            });
+                                          } else {
+                                            props.handleChange('payee')('');
+                                          }
+                                        }}
+                                        placeholder={strings.Select + strings.Payee}
+                                        id="payee"
+                                        name="payee"
+                                        className={
+                                          props.errors.payee && props.touched.payee
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.payee && props.touched.payee && (
+                                        <div className="invalid-feedback">{props.errors.payee}</div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="expenseAmount">
+                                        <span className="text-danger">* </span>
+                                        {strings.Amount}
+                                      </Label>
+                                      <Input
+                                        type="text"
+                                        min="0"
+                                        maxLength="14,2"
+                                        name="expenseAmount"
+                                        id="expenseAmount"
+                                        rows="5"
+                                        className={
+                                          props.errors.expenseAmount && props.touched.expenseAmount
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                        onChange={option => {
+                                          if (
+                                            option.target.value === '' ||
+                                            this.regDecimal.test(option.target.value)
+                                          ) {
+                                            props.handleChange('expenseAmount')(option);
+                                          }
+                                        }}
+                                        value={props.values.expenseAmount}
+                                        placeholder={'Enter' + ' ' + strings.Amount}
+                                      />
+                                      {props.errors.expenseAmount &&
+                                        props.touched.expenseAmount && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.expenseAmount}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                  {this.state.isRegisteredVat &&
+                                    props.values.expenseCategory &&
+                                    (props.values?.expenseCategory?.value
+                                      ? props.values?.expenseCategory?.value !== 34
+                                      : props.values?.expenseCategory !== 34) &&
+                                    this.renderVat(props)}
+                                  <Col lg={3}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="currencyCode">
+                                        <span className="text-danger">* </span>
+                                        {strings.Currency}
+                                      </Label>
+                                      <Select
+                                        id="currencyCode"
+                                        name="currencyCode"
+                                        // styles={customStyles}
+                                        options={
+                                          currency_convert_list
+                                            ? selectCurrencyFactory.renderOptions(
+                                                'currencyName',
+                                                'currencyCode',
+                                                currency_convert_list,
+                                                'Currency'
+                                              )
+                                            : []
+                                        }
+                                        placeholder={strings.Select + strings.Currency}
+                                        value={
+                                          props.values.currencyCode?.value
+                                            ? props.values.currencyCode
+                                            : currency_convert_list &&
+                                              selectCurrencyFactory
+                                                .renderOptions(
+                                                  'currencyName',
+                                                  'currencyCode',
+                                                  currency_convert_list,
+                                                  'Currency'
+                                                )
+                                                .find(
+                                                  obj => obj.value === props.values.currencyCode
+                                                )
+                                        }
+                                        onChange={option => {
+                                          if (option.value != '') {
+                                            props.handleChange('currencyCode')(option);
+                                            this.setExchange(option.value);
+                                            this.setCurrency(option.value);
+                                          }
+                                        }}
+                                        className={
+                                          props.errors.currencyCode && props.touched.currencyCode
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.currencyCode && props.touched.currencyCode && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.currencyCode}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                  {(props.values?.payee?.value === 'Company Expense' ||
+                                    props.values?.payee === 'Company Expense') && (
+                                    <Col lg={3}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="payMode">
+                                          <span className="text-danger">* </span>{' '}
+                                          {strings.PayThrough}
+                                        </Label>
+                                        <Select
+                                          options={
+                                            pay_mode_list
+                                              ? selectOptionsFactory.renderOptions(
+                                                  'label',
+                                                  'value',
+                                                  pay_mode_list,
+                                                  'Pay Through'
+                                                )
+                                              : []
+                                          }
+                                          value={props.values.payMode}
+                                          onChange={option => {
+                                            if (option && option.value) {
+                                              props.handleChange('payMode')(option);
+                                            } else {
+                                              props.handleChange('payMode')('');
+                                            }
+                                          }}
+                                          placeholder={strings.Select + strings.PayThrough}
+                                          id="payMode"
+                                          name="payMode"
+                                          className={
+                                            props.errors.payMode && props.touched.payMode
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                        />
+                                        {props.errors.payMode && props.touched.payMode && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.payMode}
+                                          </div>
+                                        )}
+                                      </FormGroup>
+                                    </Col>
+                                  )}
+                                </Row>
 
-																							)
-																							: []
-																					}
-																					value={props.values.placeOfSupplyId}
-																					className={
-																						props.errors.placeOfSupplyId &&
-																							props.touched.placeOfSupplyId
-																							? 'is-invalid'
-																							: ''
-																					}
-																					onChange={(option) => {
-																						if (option.value != '')
-																							props.handleChange('placeOfSupplyId')(option);
-																						else
-																							props.handleChange('placeOfSupplyId')('');
-																					}
-																					}
-																				/>
-																				{props.errors.placeOfSupplyId &&
-																					props.touched.placeOfSupplyId && (
-																						<div className="invalid-feedback">
-																							{props.errors.placeOfSupplyId}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>)}
-																		{this.state.isRegisteredVat && props.values.expenseCategory && (props.values?.expenseCategory?.value ? props.values?.expenseCategory?.value !== 34 : props.values?.expenseCategory !== 34) && (
-																			<Col className='mb-2' lg={3}>
-																				<Label htmlFor="inline-radio3"><span className="text-danger">* </span>{strings.ExpenseType}</Label>
-																				<div style={{ display: "flex" }}>
-																					{this.state.isVatClaimable === false ?
-																						<span style={{ color: "#0069d9" }} className='mr-4'><b>{strings.NonClaimable}</b></span> :
-																						<span className='mr-4'>{strings.NonClaimable}</span>}
-
-																					<Switch
-																						checked={this.state.isVatClaimable}
-																						onChange={(expenseType) => {
-																							props.handleChange('expenseType')(expenseType);
-
-																							this.setState({ expenseType, }, () => { },);
-																							if (this.state.isVatClaimable === true) {
-																								this.setState({ isVatClaimable: false });
-																							}
-																							else {
-																								this.setState({ isVatClaimable: true });
-																							}
-																							// if (this.state.expenseType == true)
-																							// 	this.setState({ expenseType: true })
-																						}}
-																						onColor="#2064d8"
-																						onHandleColor="#2693e6"
-																						handleDiameter={25}
-																						uncheckedIcon={false}
-																						checkedIcon={false}
-																						boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
-																						activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
-																						height={20}
-																						width={48}
-																						className="react-switch"
-																					/>
-																					{this.state.isVatClaimable === true ?
-																						<span style={{ color: "#0069d9" }} className='ml-4'><b>{strings.Claimable}</b></span> :
-																						<span className='ml-4'>{strings.Claimable}</span>
-																					}
-																				</div>
-																			</Col>)}
-
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="payee">
-																					<span className="text-danger">* </span>{strings.PaidBy}
-																				</Label>
-																				<Select
-																					isDisabled={props.values?.expenseCategory?.value === 34 || props.values?.expenseCategory === 34}
-																					options={
-																						pay_to_list
-																							? selectOptionsFactory.renderOptions(
-																								'label',
-																								'value',
-																								pay_to_list,
-																								'Payee',
-																							)
-																							: []
-																					}
-																					value={props.values.payee}
-																					onChange={(option) => {
-																						if (option && option.value) {
-																							props.handleChange('payee')(option,);
-																							this.setState({ payee: option ? option : option.value })
-																						} else {
-																							props.handleChange('payee')('');
-																						}
-																					}}
-																					placeholder={strings.Select + strings.Payee}
-																					id="payee"
-																					name="payee"
-																					className={
-																						props.errors.payee &&
-																							props.touched.payee
-																							? 'is-invalid'
-																							: ''
-																					}
-																				/>
-																				{props.errors.payee &&
-																					props.touched.payee && (
-																						<div className="invalid-feedback">
-																							{props.errors.payee}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
-																	</Row>
-																	<Row>
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="expenseAmount">
-																					<span className="text-danger">* </span>{strings.Amount}
-																				</Label>
-																				<Input
-																					type="text"
-																					min="0"
-																					maxLength="14,2"
-																					name="expenseAmount"
-																					id="expenseAmount"
-																					rows="5"
-																					className={
-																						props.errors.expenseAmount &&
-																							props.touched.expenseAmount
-																							? 'is-invalid'
-																							: ''
-																					}
-																					onChange={(option) => {
-																						if (
-																							option.target.value === '' ||
-																							this.regDecimal.test(
-																								option.target.value,
-																							)
-																						) {
-																							props.handleChange('expenseAmount')(
-																								option,
-																							);
-																						}
-																					}}
-																					value={props.values.expenseAmount}
-																					placeholder={"Enter" + " " + strings.Amount}
-																				/>
-																				{props.errors.expenseAmount &&
-																					props.touched.expenseAmount && (
-																						<div className="invalid-feedback">
-																							{props.errors.expenseAmount}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
-																		{this.state.isRegisteredVat && props.values.expenseCategory && (props.values?.expenseCategory?.value ? props.values?.expenseCategory?.value !== 34 : props.values?.expenseCategory !== 34) &&
-																			(this.renderVat(props))
-																		}
-																		<Col lg={3}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="currencyCode">
-																					<span className="text-danger">* </span>
-																					{strings.Currency}
-																				</Label>
-																				<Select
-																					id="currencyCode"
-																					name="currencyCode"
-																					// styles={customStyles}
-																					options={
-																						currency_convert_list
-																							? selectCurrencyFactory.renderOptions(
-																								'currencyName',
-																								'currencyCode',
-																								currency_convert_list,
-																								'Currency',
-																							)
-																							: []
-																					}
-																					placeholder={strings.Select + strings.Currency}
-																					value={props.values.currencyCode?.value ? props.values.currencyCode :
-																						currency_convert_list
-																						&& selectCurrencyFactory.renderOptions(
-																							'currencyName',
-																							'currencyCode',
-																							currency_convert_list,
-																							'Currency',
-																						).find(obj => obj.value === props.values.currencyCode)
-																					}
-																					onChange={(option) => {
-																						if (option.value != "") {
-																							props.handleChange('currencyCode')(option);
-																							this.setExchange(option.value);
-																							this.setCurrency(option.value);
-																						}
-																					}}
-																					className={
-																						props.errors.currencyCode &&
-																							props.touched.currencyCode
-																							? 'is-invalid'
-																							: ''
-																					}
-																				/>
-																				{props.errors.currencyCode &&
-																					props.touched.currencyCode && (
-																						<div className="invalid-feedback">
-																							{props.errors.currencyCode}
-																						</div>
-																					)}
-																			</FormGroup>
-																		</Col>
-																		{(props.values?.payee?.value === 'Company Expense' || props.values?.payee === 'Company Expense') &&
-																			<Col lg={3}>
-																				<FormGroup className="mb-3">
-																					<Label htmlFor="payMode"><span className="text-danger">* </span> {strings.PayThrough}</Label>
-																					<Select
-																						options={
-																							pay_mode_list
-																								? selectOptionsFactory.renderOptions(
-																									'label',
-																									'value',
-																									pay_mode_list,
-																									'Pay Through',
-																								)
-																								: []
-																						}
-																						value={props.values.payMode}
-																						onChange={(option) => {
-																							if (option && option.value) {
-																								props.handleChange('payMode')(option,);
-																							} else {
-																								props.handleChange('payMode')('');
-																							}
-																						}}
-																						placeholder={strings.Select + strings.PayThrough}
-																						id="payMode"
-																						name="payMode"
-																						className={
-																							props.errors.payMode &&
-																								props.touched.payMode
-																								? 'is-invalid'
-																								: ''
-																						}
-																					/>
-																					{props.errors.payMode &&
-																						props.touched.payMode && (
-																							<div className="invalid-feedback">
-																								{props.errors.payMode}
-																							</div>
-																						)}
-																				</FormGroup>
-																			</Col>
-																		}
-																	</Row>
-															
-																	{props.values.vatCategoryId !== '' && props.values.vatCategoryId.label !== 'Select VAT' && props.values.expenseCategory && (props.values?.expenseCategory?.value ? props.values?.expenseCategory?.value !== 34 : props.values?.expenseCategory !== 34) &&
-																		props.values.vatCategoryId.value === 1 &&
-																		
-																		(
-																			<Row>
-																				<Col></Col>
-																				<Col >
-																					<FormGroup>
-																						<span className='mr-4'>{strings.ExclusiveVAT}</span>
-																						<Switch
-																							checked={!this.state.exclusiveVat}
-																							onChange={(checked) => {
-																								this.setState({
-																									exclusiveVat: !checked
-																								});
-																							}}
-																							onColor="#2064d8"
-																							onHandleColor="#2693e6"
-																							handleDiameter={25}
-																							uncheckedIcon={false}
-																							checkedIcon={false}
-																							boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
-																							activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
-																							height={20}
-																							width={48}
-																							className="react-switch "
-																						/>
-																						<span className='ml-4'>{strings.InclusiveVAT}</span>
-
-																					</FormGroup>
-																				</Col>
-																				<Col></Col>
-																				<Col></Col></Row>
-																		)
-																	}
-																	<Row>
-																		{(this.state.isRegisteredVat && props.values.expenseCategory && (props.values?.expenseCategory?.value ? props.values?.expenseCategory?.value !== 34 : props.values?.expenseCategory !== 34)) && (((this.state.isDesignatedZone && (this.state.taxTreatmentId === 5 || this.state.taxTreatmentId === 6 || this.state.taxTreatmentId === 7))
-																			|| (!this.state.isDesignatedZone && (this.state.taxTreatmentId !== 3 && this.state.taxTreatmentId !== 8))
-																		)) && (
-																				<Col>
-																					
-																					<Checkbox
-																						id="isReverseChargeEnabled"
-																						checked={this.state.isReverseChargeEnabled}
-																						onChange={(option) => {
-																							this.setState({ isReverseChargeEnabled: !this.state.isReverseChargeEnabled, exclusiveVat: true })
-																							// for resetting Vat
-																							props.handleChange('vatCategoryId')('');
-																						}}
-																					/>
-																					<Label>{strings.IsReverseCharge}</Label>
-																				</Col>)}
-																	</Row>
-																	<hr />
-																	<Row style={{ display: props.values.exchangeRate === 1 ? 'none' : '' }}>
-																		<Col>
-																			<Label>
-																				{strings.CurrencyExchangeRate}
-																			</Label>
-																		</Col>
-																	</Row>
-																	<Row style={{ display: props.values.exchangeRate === 1 ? 'none' : '' }}>
-																		<Col lg={1}>
-																			<Input
-																				disabled
-																				id="1"
-																				name="1"
-																				value={
-																					1}
-
-																			/>
-																		</Col>
-																		<Col lg={2}>
-																			<FormGroup className="mb-3">
-																				{/* <Label htmlFor="exchangeRate">
+                                {props.values.vatCategoryId !== '' &&
+                                  props.values.vatCategoryId.label !== 'Select VAT' &&
+                                  props.values.expenseCategory &&
+                                  (props.values?.expenseCategory?.value
+                                    ? props.values?.expenseCategory?.value !== 34
+                                    : props.values?.expenseCategory !== 34) &&
+                                  props.values.vatCategoryId.value === 1 && (
+                                    <Row>
+                                      <Col></Col>
+                                      <Col>
+                                        <FormGroup>
+                                          <span className="mr-4">{strings.ExclusiveVAT}</span>
+                                          <Switch
+                                            checked={!this.state.exclusiveVat}
+                                            onChange={checked => {
+                                              this.setState({
+                                                exclusiveVat: !checked,
+                                              });
+                                            }}
+                                            onColor="#2064d8"
+                                            onHandleColor="#2693e6"
+                                            handleDiameter={25}
+                                            uncheckedIcon={false}
+                                            checkedIcon={false}
+                                            boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+                                            activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+                                            height={20}
+                                            width={48}
+                                            className="react-switch "
+                                          />
+                                          <span className="ml-4">{strings.InclusiveVAT}</span>
+                                        </FormGroup>
+                                      </Col>
+                                      <Col></Col>
+                                      <Col></Col>
+                                    </Row>
+                                  )}
+                                <Row>
+                                  {this.state.isRegisteredVat &&
+                                    props.values.expenseCategory &&
+                                    (props.values?.expenseCategory?.value
+                                      ? props.values?.expenseCategory?.value !== 34
+                                      : props.values?.expenseCategory !== 34) &&
+                                    ((this.state.isDesignatedZone &&
+                                      (this.state.taxTreatmentId === 5 ||
+                                        this.state.taxTreatmentId === 6 ||
+                                        this.state.taxTreatmentId === 7)) ||
+                                      (!this.state.isDesignatedZone &&
+                                        this.state.taxTreatmentId !== 3 &&
+                                        this.state.taxTreatmentId !== 8)) && (
+                                      <Col>
+                                        <Checkbox
+                                          id="isReverseChargeEnabled"
+                                          checked={this.state.isReverseChargeEnabled}
+                                          onChange={option => {
+                                            this.setState({
+                                              isReverseChargeEnabled:
+                                                !this.state.isReverseChargeEnabled,
+                                              exclusiveVat: true,
+                                            });
+                                            // for resetting Vat
+                                            props.handleChange('vatCategoryId')('');
+                                          }}
+                                        />
+                                        <Label>{strings.IsReverseCharge}</Label>
+                                      </Col>
+                                    )}
+                                </Row>
+                                <hr />
+                                <Row
+                                  style={{ display: props.values.exchangeRate === 1 ? 'none' : '' }}
+                                >
+                                  <Col>
+                                    <Label>{strings.CurrencyExchangeRate}</Label>
+                                  </Col>
+                                </Row>
+                                <Row
+                                  style={{ display: props.values.exchangeRate === 1 ? 'none' : '' }}
+                                >
+                                  <Col lg={1}>
+                                    <Input disabled id="1" name="1" value={1} />
+                                  </Col>
+                                  <Col lg={2}>
+                                    <FormGroup className="mb-3">
+                                      {/* <Label htmlFor="exchangeRate">
 																						Exchange rate
 																					</Label> */}
-																				<div>
-																					<Input
-																						disabled
-																						className="form-control"
-																						id="currencyName"
-																						name="currencyName"
-
-																						value={props.values.currencyName}
-																						onChange={(value) => {
-																							props.handleChange('currencyName')(
-																								value,
-																							);
-																						}}
-																					/>
-																				</div>
-																			</FormGroup>
-																		</Col>
-																		<FormGroup className="mt-2"><label><b>=</b></label>	</FormGroup>
-																		<Col lg={2}>
-																			<FormGroup className="mb-3">
-																				{/* <Label htmlFor="exchangeRate">
+                                      <div>
+                                        <Input
+                                          disabled
+                                          className="form-control"
+                                          id="currencyName"
+                                          name="currencyName"
+                                          value={props.values.currencyName}
+                                          onChange={value => {
+                                            props.handleChange('currencyName')(value);
+                                          }}
+                                        />
+                                      </div>
+                                    </FormGroup>
+                                  </Col>
+                                  <FormGroup className="mt-2">
+                                    <label>
+                                      <b>=</b>
+                                    </label>{' '}
+                                  </FormGroup>
+                                  <Col lg={2}>
+                                    <FormGroup className="mb-3">
+                                      {/* <Label htmlFor="exchangeRate">
 																						Exchange rate
 																					</Label> */}
-																				<div>
-																					<Input
-																						type="number"
-																						min="0"
-																						className="form-control"
-																						id="exchangeRate"
-																						name="exchangeRate"
-																						maxLength="20"
-																						value={props.values.exchangeRate}
-																						onChange={(value) => {
-																							props.handleChange('exchangeRate')(
-																								value,
-																							);
-																						}}
-																					/>
-																				</div>
-																			</FormGroup>
-																		</Col>
+                                      <div>
+                                        <Input
+                                          type="number"
+                                          min="0"
+                                          className="form-control"
+                                          id="exchangeRate"
+                                          name="exchangeRate"
+                                          maxLength="20"
+                                          value={props.values.exchangeRate}
+                                          onChange={value => {
+                                            props.handleChange('exchangeRate')(value);
+                                          }}
+                                        />
+                                      </div>
+                                    </FormGroup>
+                                  </Col>
 
-																		<Col lg={2}>
-																			<Input
-																				disabled
-																				id="currencyName"
-																				name="currencyName"
-																				value={
-																					this.state.basecurrency.currencyName}
-
-																			/>
-																		</Col>
-																	</Row>
-																	<Row>
-																		<Col lg={8}>
-																			<FormGroup className="mb-3">
-																				<Label htmlFor="expenseDescription">
-																					{strings.Description}
-																				</Label>
-																				<Input
-																					type="textarea"
-																					maxLength="250"
-																					name="expenseDescription"
-																					id="expenseDescription"
-																					rows="5"
-																					placeholder={"Enter" + " " + strings.Description}
-																					onChange={(option) =>
-																						props.handleChange('expenseDescription')(
-																							option,
-																						)
-																					}
-																					value={props.values.expenseDescription}
-																				/>
-																			</FormGroup>
-																		</Col>
-																	</Row>
-																	<hr />
-																	<Row>
-																		<Col lg={8}>
-																			{/* <FormGroup className="py-2">
+                                  <Col lg={2}>
+                                    <Input
+                                      disabled
+                                      id="currencyName"
+                                      name="currencyName"
+                                      value={this.state.basecurrency.currencyName}
+                                    />
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={8}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="expenseDescription">
+                                        {strings.Description}
+                                      </Label>
+                                      <Input
+                                        type="textarea"
+                                        maxLength="250"
+                                        name="expenseDescription"
+                                        id="expenseDescription"
+                                        rows="5"
+                                        placeholder={'Enter' + ' ' + strings.Description}
+                                        onChange={option =>
+                                          props.handleChange('expenseDescription')(option)
+                                        }
+                                        value={props.values.expenseDescription}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <hr />
+                                <Row>
+                                  <Col lg={8}>
+                                    {/* <FormGroup className="py-2">
 																		<Label htmlFor="notes">{strings.Notes}</Label><br/>
 																		<TextareaAutosize
 																			type="textarea"
@@ -1742,32 +1758,38 @@ class CreateExpense extends React.Component {
 																			value={props.values.notes}
 																		/>
 																	</FormGroup> */}
-																			<Row>
-																				<Col lg={6}>
-																					<FormGroup className="mb-3">
-																						<Label htmlFor="receiptNumber">
-																							{strings.ReferenceNumber}
-																						</Label>
-																						<Input
-																							type="text"
-																							maxLength="20"
-																							id="receiptNumber"
-																							name="receiptNumber"
-																							value={props.values.receiptNumber}
-																							placeholder={strings.ReceiptNumber}
-																							onChange={(value) => {
-																								props.handleChange('receiptNumber')(value);
-
-																							}}
-																							className={props.errors.receiptNumber && props.touched.receiptNumber ? "is-invalid" : " "}
-																						/>
-																						{props.errors.receiptNumber && props.touched.receiptNumber && (
-																							<div className="invalid-feedback">{props.errors.receiptNumber}</div>
-																						)}
-
-																					</FormGroup>
-																				</Col>
-																				{/* <Col lg={6}>
+                                    <Row>
+                                      <Col lg={6}>
+                                        <FormGroup className="mb-3">
+                                          <Label htmlFor="receiptNumber">
+                                            {strings.ReferenceNumber}
+                                          </Label>
+                                          <Input
+                                            type="text"
+                                            maxLength="20"
+                                            id="receiptNumber"
+                                            name="receiptNumber"
+                                            value={props.values.receiptNumber}
+                                            placeholder={strings.ReceiptNumber}
+                                            onChange={value => {
+                                              props.handleChange('receiptNumber')(value);
+                                            }}
+                                            className={
+                                              props.errors.receiptNumber &&
+                                              props.touched.receiptNumber
+                                                ? 'is-invalid'
+                                                : ' '
+                                            }
+                                          />
+                                          {props.errors.receiptNumber &&
+                                            props.touched.receiptNumber && (
+                                              <div className="invalid-feedback">
+                                                {props.errors.receiptNumber}
+                                              </div>
+                                            )}
+                                        </FormGroup>
+                                      </Col>
+                                      {/* <Col lg={6}>
 																			<FormGroup className="mb-3">
 																				<Field
 																					name="attachmentFile"
@@ -1825,8 +1847,8 @@ class CreateExpense extends React.Component {
 																					)}
 																			</FormGroup>
 																		</Col> */}
-																			</Row>
-																			{/* <FormGroup className="mb-3">
+                                    </Row>
+                                    {/* <FormGroup className="mb-3">
 																		<Label htmlFor="receiptAttachmentDescription">
 																			{strings.AttachmentDescription}
 																		</Label><br/>
@@ -1850,99 +1872,107 @@ class CreateExpense extends React.Component {
 																			}
 																		/>
 																	</FormGroup> */}
-																		</Col>
-																	</Row>
+                                  </Col>
+                                </Row>
 
-																	<Row>
-																		<Col lg={12} className="mt-5">
-																			<FormGroup className="text-right">
-																				<Button
-																					type="button"
-																					color="primary"
-																					className="btn-square mr-3"
-																					disabled={this.state.disabled}
-																					onClick={() => {
-																						//  added validation popup	msg
-																						console.log(props.errors, this.state.exist, "ERRORS");
-																						props.handleBlur();
-																						if (props.errors && Object.keys(props.errors).length != 0) {
-																							if (props.errors.expenseNumber && this.state.exist === true)
-																								this.props.commonActions.fillManDatoryDetails();
-																						}
-																						this.setState(
-																							{ createMore: false },
-																							() => {
-																								props.handleSubmit();
-																							},
-																						);
-																					}}
-																				>
-																					<i className="fa fa-dot-circle-o"></i>{' '}
-																					{this.state.disabled
-																						? 'Creating...'
-																						: strings.Create}
-																				</Button>
-																				{this.props.location.state && this.props.location.state.parentId ? "" : <Button
-																					name="button"
-																					color="primary"
-																					className="btn-square mr-3"
-																					disabled={this.state.disabled}
-																					onClick={() => {
-																						//	added validation popup	msg
-																						console.log(props.errors, this.state.exist, "ERRORS");
-																						props.handleBlur();
-																						if (props.errors && Object.keys(props.errors).length != 0) {
-																							if (props.errors.expenseNumber && this.state.exist === true)
-																								this.props.commonActions.fillManDatoryDetails();
-																						}
+                                <Row>
+                                  <Col lg={12} className="mt-5">
+                                    <FormGroup className="text-right">
+                                      <Button
+                                        type="button"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        disabled={this.state.disabled}
+                                        onClick={() => {
+                                          //  added validation popup	msg
+                                          console.log(props.errors, this.state.exist, 'ERRORS');
+                                          props.handleBlur();
+                                          if (
+                                            props.errors &&
+                                            Object.keys(props.errors).length != 0
+                                          ) {
+                                            if (
+                                              props.errors.expenseNumber &&
+                                              this.state.exist === true
+                                            )
+                                              this.props.commonActions.fillManDatoryDetails();
+                                          }
+                                          this.setState({ createMore: false }, () => {
+                                            props.handleSubmit();
+                                          });
+                                        }}
+                                      >
+                                        <i className="fa fa-dot-circle-o"></i>{' '}
+                                        {this.state.disabled ? 'Creating...' : strings.Create}
+                                      </Button>
+                                      {this.props.location.state &&
+                                      this.props.location.state.parentId ? (
+                                        ''
+                                      ) : (
+                                        <Button
+                                          name="button"
+                                          color="primary"
+                                          className="btn-square mr-3"
+                                          disabled={this.state.disabled}
+                                          onClick={() => {
+                                            //	added validation popup	msg
+                                            console.log(props.errors, this.state.exist, 'ERRORS');
+                                            props.handleBlur();
+                                            if (
+                                              props.errors &&
+                                              Object.keys(props.errors).length != 0
+                                            ) {
+                                              if (
+                                                props.errors.expenseNumber &&
+                                                this.state.exist === true
+                                              )
+                                                this.props.commonActions.fillManDatoryDetails();
+                                            }
 
-																						this.setState(
-																							{ createMore: true },
-																							() => {
-																								props.handleSubmit();
-																							},
-																						);
-																					}}
-																				>
-																					<i className="fa fa-refresh"></i> 	{this.state.disabled
-																						? 'Creating...'
-																						: strings.CreateandMore}
-																				</Button>}
-																				<Button
-																					color="secondary"
-																					className="btn-square"
-																					onClick={() => {
-																						if (this.props?.location?.state?.renderURL) {
-																							this.props.history.push(
-																								`${this.props?.location?.state?.renderURL}`, 
-																								{expenseId: this.props?.location?.state?.renderID },);
-																						} else
-																							this.props.history.push(
-																								'/admin/expense/expense',
-																							);
-																					}}
-																				>
-																					<i className="fa fa-ban"></i> {strings.Cancel}
-																				</Button>
-																			</FormGroup>
-																		</Col>
-																	</Row>
-																</Form>
-															)}
-														</Formik>
-													</Col>
-												</Row>
-											)}
-										</CardBody>
-									</Card>
-								</Col>
-							</Row>
-						</div>
-					</div>
-					{this.state.disableLeavePage ? "" : <LeavePage />}
-				</div>
-		);
-	}
+                                            this.setState({ createMore: true }, () => {
+                                              props.handleSubmit();
+                                            });
+                                          }}
+                                        >
+                                          <i className="fa fa-refresh"></i>{' '}
+                                          {this.state.disabled
+                                            ? 'Creating...'
+                                            : strings.CreateandMore}
+                                        </Button>
+                                      )}
+                                      <Button
+                                        color="secondary"
+                                        className="btn-square"
+                                        onClick={() => {
+                                          if (this.props?.location?.state?.renderURL) {
+                                            this.props.history.push(
+                                              `${this.props?.location?.state?.renderURL}`,
+                                              { expenseId: this.props?.location?.state?.renderID }
+                                            );
+                                          } else this.props.history.push('/admin/expense/expense');
+                                        }}
+                                      >
+                                        <i className="fa fa-ban"></i> {strings.Cancel}
+                                      </Button>
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                              </Form>
+                            )}
+                          </Formik>
+                        </Col>
+                      </Row>
+                    )}
+                  </CardBody>
+                </Card>
+              </Col>
+            </Row>
+          </div>
+        </div>
+        {this.state.disableLeavePage ? '' : <LeavePage />}
+      </div>
+    );
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateExpense);

--- a/apps/frontend/src/screens/journal/screens/create/screen.js
+++ b/apps/frontend/src/screens/journal/screens/create/screen.js
@@ -2,24 +2,24 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Row,
-	Col,
-	Form,
-	FormGroup,
-	Input,
-	Label,
-	Badge,
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Input,
+  Label,
+  Badge,
 } from 'reactstrap';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import Select from 'react-select';
 import DatePicker from 'react-datepicker';
 import { Formik, Field } from 'formik';
 import * as Yup from 'yup';
-import { Currency ,LeavePage, Loader} from 'components';
+import { Currency, LeavePage, Loader } from 'components';
 import { CommonActions } from 'services/global';
 import { selectCurrencyFactory } from 'utils';
 import * as JournalActions from '../../actions';
@@ -27,1379 +27,1309 @@ import * as JournalCreateActions from './actions';
 import 'react-datepicker/dist/react-datepicker.css';
 import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
 import './style.scss';
-import {data}  from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 
-const mapStateToProps = (state) => {
-	return {
-		transaction_category_list: state.journal.transaction_category_list,
-		currency_list: state.journal.currency_list,
-		contact_list: state.journal.contact_list,
-		vat_list: state.journal.vat_list,
-		universal_currency_list: state.common.universal_currency_list,
-	};
+const mapStateToProps = state => {
+  return {
+    transaction_category_list: state.journal.transaction_category_list,
+    currency_list: state.journal.currency_list,
+    contact_list: state.journal.contact_list,
+    vat_list: state.journal.vat_list,
+    universal_currency_list: state.common.universal_currency_list,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		commonActions: bindActionCreators(CommonActions, dispatch),
-		journalActions: bindActionCreators(JournalActions, dispatch),
-		journalCreateActions: bindActionCreators(JournalCreateActions, dispatch),
-	};
+const mapDispatchToProps = dispatch => {
+  return {
+    commonActions: bindActionCreators(CommonActions, dispatch),
+    journalActions: bindActionCreators(JournalActions, dispatch),
+    journalCreateActions: bindActionCreators(JournalCreateActions, dispatch),
+  };
 };
 const customStyles = {
-	control: (base, state) => ({
-		...base,
-		borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		boxShadow: state.isFocused ? null : null,
-		'&:hover': {
-			borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		},
-	}),
+  control: (base, state) => ({
+    ...base,
+    borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    boxShadow: state.isFocused ? null : null,
+    '&:hover': {
+      borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    },
+  }),
 };
 
 let strings = new LocalizedStrings(data);
 class CreateJournal extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			language: window['localStorage'].getItem('language'),
-			loading: false,
-			createMore: false,
-			disabled: false,
-			exist:false,
-			data: [
-				{
-					id: 0,
-					description: '',
-					transactionCategoryId: '',
-					contactId: '',
-					debitAmount: 0,
-					creditAmount: 0,
-				},
-				{
-					id: 1,
-					description: '',
-					transactionCategoryId: '',
-					contactId: '',
-					debitAmount: 0,
-					creditAmount: 0,
-				},
-			],
-			idCount: 1,
-			initValue: {
-				journalDate: new Date(),
-				journalReferenceNo: '',
-				description: '',
-				currencyCode: '',
-				subTotalDebitAmount: 0,
-				totalDebitAmount: 0,
-				totalCreditAmount: 0,
-				subTotalCreditAmount: 0,
-				temp: false,
-				journalLineItems: [
-					{
-						id: 0,
-						description: '',
-						transactionCategoryId: '',
-						contactId: '',
-						debitAmount: 0,
-						creditAmount: 0,
-					},
-					{
-						id: 1,
-						description: '',
-						transactionCategoryId: '',
-						contactId: '',
-						debitAmount: 0,
-						creditAmount: 0,
-					},
-				],
-			},
-			submitJournal: false,
-			loadingMsg:"Loading...",
-			disableLeavePage:false,
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: window['localStorage'].getItem('language'),
+      loading: false,
+      createMore: false,
+      disabled: false,
+      exist: false,
+      data: [
+        {
+          id: 0,
+          description: '',
+          transactionCategoryId: '',
+          contactId: '',
+          debitAmount: 0,
+          creditAmount: 0,
+        },
+        {
+          id: 1,
+          description: '',
+          transactionCategoryId: '',
+          contactId: '',
+          debitAmount: 0,
+          creditAmount: 0,
+        },
+      ],
+      idCount: 1,
+      initValue: {
+        journalDate: new Date(),
+        journalReferenceNo: '',
+        description: '',
+        currencyCode: '',
+        subTotalDebitAmount: 0,
+        totalDebitAmount: 0,
+        totalCreditAmount: 0,
+        subTotalCreditAmount: 0,
+        temp: false,
+        journalLineItems: [
+          {
+            id: 0,
+            description: '',
+            transactionCategoryId: '',
+            contactId: '',
+            debitAmount: 0,
+            creditAmount: 0,
+          },
+          {
+            id: 1,
+            description: '',
+            transactionCategoryId: '',
+            contactId: '',
+            debitAmount: 0,
+            creditAmount: 0,
+          },
+        ],
+      },
+      submitJournal: false,
+      loadingMsg: 'Loading...',
+      disableLeavePage: false,
+    };
 
-			
-		};
+    this.formRef = React.createRef();
+    this.regEx = /^[0-9\d]+$/;
+    this.regExBoth = /[a-zA-Z0-9]+$/;
+    this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
+  }
 
-		this.formRef = React.createRef();
-		this.regEx = /^[0-9\d]+$/;
-		this.regExBoth = /[a-zA-Z0-9]+$/;
-		this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
-	}
+  componentDidMount = () => {
+    this.initializeData();
+  };
 
-	componentDidMount = () => {
-		this.initializeData();
-	};
+  initializeData = () => {
+    this.props.journalActions.getContactList();
+    this.props.journalActions.getCurrencyList().then(response => {
+      this.setState({
+        initValue: {
+          ...this.state.initValue,
+          ...{
+            currencyCode: response.data ? parseInt(response.data[0].currencyCode) : '',
+          },
+        },
+      });
+      this.formRef.current.setFieldValue('currencyCode', response.data[0].currencyCode, true);
+    });
+    this.props.journalActions.getTransactionCategoryList();
+    this.props.commonActions.getCompanyDetails().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        const isRegisteredVat = action.payload.isRegisteredVat;
 
-	initializeData = () => {
-
-
-		this.props.journalActions.getContactList();
-		this.props.journalActions.getCurrencyList().then((response) => {
-			this.setState({
-				initValue: {
-					...this.state.initValue,
-					...{
-						currencyCode: response.data
-							? parseInt(response.data[0].currencyCode)
-							: '',
-					},
-				},
-			});
-			this.formRef.current.setFieldValue(
-				'currencyCode',
-				response.data[0].currencyCode,
-				true,
-			);
-		});
-		this.props.journalActions.getTransactionCategoryList();
-		this.props.commonActions.getCompanyDetails().then((res) => {
-            if (res.status === 200) {
-              const isRegisteredVat = res.data.isRegisteredVat;
-     
-              this.props.history.replace({
-                pathname: this.props.location.pathname,
-                state: {
-                  ...this.props.location.state,
-                  isRegisteredVat: isRegisteredVat,
-                },
-              });
-     
-              this.setState({
-                companyDetails: res.data,
-                isRegisteredVat: isRegisteredVat,
-              });
-            }
+        this.props.history.replace({
+          pathname: this.props.location.pathname,
+          state: {
+            ...this.props.location.state,
+            isRegisteredVat: isRegisteredVat,
+          },
         });
-	};
 
-	// getjournalReferenceNo = () => {
-	// 	this.props.journalActions.getInvoiceNo().then((res) => {
-	// 		if (res.status === 200) {
-	// 			this.setState({
-	// 				initValue: {
-	// 					...this.state.initValue,
-	// 					...{ journalReferenceNo: res.data },
-	// 				},
-	// 			});
-	// 			if( res &&  res.data)
-	// 			console.log(res.data)
-	// 			this.formRef.current.setFieldValue('journalReferenceNo', res.data, true,
-	// 			 this.validationCheck(res.data)
-	// 			);
-	// 		}
-	// 	});
-	// };
-	validationCheck = (value) => {
-		const data = {
-			moduleType: 20,
-			name: value,
-		};
-		this.props.journalActions
-			.checkValidation(data)
-			.then((response) => {
-				
-				if (response.data === 'Journal Reference Number Already Exists') {
-					this.setState(
-						{
-							exist: true,
-						},
-						
-						() => {},
-					);
-				
-				} else {
-					this.setState({
-						exist: false,
-					});
-				}
-			});
-	};
-	renderActions = (cell, rows, props) => {
-		return (
-			<Button
-				size="sm"
-				className="btn-twitter btn-brand icon"
-				disabled={this.state.data.length <= 2 ? true : false}
-				onClick={(e) => {
-					this.deleteRow(e, rows, props);
-				}}
-			>
-				<i className="fas fa-trash"></i>
-			</Button>
-		);
-	};
+        this.setState({
+          companyDetails: action.payload,
+          isRegisteredVat: isRegisteredVat,
+        });
+      }
+    });
+  };
 
-	checkedRow = () => {
-		if (this.state.data.length > 0) {
-			let length = this.state.data.length - 1;
-			let temp = Object.values(this.state.data[`${length}`]).indexOf('');
-			if (temp > -1) {
-				return true;
-			} else {
-				return false;
-			}
-		} else {
-			return false;
-		}
-	};
+  // getjournalReferenceNo = () => {
+  // 	this.props.journalActions.getInvoiceNo().then((res) => {
+  // 		if (res.status === 200) {
+  // 			this.setState({
+  // 				initValue: {
+  // 					...this.state.initValue,
+  // 					...{ journalReferenceNo: res.data },
+  // 				},
+  // 			});
+  // 			if( res &&  res.data)
+  // 			console.log(res.data)
+  // 			this.formRef.current.setFieldValue('journalReferenceNo', res.data, true,
+  // 			 this.validationCheck(res.data)
+  // 			);
+  // 		}
+  // 	});
+  // };
+  validationCheck = value => {
+    const data = {
+      moduleType: 20,
+      name: value,
+    };
+    this.props.journalActions.checkValidation(data).then(response => {
+      if (response.data === 'Journal Reference Number Already Exists') {
+        this.setState(
+          {
+            exist: true,
+          },
 
-	renderAccount = (cell, row, props) => {
-		const { transaction_category_list } = this.props;
-		console.log(transaction_category_list);
-		let transactionCategoryList =
-			transaction_category_list && transaction_category_list.length
-				? [
-               		{
-						label: 'Select Account',
-						options: [
-							{
-								transactionCategoryId: '',
-								transactionCategoryName: 'Select Account',
-							},
-						]
-					},
-					...transaction_category_list
-					]
-				: transaction_category_list;
+          () => {}
+        );
+      } else {
+        this.setState({
+          exist: false,
+        });
+      }
+    });
+  };
+  renderActions = (cell, rows, props) => {
+    return (
+      <Button
+        size="sm"
+        className="btn-twitter btn-brand icon"
+        disabled={this.state.data.length <= 2 ? true : false}
+        onClick={e => {
+          this.deleteRow(e, rows, props);
+        }}
+      >
+        <i className="fas fa-trash"></i>
+      </Button>
+    );
+  };
 
-				if (!this.state.isRegisteredVat) {
-					const vatCategories = [
-						'VAT Penalty',
-						'Output VAT Adjustment',
-						'Input VAT Adjustment',
-						'VAT Payable',
-						'Input VAT',
-						'GCC VAT Payable',
-						'Output VAT'
-					];
-				
-					// Ensure transactionCategoryList is defined and an array before checking
-					if (Array.isArray(transactionCategoryList)) {
-						// Check if there are any VAT categories present in the transactionCategoryList
-						const hasVatCategories = transactionCategoryList.some(group =>
-							group.options && group.options.some(option => vatCategories.includes(option.label))
-						);
-				
-						if (hasVatCategories) {
-							transactionCategoryList = transactionCategoryList.map(group => {
-								return {
-									...group,
-									options: group.options ? group.options.filter(
-										option => !vatCategories.includes(option.label)
-									) : []
-								};
-							});
-						}
-					}
-				}
+  checkedRow = () => {
+    if (this.state.data.length > 0) {
+      let length = this.state.data.length - 1;
+      let temp = Object.values(this.state.data[`${length}`]).indexOf('');
+      if (temp > -1) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  };
 
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderAccount = (cell, row, props) => {
+    const { transaction_category_list } = this.props;
+    console.log(transaction_category_list);
+    let transactionCategoryList =
+      transaction_category_list && transaction_category_list.length
+        ? [
+            {
+              label: 'Select Account',
+              options: [
+                {
+                  transactionCategoryId: '',
+                  transactionCategoryName: 'Select Account',
+                },
+              ],
+            },
+            ...transaction_category_list,
+          ]
+        : transaction_category_list;
 
-		return (
-			// <Field
-			// 	name={`journalLineItems.${idx}.transactionCategoryId`}
-			// 	render={({ field, form }) => (
-			// 		<Input
-			// 			styles={customStyles}
-			// 			type="select"
-			// 			onChange={(e) => {
-			// 				this.selectItem(e, row, 'transactionCategoryId', form, field);
-			// 			}}
-			// 			value={row.transactionCategoryId}
-			// 			className={`form-control
-			//       ${
-			// 				props.errors.journalLineItems &&
-			// 				props.errors.journalLineItems[parseInt(idx, 10)] &&
-			// 				props.errors.journalLineItems[parseInt(idx, 10)]
-			// 					.transactionCategoryId &&
-			// 				Object.keys(props.touched).length > 0 &&
-			// 				props.touched.journalLineItems &&
-			// 				props.touched.journalLineItems[parseInt(idx, 10)] &&
-			// 				props.touched.journalLineItems[parseInt(idx, 10)]
-			// 					.transactionCategoryId
-			// 					? 'is-invalid'
-			// 					: ''
-			// 			}`}
-			// 		>
-			// 			{transactionCategoryList
-			// 				? transactionCategoryList.map((obj) => {
-			// 						return (
-			// 							<option
-			// 								value={obj.transactionCategoryId}
-			// 								key={obj.transactionCategoryId}
-			// 							>
-			// 								{obj.transactionCategoryName}
-			// 							</option>
-			// 						);
-			// 				  })
-			// 				: ''}
-			// 		</Input>
-			// 	)}
-			// />
+    if (!this.state.isRegisteredVat) {
+      const vatCategories = [
+        'VAT Penalty',
+        'Output VAT Adjustment',
+        'Input VAT Adjustment',
+        'VAT Payable',
+        'Input VAT',
+        'GCC VAT Payable',
+        'Output VAT',
+      ];
 
-			<Field
-				name={`journalLineItems.${idx}.transactionCategoryId`}
-				render={({ field, form }) => (
-					<>
-				
-					<Select
-						styles={{
-							menu: (provided) => ({ ...provided, zIndex: 9999 }),
-						}}
-						options={transactionCategoryList || []}
-						id="transactionCategoryId"
-						onChange={(e) => {
-							this.selectItem(e.value,row,'transactionCategoryId',form,field);
-						}}
-						placeholder={strings.Select+strings.Account}
-						className={`${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].transactionCategoryId
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-					{	props.errors.journalLineItems &&
-					props.errors.journalLineItems[parseInt(idx, 10)] &&
-					props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId &&
-					Object.keys(props.touched).length > 0 &&
-					props.touched.journalLineItems &&
-					props.touched.journalLineItems[parseInt(idx, 10)] &&
-					props.touched.journalLineItems[parseInt(idx, 10)].transactionCategoryId &&(
-						<div className='invalid-feedback'>
-						{props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId}
-					</div>
-						
-					)}
-					</>
-				)}
-			/>
-		);
-	};
+      // Ensure transactionCategoryList is defined and an array before checking
+      if (Array.isArray(transactionCategoryList)) {
+        // Check if there are any VAT categories present in the transactionCategoryList
+        const hasVatCategories = transactionCategoryList.some(
+          group =>
+            group.options && group.options.some(option => vatCategories.includes(option.label))
+        );
 
-	renderDescription = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+        if (hasVatCategories) {
+          transactionCategoryList = transactionCategoryList.map(group => {
+            return {
+              ...group,
+              options: group.options
+                ? group.options.filter(option => !vatCategories.includes(option.label))
+                : [],
+            };
+          });
+        }
+      }
+    }
 
-		return (
-			<Field
-				name={`journalLineItems.${idx}.description`}
-				render={({ field, form }) => (
-					<Input
-						type="text"
-						maxLength="250"
-						value={row['description'] !== '' ? row['description'] : ''}
-						onChange={(e) => {
-							this.selectItem(e.target.value, row, 'description', form, field);
-						}}
-						placeholder={strings.Description}
-						className={`form-control 
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
+
+    return (
+      // <Field
+      // 	name={`journalLineItems.${idx}.transactionCategoryId`}
+      // 	render={({ field, form }) => (
+      // 		<Input
+      // 			styles={customStyles}
+      // 			type="select"
+      // 			onChange={(e) => {
+      // 				this.selectItem(e, row, 'transactionCategoryId', form, field);
+      // 			}}
+      // 			value={row.transactionCategoryId}
+      // 			className={`form-control
+      //       ${
+      // 				props.errors.journalLineItems &&
+      // 				props.errors.journalLineItems[parseInt(idx, 10)] &&
+      // 				props.errors.journalLineItems[parseInt(idx, 10)]
+      // 					.transactionCategoryId &&
+      // 				Object.keys(props.touched).length > 0 &&
+      // 				props.touched.journalLineItems &&
+      // 				props.touched.journalLineItems[parseInt(idx, 10)] &&
+      // 				props.touched.journalLineItems[parseInt(idx, 10)]
+      // 					.transactionCategoryId
+      // 					? 'is-invalid'
+      // 					: ''
+      // 			}`}
+      // 		>
+      // 			{transactionCategoryList
+      // 				? transactionCategoryList.map((obj) => {
+      // 						return (
+      // 							<option
+      // 								value={obj.transactionCategoryId}
+      // 								key={obj.transactionCategoryId}
+      // 							>
+      // 								{obj.transactionCategoryName}
+      // 							</option>
+      // 						);
+      // 				  })
+      // 				: ''}
+      // 		</Input>
+      // 	)}
+      // />
+
+      <Field
+        name={`journalLineItems.${idx}.transactionCategoryId`}
+        render={({ field, form }) => (
+          <>
+            <Select
+              styles={{
+                menu: provided => ({ ...provided, zIndex: 9999 }),
+              }}
+              options={transactionCategoryList || []}
+              id="transactionCategoryId"
+              onChange={e => {
+                this.selectItem(e.value, row, 'transactionCategoryId', form, field);
+              }}
+              placeholder={strings.Select + strings.Account}
+              className={`${
+                props.errors.journalLineItems &&
+                props.errors.journalLineItems[parseInt(idx, 10)] &&
+                props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId &&
+                Object.keys(props.touched).length > 0 &&
+                props.touched.journalLineItems &&
+                props.touched.journalLineItems[parseInt(idx, 10)] &&
+                props.touched.journalLineItems[parseInt(idx, 10)].transactionCategoryId
+                  ? 'is-invalid'
+                  : ''
+              }`}
+            />
+            {props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].transactionCategoryId && (
+                <div className="invalid-feedback">
+                  {props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId}
+                </div>
+              )}
+          </>
+        )}
+      />
+    );
+  };
+
+  renderDescription = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
+
+    return (
+      <Field
+        name={`journalLineItems.${idx}.description`}
+        render={({ field, form }) => (
+          <Input
+            type="text"
+            maxLength="250"
+            value={row['description'] !== '' ? row['description'] : ''}
+            onChange={e => {
+              this.selectItem(e.target.value, row, 'description', form, field);
+            }}
+            placeholder={strings.Description}
+            className={`form-control 
              ${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].description &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].description
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-				)}
-			/>
-		);
-	};
+               props.errors.journalLineItems &&
+               props.errors.journalLineItems[parseInt(idx, 10)] &&
+               props.errors.journalLineItems[parseInt(idx, 10)].description &&
+               Object.keys(props.touched).length > 0 &&
+               props.touched.journalLineItems &&
+               props.touched.journalLineItems[parseInt(idx, 10)] &&
+               props.touched.journalLineItems[parseInt(idx, 10)].description
+                 ? 'is-invalid'
+                 : ''
+             }`}
+          />
+        )}
+      />
+    );
+  };
 
-	renderContact = (cell, row, props) => {
-		const { contact_list } = this.props;
-		console.log(contact_list)
-		let contactList = contact_list.length
-			? [{ value: '', label: 'Select Contact' }, ...contact_list]
-			: contact_list;
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderContact = (cell, row, props) => {
+    const { contact_list } = this.props;
+    console.log(contact_list);
+    let contactList = contact_list.length
+      ? [{ value: '', label: 'Select Contact' }, ...contact_list]
+      : contact_list;
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-		return (
-		      <Field
-				name={`journalLineItems.${idx}.contactId`}
-				render={({ field, form }) => (
-					<Input
-						type="select"
-						onChange={(e) => {
-							this.selectItem(e.target.value, row, 'contactId', form, field);
-						}}
-						value={row.contactId}
-						// placeholder={strings.Select+strings.Contact}
-						className={`form-control 
+    return (
+      <Field
+        name={`journalLineItems.${idx}.contactId`}
+        render={({ field, form }) => (
+          <Input
+            type="select"
+            onChange={e => {
+              this.selectItem(e.target.value, row, 'contactId', form, field);
+            }}
+            value={row.contactId}
+            // placeholder={strings.Select+strings.Contact}
+            className={`form-control 
              ${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].contactId
-								? 'is-invalid'
-								: ''
-						}`}
-					>
-						<option value="">Select Customer Name</option>
-						
-						{contactList
-                    ? contactList
-                          .filter((obj) => obj.value)
-                          .map((obj) => (
-                              <option value={obj.value} key={obj.value}>
-                                  {obj.label.contactName}
-                              </option>
-                          ))
-                    : ''}
-					</Input>
-				)}
-			/>
-		);
-	};
+               props.errors.journalLineItems &&
+               props.errors.journalLineItems[parseInt(idx, 10)] &&
+               props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
+               Object.keys(props.touched).length > 0 &&
+               props.touched.journalLineItems &&
+               props.touched.journalLineItems[parseInt(idx, 10)] &&
+               props.touched.journalLineItems[parseInt(idx, 10)].contactId
+                 ? 'is-invalid'
+                 : ''
+             }`}
+          >
+            <option value="">Select Customer Name</option>
 
-	renderDebits = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+            {contactList
+              ? contactList
+                  .filter(obj => obj.value)
+                  .map(obj => (
+                    <option value={obj.value} key={obj.value}>
+                      {obj.label.contactName}
+                    </option>
+                  ))
+              : ''}
+          </Input>
+        )}
+      />
+    );
+  };
 
-		return (
-			<Field
-				name={`journalLineItems.${idx}.debitAmount`}
-				render={({ field, form }) => (
-					<>
-					<Input
-					type="number"
-					min="0"
-					maxLength="14,2"
-						value={row['debitAmount'] !== 0 ? row['debitAmount'] : 0}
-						onChange={(e) => {
-							if (
-								e.target.value === '' ||
-								this.regDecimal.test(e.target.value)
-							) {
-								this.selectItem(
-									e.target.value,
-									row,
-									'debitAmount',
-									form,
-									field,
-								);
-							}
-						}}
-						placeholder={strings.Debit+" "+strings.Amount}
-						className={`form-control 
+  renderDebits = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
+
+    return (
+      <Field
+        name={`journalLineItems.${idx}.debitAmount`}
+        render={({ field, form }) => (
+          <>
+            <Input
+              type="number"
+              min="0"
+              maxLength="14,2"
+              value={row['debitAmount'] !== 0 ? row['debitAmount'] : 0}
+              onChange={e => {
+                if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                  this.selectItem(e.target.value, row, 'debitAmount', form, field);
+                }
+              }}
+              placeholder={strings.Debit + ' ' + strings.Amount}
+              className={`form-control 
             			${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].debitAmount
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-					{props.errors.journalLineItems &&
-						props.errors.journalLineItems[parseInt(idx, 10)] &&
-						props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
-						Object.keys(props.touched).length > 0 &&
-						props.touched.journalLineItems &&
-						props.touched.journalLineItems[parseInt(idx, 10)] &&
-						props.touched.journalLineItems[parseInt(idx, 10)].debitAmount && (
-							<div className='invalid-feedback'>
-								{props.errors.journalLineItems[parseInt(idx, 10)].debitAmount}
-							</div>
+                    props.errors.journalLineItems &&
+                    props.errors.journalLineItems[parseInt(idx, 10)] &&
+                    props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
+                    Object.keys(props.touched).length > 0 &&
+                    props.touched.journalLineItems &&
+                    props.touched.journalLineItems[parseInt(idx, 10)] &&
+                    props.touched.journalLineItems[parseInt(idx, 10)].debitAmount
+                      ? 'is-invalid'
+                      : ''
+                  }`}
+            />
+            {props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].debitAmount && (
+                <div className="invalid-feedback">
+                  {props.errors.journalLineItems[parseInt(idx, 10)].debitAmount}
+                </div>
+              )}
+          </>
+        )}
+      />
+    );
+  };
 
-						)}
-						</>
-				)}
-			/>
-		);
-	};
+  renderCredits = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-	renderCredits = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
-
-		return (
-			<Field
-				name={`journalLineItems.${idx}.creditAmount`}
-				render={({ field, form }) => (
-					<>
-					<Input
-					type="number"
-					min="0"
-					maxLength="14,2"
-						value={row['creditAmount'] !== 0 ? row['creditAmount'] : 0}
-						onChange={(e) => {
-							if (
-								e.target.value === '' ||
-								this.regDecimal.test(e.target.value)
-							) {
-								this.selectItem(
-									e.target.value,
-									row,
-									'creditAmount',
-									form,
-									field,
-								);
-							}
-						}}
-						placeholder={strings.Credit+" "+strings.Amount}
-						className={`form-control 
+    return (
+      <Field
+        name={`journalLineItems.${idx}.creditAmount`}
+        render={({ field, form }) => (
+          <>
+            <Input
+              type="number"
+              min="0"
+              maxLength="14,2"
+              value={row['creditAmount'] !== 0 ? row['creditAmount'] : 0}
+              onChange={e => {
+                if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                  this.selectItem(e.target.value, row, 'creditAmount', form, field);
+                }
+              }}
+              placeholder={strings.Credit + ' ' + strings.Amount}
+              className={`form-control 
             ${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].creditAmount
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-					{props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].creditAmount && (
-								<div className='invalid-feedback'>
-									{props.errors.journalLineItems[parseInt(idx, 10)].creditAmount}
-								</div>
+              props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].creditAmount
+                ? 'is-invalid'
+                : ''
+            }`}
+            />
+            {props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].creditAmount && (
+                <div className="invalid-feedback">
+                  {props.errors.journalLineItems[parseInt(idx, 10)].creditAmount}
+                </div>
+              )}
+          </>
+        )}
+      />
+    );
+  };
 
-							)}
-					</>
+  addRow = () => {
+    const data = [...this.state.data];
+    this.setState(
+      {
+        data: data.concat({
+          id: this.state.idCount + 1,
+          description: '',
+          transactionCategoryId: '',
+          contactId: '',
+          debitAmount: 0,
+          creditAmount: 0,
+        }),
+        idCount: this.state.idCount + 1,
+      },
+      () => {
+        this.formRef.current.setFieldValue('journalLineItems', this.state.data, true);
+        this.formRef.current.setFieldTouched(
+          `journalLineItems[${this.state.data.length - 1}]`,
+          false,
+          true
+        );
+      }
+    );
+  };
 
-				)}
-			/>
-		);
-	};
+  selectItem = (e, row, name, form, field) => {
+    //e.preventDefault();
+    let idx;
+    const data = this.state.data;
+    data.map((obj, index) => {
+      if (obj.id === row.id) {
+        if (name === 'debitAmount') {
+          obj[`${name}`] = e;
+          obj['creditAmount'] = 0;
+        } else if (name === 'creditAmount') {
+          obj[`${name}`] = e;
+          obj['debitAmount'] = 0;
+        } else {
+          obj[`${name}`] = e;
+        }
+        idx = index;
+      }
+      return obj;
+    });
+    if (name === 'debitAmount') {
+      form.setFieldValue(`journalLineItems.[${idx}].creditAmount`, 0, true);
+      form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
+      this.updateAmount(data);
+    } else if (name === 'creditAmount') {
+      form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
+      form.setFieldValue(`journalLineItems.[${idx}].debitAmount`, 0, true);
+      this.updateAmount(data);
+    } else {
+      this.setState({ data }, () => {
+        this.formRef.current.setFieldValue(
+          field.name,
+          this.state.data[parseInt(idx, 10)][`${name}`],
+          true
+        );
+      });
+    }
+  };
 
-	addRow = () => {
-		const data = [...this.state.data];
-		this.setState(
-			{
-				data: data.concat({
-					id: this.state.idCount + 1,
-					description: '',
-					transactionCategoryId: '',
-					contactId: '',
-					debitAmount: 0,
-					creditAmount: 0,
-				}),
-				idCount: this.state.idCount + 1,
-			},
-			() => {
-				this.formRef.current.setFieldValue(
-					'journalLineItems',
-					this.state.data,
-					true,
-				);
-				this.formRef.current.setFieldTouched(
-					`journalLineItems[${this.state.data.length - 1}]`,
-					false,
-					true,
-				);
-			},
-		);
-	};
+  deleteRow = (e, row, props) => {
+    const id = row['id'];
+    let newData = [];
+    e.preventDefault();
+    const data = this.state.data;
+    newData = data.filter(obj => obj.id !== id);
+    props.setFieldValue('journalLineItems', newData, true);
+    this.updateAmount(newData);
+  };
 
-	selectItem = (e, row, name, form, field) => {
-		//e.preventDefault();
-		let idx;
-		const data = this.state.data;
-		data.map((obj, index) => {
-			if (obj.id === row.id) {
-				if (name === 'debitAmount') {
-					obj[`${name}`] = e;
-					obj['creditAmount'] = 0;
-				} else if (name === 'creditAmount') {
-					obj[`${name}`] = e;
-					obj['debitAmount'] = 0;
-				} else {
-					obj[`${name}`] = e;
-				}
-				idx = index;
-			}
-			return obj;
-		});
-		if (name === 'debitAmount') {
-			form.setFieldValue(`journalLineItems.[${idx}].creditAmount`, 0, true);
-			form.setFieldValue(
-				field.name,
-				this.state.data[parseInt(idx, 10)][`${name}`],
-				true,
-			);
-			this.updateAmount(data);
-		} else if (name === 'creditAmount') {
-			form.setFieldValue(
-				field.name,
-				this.state.data[parseInt(idx, 10)][`${name}`],
-				true,
-			);
-			form.setFieldValue(`journalLineItems.[${idx}].debitAmount`, 0, true);
-			this.updateAmount(data);
-		} else {
-			this.setState({ data }, () => {
-				this.formRef.current.setFieldValue(
-					field.name,
-					this.state.data[parseInt(idx, 10)][`${name}`],
-					true,
-				);
-			});
-		}
-	};
+  updateAmount = data => {
+    let subTotalDebitAmount = 0;
+    let subTotalCreditAmount = 0;
+    // let totalDebitAmount = 0;
+    // let totalCreditAmount = 0;
 
-	deleteRow = (e, row, props) => {
-		const id = row['id'];
-		let newData = [];
-		e.preventDefault();
-		const data = this.state.data;
-		newData = data.filter((obj) => obj.id !== id);
-		props.setFieldValue('journalLineItems', newData, true);
-		this.updateAmount(newData);
-	};
+    data.map(obj => {
+      if (obj.debitAmount || obj.creditAmount) {
+        subTotalDebitAmount = subTotalDebitAmount + +obj.debitAmount;
+        subTotalCreditAmount = subTotalCreditAmount + +obj.creditAmount;
+      }
+      return obj;
+    });
 
-	updateAmount = (data) => {
-		let subTotalDebitAmount = 0;
-		let subTotalCreditAmount = 0;
-		// let totalDebitAmount = 0;
-		// let totalCreditAmount = 0;
+    this.setState({
+      data,
+      initValue: {
+        ...this.state.initValue,
+        ...{
+          subTotalDebitAmount,
+          totalDebitAmount: subTotalDebitAmount,
+          totalCreditAmount: subTotalCreditAmount,
+          subTotalCreditAmount,
+        },
+      },
+    });
+  };
 
-		data.map((obj) => {
-			if (obj.debitAmount || obj.creditAmount) {
-				subTotalDebitAmount = subTotalDebitAmount + +obj.debitAmount;
-				subTotalCreditAmount = subTotalCreditAmount + +obj.creditAmount;
-			}
-			return obj;
-		});
+  handleSubmit = (values, resetForm) => {
+    if (
+      this.state.submitJournal &&
+      this.state.initValue.totalCreditAmount.toLocaleString(navigator.language, {
+        minimumFractionDigits: 2,
+      }) !==
+        this.state.initValue.totalDebitAmount.toLocaleString(navigator.language, {
+          minimumFractionDigits: 2,
+        })
+    )
+      this.setState({ disabled: false });
+    else this.setState({ disabled: true });
+    const { data, initValue } = this.state;
+    if (initValue.totalCreditAmount === initValue.totalDebitAmount) {
+      data.map(item => {
+        delete item.id;
+        item.transactionCategoryId = item.transactionCategoryId ? item.transactionCategoryId : '';
+        item.contactId = item.contactId ? item.contactId : '';
 
-		this.setState({
-			data,
-			initValue: {
-				...this.state.initValue,
-				...{
-					subTotalDebitAmount,
-					totalDebitAmount: subTotalDebitAmount,
-					totalCreditAmount: subTotalCreditAmount,
-					subTotalCreditAmount,
-				},
-			},
-		});
-	};
-
-	handleSubmit = (values, resetForm) => {
-		if(this.state.submitJournal &&
-          this.state.initValue.totalCreditAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) !==
-          this.state.initValue.totalDebitAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }))
+        return item;
+      });
+      const postData = {
+        journalDate: values.journalDate ? values.journalDate : '',
+        journalReferenceNo: values.journalReferenceNo ? values.journalReferenceNo : '',
+        description: values.description ? values.description : '',
+        currencyCode: values.currencyCode ? values.currencyCode : '',
+        subTotalCreditAmount: initValue.subTotalCreditAmount,
+        subTotalDebitAmount: initValue.subTotalDebitAmount,
+        totalCreditAmount: initValue.totalCreditAmount,
+        totalDebitAmount: initValue.totalDebitAmount,
+        journalLineItems: data,
+      };
+      this.setState({
+        loading: true,
+        disableLeavePage: true,
+        loadingMsg: 'Creating New Journal...',
+      });
+      this.props.journalCreateActions
+        .createJournal(postData)
+        .then(res => {
           this.setState({ disabled: false });
-        else
-    	this.setState({ disabled: true });
-		const { data, initValue } = this.state;
-		if (initValue.totalCreditAmount === initValue.totalDebitAmount) {
-			data.map((item) => {
-				delete item.id;
-				item.transactionCategoryId = item.transactionCategoryId
-					? item.transactionCategoryId
-					: '';
-				item.contactId = item.contactId ? item.contactId : '';
+          this.setState({ loading: false });
+          if (res.status === 200) {
+            this.props.commonActions.tostifyAlert(
+              'success',
+              res.data ? res.data.message : 'New Journal Created Successfully'
+            );
+            if (this.state.createMore) {
+              this.setState(
+                {
+                  createMore: false,
+                  disableLeavePage: false,
+                  submitJournal: false,
+                  data: [
+                    {
+                      id: 0,
+                      description: '',
+                      transactionCategoryId: '',
+                      contactId: '',
+                      debitAmount: 0,
+                      creditAmount: 0,
+                    },
+                    {
+                      id: 1,
+                      description: '',
+                      transactionCategoryId: '',
+                      contactId: '',
+                      debitAmount: 0,
+                      creditAmount: 0,
+                    },
+                  ],
+                  initValue: {
+                    ...this.state.initValue,
+                    ...{
+                      journalLineItems: [
+                        {
+                          id: 0,
+                          description: '',
+                          transactionCategoryId: '',
+                          contactId: '',
+                          debitAmount: 0,
+                          creditAmount: 0,
+                        },
+                        {
+                          id: 1,
+                          description: '',
+                          transactionCategoryId: '',
+                          contactId: '',
+                          debitAmount: 0,
+                          creditAmount: 0,
+                        },
+                      ],
+                      subTotalDebitAmount: 0,
+                      totalDebitAmount: 0,
+                      totalCreditAmount: 0,
+                      subTotalCreditAmount: 0,
+                    },
+                  },
+                },
+                () => {
+                  resetForm(this.state.initValue);
+                }
+              );
+            } else {
+              this.props.history.push('/admin/accountant/journal');
+              this.setState({ loading: false });
+            }
+          }
+        })
+        .catch(err => {
+          this.setState({ disabled: false });
+          this.props.commonActions.tostifyAlert(
+            'error',
+            err.data ? err.data.message : 'Journal Created Unsuccessfully'
+          );
+        });
+    }
+  };
 
-				return item;
-			});
-			const postData = {
-				journalDate: values.journalDate ? values.journalDate : '',
-				journalReferenceNo: values.journalReferenceNo
-					? values.journalReferenceNo
-					: '',
-				description: values.description ? values.description : '',
-				currencyCode: values.currencyCode ? values.currencyCode : '',
-				subTotalCreditAmount: initValue.subTotalCreditAmount,
-				subTotalDebitAmount: initValue.subTotalDebitAmount,
-				totalCreditAmount: initValue.totalCreditAmount,
-				totalDebitAmount: initValue.totalDebitAmount,
-				journalLineItems: data,
-			};
-			this.setState({ loading:true, disableLeavePage:true,loadingMsg:"Creating New Journal..."});
-			this.props.journalCreateActions
-				.createJournal(postData)
-				.then((res) => {
-					this.setState({ disabled: false });
-					this.setState({ loading:false});
-					if (res.status === 200) {
-						this.props.commonActions.tostifyAlert(
-							'success',
-							res.data ? res.data.message : 'New Journal Created Successfully',
-						);
-						if (this.state.createMore) {
-							this.setState(
-								{
-									createMore: false,
-									disableLeavePage: false,
-									submitJournal: false,
-									data: [
-										{
-											id: 0,
-											description: '',
-											transactionCategoryId: '',
-											contactId: '',
-											debitAmount: 0,
-											creditAmount: 0,
-										},
-										{
-											id: 1,
-											description: '',
-											transactionCategoryId: '',
-											contactId: '',
-											debitAmount: 0,
-											creditAmount: 0,
-										},
-									],
-									initValue: {
-										...this.state.initValue,
-										...{
-											journalLineItems: [
-												{
-													id: 0,
-													description: '',
-													transactionCategoryId: '',
-													contactId: '',
-													debitAmount: 0,
-													creditAmount: 0,
-												},
-												{
-													id: 1,
-													description: '',
-													transactionCategoryId: '',
-													contactId: '',
-													debitAmount: 0,
-													creditAmount: 0,
-												},
-											],
-											subTotalDebitAmount: 0,
-											totalDebitAmount: 0,
-											totalCreditAmount: 0,
-											subTotalCreditAmount: 0,
-										},
-									},
-								},
-								() => {
-									resetForm(this.state.initValue);
-														},
-							);
-						} else {
-							this.props.history.push('/admin/accountant/journal');
-							this.setState({ loading:false,});
-							
-						}
-					}
-				})
-				.catch((err) => {
-					this.setState({ disabled: false });
-					this.props.commonActions.tostifyAlert(
-						'error',
-						err.data ? err.data.message : 'Journal Created Unsuccessfully'
-					);
-				});
-		}
-	};
+  render() {
+    strings.setLanguage(this.state.language);
+    const { data, initValue, loading, loadingMsg, exist } = this.state;
+    const { currency_list, universal_currency_list } = this.props;
 
-	render() {
-		strings.setLanguage(this.state.language);
-		const { data, initValue ,loading,loadingMsg,exist} = this.state;
-		const { currency_list,universal_currency_list } = this.props;
+    return loading == true ? (
+      <Loader loadingMsg={loadingMsg} />
+    ) : (
+      <div>
+        <div className="create-journal-screen">
+          <div className="animated fadeIn">
+            <Row>
+              <Col lg={12} className="mx-auto">
+                <Card>
+                  <CardHeader>
+                    <Row>
+                      <Col lg={12}>
+                        <div className="h4 mb-0 d-flex align-items-center">
+                          <i className="fa fa-diamond" />
+                          <span className="ml-2">{strings.CreateJournal}</span>
+                        </div>
+                      </Col>
+                    </Row>
+                  </CardHeader>
+                  <CardBody>
+                    {loading ? (
+                      <Row>
+                        <Col lg={12}>
+                          <Loader />
+                        </Col>
+                      </Row>
+                    ) : (
+                      <Row>
+                        <Col lg={12}>
+                          <Formik
+                            initialValues={initValue}
+                            ref={this.formRef}
+                            onSubmit={(values, { resetForm }) => {
+                              this.handleSubmit(values, resetForm);
+                            }}
+                            validate={values => {
+                              let errors = {};
+                              if (!values.journalDate) {
+                                errors.journalDate = 'Date is required';
+                              }
+                              if (exist === true) {
+                                errors.journalReferenceNo =
+                                  'Journal reference number already exists';
+                              }
+                              if (
+                                this.state.initValue.totalCreditAmount === 0 &&
+                                this.state.initValue.totalDebitAmount === 0
+                              ) {
+                                errors.submitJournal = '*Total Amount Must Be Greater Than Zero';
+                              }
+                              return errors;
+                            }}
+                            validationSchema={Yup.object().shape({
+                              // journalDate: Yup.date().required(
+                              // 	'Journal date is required',
+                              // ),
+                              journalLineItems: Yup.array()
+                                .of(
+                                  Yup.object().shape({
+                                    transactionCategoryId:
+                                      Yup.string().required('Account is required'),
+                                    debitAmount: Yup.string().required('Debit is required'),
+                                    creditAmount: Yup.string().required('Credit is required'),
+                                  })
+                                )
+                                .min(
+                                  2,
+                                  'Atleast two journal debit and credit details is mandatory'
+                                ),
+                            })}
+                          >
+                            {props => (
+                              <Form onSubmit={props.handleSubmit}>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="date">
+                                        <span className="text-danger">* </span>
+                                        {strings.JournalDate}
+                                      </Label>
+                                      <DatePicker
+                                        id="journalDate"
+                                        name="journalDate"
+                                        className={`form-control ${
+                                          props.errors.journalDate && props.touched.journalDate
+                                            ? 'is-invalid'
+                                            : ''
+                                        }`}
+                                        placeholderText={strings.JournalDate}
+                                        selected={props.values.journalDate}
+                                        showMonthDropdown
+                                        showYearDropdown
+                                        dropdownMode="select"
+                                        dateFormat="dd-MM-yyyy"
+                                        maxDate={new Date()}
+                                        onChange={value => {
+                                          props.handleChange('journalDate')(value);
+                                        }}
+                                      />
+                                      {props.errors.journalDate && props.touched.journalDate && (
+                                        <div className="invalid-feedback">
+                                          {props.errors.journalDate.includes('nullable()')
+                                            ? 'Journal date is required'
+                                            : props.errors.journalDate}
+                                        </div>
+                                      )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="journalReferenceNo">
+                                        {strings.JournalReference}
+                                      </Label>
+                                      <Input
+                                        type="text"
+                                        maxLength="50"
+                                        id="journalReferenceNo"
+                                        name="journalReferenceNo"
+                                        placeholder={strings.Enter + strings.JournalReferenceNo}
+                                        value={props.values.journalReferenceNo}
+                                        //  onBlur={props.handleBlur('journalReferenceNo')}
+                                        onChange={option => {
+                                          props.handleChange('journalReferenceNo')(option);
 
-		return (
-			loading ==true? <Loader loadingMsg={loadingMsg}/> :
-			<div>
-			<div className="create-journal-screen">
-				<div className="animated fadeIn">
-					<Row>
-						<Col lg={12} className="mx-auto">
-							<Card>
-								<CardHeader>
-									<Row>
-										<Col lg={12}>
-											<div className="h4 mb-0 d-flex align-items-center">
-												<i className="fa fa-diamond" />
-												<span className="ml-2">{strings.CreateJournal}</span>
-											</div>
-										</Col>
-									</Row>
-								</CardHeader>
-								<CardBody>
-								{loading ? (
-										<Row>
-											<Col lg={12}>
-												<Loader />
-											</Col>
-										</Row>
-									) : (
-									<Row>
-										<Col lg={12}>
-											<Formik
-												initialValues={initValue}
-												ref={this.formRef}
-												onSubmit={(values, { resetForm }) => {
-													this.handleSubmit(values, resetForm);
-												}}
-												
-												validate={(values) => {
-													let errors = {};
-													if (!values.journalDate) {
-														errors.journalDate =
-															'Date is required';
-													}
-													if (exist === true) {
-														errors.journalReferenceNo =
-															'Journal reference number already exists';
-													}
-													if (this.state.initValue.totalCreditAmount === 0
-														&& this.state.initValue.totalDebitAmount === 0) {
-														errors.submitJournal = "*Total Amount Must Be Greater Than Zero";
-													}
-													return errors;
-												}
-											}
-												validationSchema={Yup.object().shape({
-													// journalDate: Yup.date().required(
-													// 	'Journal date is required',
-													// ),
-													journalLineItems: Yup.array()
-														.of(
-															Yup.object().shape({
-																transactionCategoryId: Yup.string().required(
-																	'Account is required',
-																),
-																debitAmount: Yup.string().required('Debit is required'),
-																creditAmount: Yup.string().required('Credit is required'),
-															}),
-														)
-														.min(
-															2,
-															'Atleast two journal debit and credit details is mandatory',
-														),
-												})}
-											>
-												{(props) => (
-													<Form onSubmit={props.handleSubmit}>
-														<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																<Label htmlFor="date">
-																		<span className="text-danger">* </span>
-																		{strings.JournalDate}
-																	</Label>
-																	<DatePicker
-																		id="journalDate"
-																		name="journalDate"
-																		className={`form-control ${
-																			props.errors.journalDate &&
-																			props.touched.journalDate
-																				? 'is-invalid'
-																				: ''
-																		}`}
-																		placeholderText={strings.JournalDate}
-																		selected={props.values.journalDate}
-																		showMonthDropdown
-																		showYearDropdown
-																		dropdownMode="select"
-																		dateFormat="dd-MM-yyyy"   
-																		maxDate={new Date()}
-																		onChange={(value) => {
-																			props.handleChange('journalDate')(value);
-																		}}
-																	/>
-																	{props.errors.journalDate &&
-																		props.touched.journalDate && (
-																			<div className="invalid-feedback">
-																				{props.errors.journalDate.includes("nullable()") ? "Journal date is required" :props.errors.journalDate}
+                                          // this.validationCheck(option.target.value);
+                                        }}
+                                        className={
+                                          props.errors.journalReferenceNo &&
+                                          props.touched.journalReferenceNo
+                                            ? 'is-invalid'
+                                            : ''
+                                        }
+                                      />
+                                      {props.errors.journalReferenceNo &&
+                                        props.touched.journalReferenceNo && (
+                                          <div className="invalid-feedback">
+                                            {props.errors.journalReferenceNo}
+                                          </div>
+                                        )}
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="description">{strings.Notes}</Label>
+                                      <Input
+                                        type="textarea"
+                                        maxLength="250"
+                                        name="description"
+                                        id="description"
+                                        rows="5"
+                                        placeholder={strings.DeliveryNotes}
+                                        value={props.values.description || ''}
+                                        onChange={value => {
+                                          props.handleChange('description')(value);
+                                        }}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="currencyCode">{strings.Currency}</Label>
+                                      <Select
+                                        styles={customStyles}
+                                        className="select-default-width"
+                                        options={
+                                          currency_list
+                                            ? selectCurrencyFactory.renderOptions(
+                                                'currencyName',
+                                                'currencyCode',
+                                                currency_list,
+                                                'Currency'
+                                              )
+                                            : []
+                                        }
+                                        id="currencyCode"
+                                        name="currencyCode"
+                                        value={
+                                          currency_list &&
+                                          selectCurrencyFactory
+                                            .renderOptions(
+                                              'currencyName',
+                                              'currencyCode',
+                                              currency_list,
+                                              'Currency'
+                                            )
+                                            .find(
+                                              option => option.value === +props.values.currencyCode
+                                            )
+                                        }
+                                        isDisabled={
+                                          props.values.postingReferenceType === 'MANUAL'
+                                            ? false
+                                            : true
+                                        }
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('currencyCode')(option);
+                                          } else {
+                                            props.handleChange('currencyCode')('');
+                                          }
+                                        }}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <hr />
+                                <Row>
+                                  <Col lg={12} className="mb-3">
+                                    <Button
+                                      color="primary"
+                                      className="btn-square mr-3"
+                                      onClick={this.addRow}
+                                    >
+                                      <i className="fa fa-plus"></i> {strings.Addmore}
+                                    </Button>
+                                  </Col>
+                                </Row>
+                                {props.errors.journalLineItems &&
+                                  typeof props.errors.journalLineItems === 'string' && (
+                                    <div
+                                      className={props.errors.journalLineItems ? 'is-invalid' : ''}
+                                    >
+                                      <div className="invalid-feedback">
+                                        <Badge
+                                          color="danger"
+                                          style={{
+                                            padding: '10px',
+                                            marginBottom: '5px',
+                                          }}
+                                        >
+                                          {props.errors.journalLineItems}
+                                        </Badge>
+                                      </div>
+                                    </div>
+                                  )}
+                                {this.state.submitJournal &&
+                                  !props.errors.journalLineItems &&
+                                  this.state.initValue.totalCreditAmount.toLocaleString(
+                                    navigator.language,
+                                    { minimumFractionDigits: 2 }
+                                  ) !==
+                                    this.state.initValue.totalDebitAmount.toLocaleString(
+                                      navigator.language,
+                                      { minimumFractionDigits: 2 }
+                                    ) && (
+                                    <div
+                                      className={
+                                        this.state.initValue.totalDebitAmount !==
+                                        this.state.initValue.totalCreditAmount
+                                          ? 'is-invalid'
+                                          : ''
+                                      }
+                                    >
+                                      <div className="invalid-feedback">
+                                        <Badge
+                                          color="danger"
+                                          style={{
+                                            padding: '10px',
+                                            marginBottom: '5px',
+                                          }}
+                                        >
+                                          *Total Credit Amount and Total Debit Amount Should be
+                                          Equal
+                                        </Badge>
+                                      </div>
+                                    </div>
+                                  )}
+                                {this.state.submitJournal && props.errors.submitJournal && (
+                                  <div
+                                    className={
+                                      this.state.initValue.totalCreditAmount === 0 &&
+                                      this.state.initValue.totalDebitAmount === 0
+                                        ? 'is-invalid'
+                                        : ''
+                                    }
+                                  >
+                                    <div className="invalid-feedback">
+                                      <Badge
+                                        color="danger"
+                                        style={{
+                                          padding: '10px',
+                                          marginBottom: '5px',
+                                        }}
+                                      >
+                                        *Total Amount Must Be Greater Than Zero
+                                      </Badge>
+                                    </div>
+                                  </div>
+                                )}
+                                <Row>
+                                  <Col lg={12}>
+                                    <BootstrapTable
+                                      options={this.options}
+                                      data={data}
+                                      version="4"
+                                      hover
+                                      keyField="id"
+                                      className="journal-create-table"
+                                    >
+                                      <TableHeaderColumn
+                                        width="55"
+                                        dataAlign="center"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderActions(cell, rows, props)
+                                        }
+                                      ></TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        width={'400px'}
+                                        dataField="transactionCategoryId"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderAccount(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.ACCOUNT}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="description"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderDescription(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.DESCRIPTION}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="contactId"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderContact(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.CONTACT}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="debitAmount"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderDebits(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.DEBIT}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="creditAmount"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderCredits(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.CREDIT}
+                                      </TableHeaderColumn>
+                                    </BootstrapTable>
+                                  </Col>
+                                </Row>
 
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-														</Row>
-														<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="journalReferenceNo">
-																	{strings.JournalReference}
-																	</Label>
-																	<Input
-																		type="text"
-																		maxLength='50'
-																		id="journalReferenceNo"
-																		name="journalReferenceNo"
-																		placeholder={strings.Enter + strings.JournalReferenceNo}
-																		value={props.values.journalReferenceNo}
-																		//  onBlur={props.handleBlur('journalReferenceNo')}
-																		onChange={(option) => {
-																				props.handleChange(
-																					'journalReferenceNo',
-																				)(option);
-																			
-																			// this.validationCheck(option.target.value);
-																		}}
-																		className={
-																			
-																			props.errors.journalReferenceNo &&
-																			props.touched.journalReferenceNo
-																				? 'is-invalid'
-																				: ''
-																		}
-																	/>
-																	{props.errors.journalReferenceNo &&
-																		props.touched.journalReferenceNo && (
-																			<div className="invalid-feedback">
-																				{props.errors.journalReferenceNo}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-														</Row>
-														<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="description">{strings.Notes}</Label>
-																	<Input
-																		type="textarea"
-																		maxLength="250"
-																		name="description"
-																		id="description"
-																		rows="5"
-																		placeholder={strings.DeliveryNotes}
-																		value={props.values.description || ''}
-																		onChange={(value) => {
-																			props.handleChange('description')(value);
-																		}}
-																	/>
-																</FormGroup>
-															</Col>
-														</Row>
-														<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="currencyCode">{strings.Currency}</Label>
-																	<Select
-																		styles={customStyles}
-																		className="select-default-width"
-																		options={
-																			currency_list
-																				? selectCurrencyFactory.renderOptions(
-																						'currencyName',
-																						'currencyCode',
-																						currency_list,
-																						'Currency',
-																				  )
-																				: []
-																		}
-																		id="currencyCode"
-																		name="currencyCode"
-																		value={
-																			currency_list &&
-																			selectCurrencyFactory
-																				.renderOptions(
-																					'currencyName',
-																					'currencyCode',
-																					currency_list,
-																					'Currency',
-																				)
-																				.find(
-																					(option) =>
-																						option.value ===
-																						+props.values.currencyCode,
-																				)
-																		}
-																		isDisabled={
-																			props.values.postingReferenceType ===
-																			'MANUAL'
-																				? false
-																				: true
-																		}
-																		onChange={(option) => {
-																			if (option && option.value) {
-																				props.handleChange('currencyCode')(
-																					option,
-																				);
-																			} else {
-																				props.handleChange('currencyCode')('');
-																			}
-																		}}
-																	/>
-																</FormGroup>
-															</Col>
-														</Row>
-														<hr />
-														<Row>
-															<Col lg={12} className="mb-3">
-																<Button
-																	color="primary"
-																	className="btn-square mr-3"
-																	onClick={this.addRow}
-																>
-																	<i className="fa fa-plus"></i> {strings.Addmore} 
-																</Button>
-															</Col>
-														</Row>
-														{props.errors.journalLineItems &&
-															typeof props.errors.journalLineItems ===
-																'string' && (
-																<div
-																	className={
-																		props.errors.journalLineItems
-																			? 'is-invalid'
-																			: ''
-																	}
-																>
-																	<div className="invalid-feedback">
-																		<Badge
-																			color="danger"
-																			style={{
-																				padding: '10px',
-																				marginBottom: '5px',
-																			}}
-																		>
-																			{props.errors.journalLineItems}
-																		</Badge>
-																	</div>
-																</div>
-															)}
-														{this.state.submitJournal &&
-														!props.errors.journalLineItems &&
-															this.state.initValue.totalCreditAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) !==
-															this.state.initValue.totalDebitAmount.toLocaleString(navigator.language, { minimumFractionDigits: 2 }) && (
-																<div
-																	className={
-																		this.state.initValue.totalDebitAmount !==
-																		this.state.initValue.totalCreditAmount
-																			? 'is-invalid'
-																			: ''
-																	}
-																>
-																	<div className="invalid-feedback">
-																		<Badge
-																			color="danger"
-																			style={{
-																				padding: '10px',
-																				marginBottom: '5px',
-																			}}
-																		>
-																			*Total Credit Amount and Total Debit
-																			Amount Should be Equal
-																		</Badge>
-																	</div>
-																</div>
-															)}
-														{this.state.submitJournal &&
-														props.errors.submitJournal && (
-																<div
-																	className={
-																		this.state.initValue.totalCreditAmount === 0
-																		&& this.state.initValue.totalDebitAmount === 0
-																			? 'is-invalid'
-																			: ''
-																	}
-																>
-																	<div className="invalid-feedback">
-																		<Badge
-																			color="danger"
-																			style={{
-																				padding: '10px',
-																				marginBottom: '5px',
-																			}}
-																		>
-																			*Total Amount Must Be Greater Than Zero
-																		</Badge>
-																	</div>
-																</div>
-															)}
-														<Row>
-															<Col lg={12}>
-																<BootstrapTable
-																	options={this.options}
-																	data={data}
-																	version="4"
-																	hover
-																	keyField="id"
-																	className="journal-create-table"
-																>
-																	<TableHeaderColumn
-																		width="55"
-																		dataAlign="center"
-																		dataFormat={(cell, rows) =>
-																			this.renderActions(cell, rows, props)
-																		}
-																	></TableHeaderColumn>
-																	<TableHeaderColumn
-																		width={ "400px" }
-																		dataField="transactionCategoryId"
-																		dataFormat={(cell, rows) =>
-																			this.renderAccount(cell, rows, props)
-																		}
+                                {this.state.data.length > 0 ? (
+                                  <Row>
+                                    <Col lg={4} className="ml-auto">
+                                      <div className="total-item p-2">
+                                        <Row>
+                                          <Col xs={4}></Col>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.Debit}</h5>
+                                          </Col>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.Credit}</h5>
+                                          </Col>
+                                        </Row>
+                                      </div>
+                                      <div className="total-item p-2">
+                                        <Row>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.SubTotal}</h5>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalDebitAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalCreditAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                        </Row>
+                                      </div>
+                                      <div className="total-item p-2">
+                                        <Row>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.Total}</h5>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalDebitAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalCreditAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                        </Row>
+                                      </div>
+                                    </Col>
+                                  </Row>
+                                ) : null}
 
-																	>
-																		{strings.ACCOUNT} 
-																	</TableHeaderColumn>
-																	<TableHeaderColumn
-																		dataField="description"
-																		dataFormat={(cell, rows) =>
-																			this.renderDescription(cell, rows, props)
-																		}
-																	>
-																		{strings.DESCRIPTION}
-																	</TableHeaderColumn>
-																	<TableHeaderColumn
-																		dataField="contactId"
-																		dataFormat={(cell, rows) =>
-																			this.renderContact(cell, rows, props)
-																		}
-																	>
-																	   {strings.CONTACT} 
-																	</TableHeaderColumn>
-																	<TableHeaderColumn
-																		dataField="debitAmount"
-																		dataFormat={(cell, rows) =>
-																			this.renderDebits(cell, rows, props)
-																		}
-																	>
-																		{strings.DEBIT} 
-																	</TableHeaderColumn>
-																	<TableHeaderColumn
-																		dataField="creditAmount"
-																		dataFormat={(cell, rows) =>
-																			this.renderCredits(cell, rows, props)
-																		}
-																	>
-																		{strings.CREDIT}
-																	</TableHeaderColumn>
-																</BootstrapTable>
-															</Col>
-														</Row>
-
-														{this.state.data.length > 0 ? (
-															<Row>
-																<Col lg={4} className="ml-auto">
-																	<div className="total-item p-2">
-																		<Row>
-																			<Col xs={4}></Col>
-																			<Col xs={4}>
-																				<h5 className="mb-0 text-right">
-																				{strings.Debit} 
-																				</h5>
-																			</Col>
-																			<Col xs={4}>
-																				<h5 className="mb-0 text-right">
-																				{strings.Credit} 
-																				</h5>
-																			</Col>
-																		</Row>
-																	</div>
-																	<div className="total-item p-2">
-																		<Row>
-																			<Col xs={4}>
-																				<h5 className="mb-0 text-right">
-																				{strings.SubTotal}
-																				</h5>
-																			</Col>
-																			<Col xs={4} className="text-right">
-																				<label className="mb-0">
-																				{universal_currency_list[0] && (
-																						<Currency
-																						value=
-																						{this.state.initValue.subTotalDebitAmount}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																				</label>
-																			</Col>
-																			<Col xs={4} className="text-right">
-																				<label className="mb-0">
-																				{universal_currency_list[0] && (
-																						<Currency
-																						value=
-																						{this.state.initValue.subTotalCreditAmount}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																				</label>
-																			</Col>
-																		</Row>
-																	</div>
-																	<div className="total-item p-2">
-																		<Row>
-																			<Col xs={4}>
-																				<h5 className="mb-0 text-right">
-																				{strings.Total}
-																				</h5>
-																			</Col>
-																			<Col xs={4} className="text-right">
-																				<label className="mb-0">
-																				{universal_currency_list[0] && (
-																						<Currency
-																						value=
-																						{this.state.initValue.subTotalDebitAmount}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																				</label>
-																			</Col>
-																			<Col xs={4} className="text-right">
-																				<label className="mb-0">
-																				{universal_currency_list[0] && (
-																						<Currency
-																						value=
-																						{this.state.initValue.subTotalCreditAmount}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																				</label>
-																			</Col>
-																		</Row>
-																	</div>
-																</Col>
-															</Row>
-														) : null}
-
-														<Row>
-															<Col lg={12} className="mt-5">
-																<FormGroup className="text-right form-action-btn">
-																	<Button
-																		type="button"
-																		color="primary"
-																		className="btn-square mr-3"
-																		disabled={this.state.disabled}
-																		onClick={() => {
-																				//  added validation popup  msg  
-																				console.log(props.errors)                                                              
-																				props.handleBlur();
-																				if(props.errors &&  Object.keys(props.errors).length != 0)
-																				this.props.commonActions.fillManDatoryDetails();
-																			this.setState(
-																				{
-																					createMore: false,
-																					submitJournal: true,
-																				},
-																				() => {
-																					props.handleSubmit();
-																				},
-																			);
-																		}}
-																	>
-																		<i className="fa fa-dot-circle-o"></i>{' '}
-																		{this.state.disabled
-																			? 'Creating...'
-																			: strings.Create }
-																	</Button>
-																	<Button
-																		type="button"
-																		color="primary"
-																		className="btn-square mr-3"
-																		onClick={() => {
-																				//  added validation popup  msg                                                                
-																				props.handleBlur();
-																				if(props.errors &&  Object.keys(props.errors).length != 0)
-																				this.props.commonActions.fillManDatoryDetails();
-																			this.setState(
-																				{
-																					createMore: true,
-																					submitJournal: true,
-																				},
-																				() => {
-																					props.handleSubmit();
-																				},
-																			);
-																		}}
-																	>
-																		<i className="fa fa-refresh"></i>{' '} 
-																		{this.state.disabled
-																			? 'Creating...'
-																			: strings.CreateandMore }
-																	</Button>
-																	<Button
-																		color="secondary"
-																		className="btn-square"
-																		onClick={() => {
-																			this.props.history.push(
-																				'/admin/accountant/journal',
-																			);
-																		}}
-																	>
-																		<i className="fa fa-ban"></i> {strings.Cancel}
-																	</Button>
-																</FormGroup>
-															</Col>
-														</Row>
-													</Form>
-												)}
-											</Formik>
-										</Col>
-									</Row>
-									)}
-								</CardBody>
-							</Card>
-						</Col>
-					</Row>
-				</div>
-			</div>
-			{this.state.disableLeavePage ?"":<LeavePage/>}
-			</div>
-		);
-	}
+                                <Row>
+                                  <Col lg={12} className="mt-5">
+                                    <FormGroup className="text-right form-action-btn">
+                                      <Button
+                                        type="button"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        disabled={this.state.disabled}
+                                        onClick={() => {
+                                          //  added validation popup  msg
+                                          console.log(props.errors);
+                                          props.handleBlur();
+                                          if (props.errors && Object.keys(props.errors).length != 0)
+                                            this.props.commonActions.fillManDatoryDetails();
+                                          this.setState(
+                                            {
+                                              createMore: false,
+                                              submitJournal: true,
+                                            },
+                                            () => {
+                                              props.handleSubmit();
+                                            }
+                                          );
+                                        }}
+                                      >
+                                        <i className="fa fa-dot-circle-o"></i>{' '}
+                                        {this.state.disabled ? 'Creating...' : strings.Create}
+                                      </Button>
+                                      <Button
+                                        type="button"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        onClick={() => {
+                                          //  added validation popup  msg
+                                          props.handleBlur();
+                                          if (props.errors && Object.keys(props.errors).length != 0)
+                                            this.props.commonActions.fillManDatoryDetails();
+                                          this.setState(
+                                            {
+                                              createMore: true,
+                                              submitJournal: true,
+                                            },
+                                            () => {
+                                              props.handleSubmit();
+                                            }
+                                          );
+                                        }}
+                                      >
+                                        <i className="fa fa-refresh"></i>{' '}
+                                        {this.state.disabled
+                                          ? 'Creating...'
+                                          : strings.CreateandMore}
+                                      </Button>
+                                      <Button
+                                        color="secondary"
+                                        className="btn-square"
+                                        onClick={() => {
+                                          this.props.history.push('/admin/accountant/journal');
+                                        }}
+                                      >
+                                        <i className="fa fa-ban"></i> {strings.Cancel}
+                                      </Button>
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                              </Form>
+                            )}
+                          </Formik>
+                        </Col>
+                      </Row>
+                    )}
+                  </CardBody>
+                </Card>
+              </Col>
+            </Row>
+          </div>
+        </div>
+        {this.state.disableLeavePage ? '' : <LeavePage />}
+      </div>
+    );
+  }
 }
 export default connect(mapStateToProps, mapDispatchToProps)(CreateJournal);

--- a/apps/frontend/src/screens/journal/screens/detail/screen.js
+++ b/apps/frontend/src/screens/journal/screens/detail/screen.js
@@ -2,17 +2,17 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Row,
-	Col,
-	Form,
-	FormGroup,
-	Input,
-	Label,
-	Badge,
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Input,
+  Label,
+  Badge,
 } from 'reactstrap';
 import Select from 'react-select';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
@@ -24,1432 +24,1289 @@ import { CommonActions } from 'services/global';
 import { selectCurrencyFactory } from 'utils';
 import * as JournalActions from '../../actions';
 import * as JournalDetailActions from './actions';
-import { Loader, LeavePage,ConfirmDeleteModal, Currency } from 'components';
+import { Loader, LeavePage, ConfirmDeleteModal, Currency } from 'components';
 import 'react-datepicker/dist/react-datepicker.css';
 import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
 import './style.scss';
-import {data}  from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 import { JOURNAL } from 'constants/types';
 
-const mapStateToProps = (state) => {
-	return {
-		transaction_category_list: state.journal.transaction_category_list,
-		currency_list: state.journal.currency_list,
-		contact_list: state.journal.contact_list,
-		vat_list: state.journal.vat_list,
-		universal_currency_list: state.common.universal_currency_list,
-		cancel_flag: state.journal.cancel_flag
-	};
+const mapStateToProps = state => {
+  return {
+    transaction_category_list: state.journal.transaction_category_list,
+    currency_list: state.journal.currency_list,
+    contact_list: state.journal.contact_list,
+    vat_list: state.journal.vat_list,
+    universal_currency_list: state.common.universal_currency_list,
+    cancel_flag: state.journal.cancel_flag,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		commonActions: bindActionCreators(CommonActions, dispatch),
-		journalActions: bindActionCreators(JournalActions, dispatch),
-		journalDetailActions: bindActionCreators(JournalDetailActions, dispatch),
-	};
+const mapDispatchToProps = dispatch => {
+  return {
+    commonActions: bindActionCreators(CommonActions, dispatch),
+    journalActions: bindActionCreators(JournalActions, dispatch),
+    journalDetailActions: bindActionCreators(JournalDetailActions, dispatch),
+  };
 };
 const customStyles = {
-	control: (base, state) => ({
-		...base,
-		borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		boxShadow: state.isFocused ? null : null,
-		'&:hover': {
-			borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-		},
-	}),
+  control: (base, state) => ({
+    ...base,
+    borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    boxShadow: state.isFocused ? null : null,
+    '&:hover': {
+      borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+    },
+  }),
 };
 
 let strings = new LocalizedStrings(data);
 class DetailJournal extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			language: window['localStorage'].getItem('language'),
-			loading: true,
-			current_journal_id: null,
-			initValue: {},
-			data: [],
-			submitJournal: false,
-		    disabled1:false,
-			disabled2: false,
-			disableLeavePage:false,
-			companyName: '',		  
-		};
-		
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: window['localStorage'].getItem('language'),
+      loading: true,
+      current_journal_id: null,
+      initValue: {},
+      data: [],
+      submitJournal: false,
+      disabled1: false,
+      disabled2: false,
+      disableLeavePage: false,
+      companyName: '',
+    };
 
-		this.formRef = React.createRef();
-		this.regEx = /^[0-9\d]+$/;
-		this.regExBoth = /[a-zA-Z0-9]+$/;
-		this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
-	}
+    this.formRef = React.createRef();
+    this.regEx = /^[0-9\d]+$/;
+    this.regExBoth = /[a-zA-Z0-9]+$/;
+    this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
+  }
 
-	componentDidMount = () => {
-		this.initializeData();
-	};
+  componentDidMount = () => {
+    this.initializeData();
+  };
 
-	initializeData = () => {
-		if (this.props.location.state && this.props.location.state.id) {
-			this.props.journalDetailActions
-				.getJournalById(this.props.location.state.id)
-				.then((res) => {
-					if (res.status === 200) {
-						this.props.journalActions.getCurrencyList();
-						this.props.journalActions.getTransactionCategoryList();
-						this.props.commonActions.getCompanyDetails().then((res) => {
-							if (res.status === 200) {
-							this.setState({ companyName: res.data.companyName });
-							}
-							  
-						})
-						this.props.journalActions.getContactList();
-						this.setState(
-							{
-								loading: false,
-								current_journal_id: this.props.location.state.id,
-								initValue: {
-									journalId: res.data.journalId,
-									journalDate: res.data.journalDate ? res.data.journalDate : '',
-									journalReferenceNo: res.data.journalReferenceNo
-										? res.data.journalReferenceNo
-										: '',
-									description: res.data.description ? res.data.description : '',
-									currencyCode: res.data.currencyCode
-										? res.data.currencyCode
-										: '',
-									subTotalDebitAmount: res.data.subTotalDebitAmount
-										? res.data.subTotalDebitAmount
-										: 0,
-									totalDebitAmount: res.data.totalDebitAmount
-										? res.data.totalDebitAmount
-										: 0,
-									totalCreditAmount: res.data.totalCreditAmount
-										? res.data.totalCreditAmount
-										: 0,
-									subTotalCreditAmount: res.data.subTotalCreditAmount
-										? res.data.subTotalCreditAmount
-										: 0,
-									journalLineItems: res.data.journalLineItems
-										? res.data.journalLineItems
-										: [],
-									postingReferenceType: res.data.postingReferenceType
-										? res.data.postingReferenceType
-										: '',
-								},
-								data: res.data.journalLineItems
-									? res.data.journalLineItems
-									: [],
-							},
-							() => {
-								const { data } = this.state;
-								const idCount =
-									data.length > 0
-										? Math.max.apply(
-												Math,
-												data.map((item) => {
-													return item.id;
-												}),
-										  )
-										: 0;
-								this.setState({
-									idCount,
-								});
-							},
-						);
-					}
-				})
-				.catch((err) => {
-					this.setState({ loading: false });
-				});
-		} else {
-			this.props.history.push('/admin/accountant/journal');
-		}
-	};
+  initializeData = () => {
+    if (this.props.location.state && this.props.location.state.id) {
+      this.props.journalDetailActions
+        .getJournalById(this.props.location.state.id)
+        .then(res => {
+          if (res.status === 200) {
+            this.props.journalActions.getCurrencyList();
+            this.props.journalActions.getTransactionCategoryList();
+            this.props.commonActions.getCompanyDetails().then(action => {
+              // Redux Toolkit thunks return action objects
+              if (action && action.type && action.type.includes('fulfilled')) {
+                this.setState({ companyName: action.payload.companyName });
+              }
+            });
+            this.props.journalActions.getContactList();
+            this.setState(
+              {
+                loading: false,
+                current_journal_id: this.props.location.state.id,
+                initValue: {
+                  journalId: res.data.journalId,
+                  journalDate: res.data.journalDate ? res.data.journalDate : '',
+                  journalReferenceNo: res.data.journalReferenceNo
+                    ? res.data.journalReferenceNo
+                    : '',
+                  description: res.data.description ? res.data.description : '',
+                  currencyCode: res.data.currencyCode ? res.data.currencyCode : '',
+                  subTotalDebitAmount: res.data.subTotalDebitAmount
+                    ? res.data.subTotalDebitAmount
+                    : 0,
+                  totalDebitAmount: res.data.totalDebitAmount ? res.data.totalDebitAmount : 0,
+                  totalCreditAmount: res.data.totalCreditAmount ? res.data.totalCreditAmount : 0,
+                  subTotalCreditAmount: res.data.subTotalCreditAmount
+                    ? res.data.subTotalCreditAmount
+                    : 0,
+                  journalLineItems: res.data.journalLineItems ? res.data.journalLineItems : [],
+                  postingReferenceType: res.data.postingReferenceType
+                    ? res.data.postingReferenceType
+                    : '',
+                },
+                data: res.data.journalLineItems ? res.data.journalLineItems : [],
+              },
+              () => {
+                const { data } = this.state;
+                const idCount =
+                  data.length > 0
+                    ? Math.max.apply(
+                        Math,
+                        data.map(item => {
+                          return item.id;
+                        })
+                      )
+                    : 0;
+                this.setState({
+                  idCount,
+                });
+              }
+            );
+          }
+        })
+        .catch(err => {
+          this.setState({ loading: false });
+        });
+    } else {
+      this.props.history.push('/admin/accountant/journal');
+    }
+  };
 
-	renderActions = (cell, rows, props) => {
-		return (
-			<Button
-				size="sm"
-				disabled={
-					props.values.postingReferenceType === 'MANUAL' ||
-					this.state.data.length > 2
-						? false
-						: true
-				}
-				className="btn-twitter btn-brand icon"
-				onClick={(e) => {
-					this.deleteRow(e, rows, props);
-				}}
-			>
-				<i className="fas fa-trash"></i>
-			</Button>
-		);
-	};
+  renderActions = (cell, rows, props) => {
+    return (
+      <Button
+        size="sm"
+        disabled={
+          props.values.postingReferenceType === 'MANUAL' || this.state.data.length > 2
+            ? false
+            : true
+        }
+        className="btn-twitter btn-brand icon"
+        onClick={e => {
+          this.deleteRow(e, rows, props);
+        }}
+      >
+        <i className="fas fa-trash"></i>
+      </Button>
+    );
+  };
 
-	checkedRow = () => {
-		if (this.state.data.length > 0) {
-			let length = this.state.data.length - 1;
-			let temp = Object.values(this.state.data[`${length}`]).indexOf('');
-			if (temp > -1) {
-				return true;
-			} else {
-				return false;
-			}
-		} else {
-			return false;
-		}
-	};
+  checkedRow = () => {
+    if (this.state.data.length > 0) {
+      let length = this.state.data.length - 1;
+      let temp = Object.values(this.state.data[`${length}`]).indexOf('');
+      if (temp > -1) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  };
 
-	renderAccount = (cell, row, props) => {
-		const { transaction_category_list } = this.props;
+  renderAccount = (cell, row, props) => {
+    const { transaction_category_list } = this.props;
 
-		// const getoptions=()=>{
-		// const tit=transactionCategoryList.find(
-		// 		(item) =>{
-		// 			item.label === row.journalTransactionCategoryLabel
-		// 		})
-				
-		// 		?.options?.find((i)=>{
-		// 			i.value===row.transactionCategoryId
-		// 		})?.label
-		// }
-		let transactionCategoryList =
-			transaction_category_list &&
-			transaction_category_list &&
-			transaction_category_list.length
-				? [
-						{
-							transactionCategoryId: '',
-							transactionCategoryName: 'Select Account',
-						},
-						...transaction_category_list,
-				  ]
-				: [];
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
-			
-if(row && row.journalTransactionCategoryLabel==='Bank')
-{
-	
-	return (
-		<Field
-			name={`journalLineItems.${idx}.transactionCategoryId`}
-			render={({ field, form }) => (			
-				<Input 
-				id="transactionCategoryId"
-				disabled={true} 
-				value={row.journalTransactionCategoryLabel ? row.transactionCategoryName == JOURNAL.AMOUNT_IN_TRANSIT ?
-					row.journalTransactionCategoryLabel:  row.transactionCategoryName
-					:''}
-				placeholder={strings.Select+strings.Account}
-					>						
-				</Input>
-			)}
-		/>
-	);
-}else
+    // const getoptions=()=>{
+    // const tit=transactionCategoryList.find(
+    // 		(item) =>{
+    // 			item.label === row.journalTransactionCategoryLabel
+    // 		})
 
-	if(row && row.transactionCategoryName==='Petty Cash')
-	{
-		return (
-			<Field
-				name={`journalLineItems.${idx}.transactionCategoryId`}
-				render={({ field, form }) => (			
-					<Input 
-					id="transactionCategoryId"
-					disabled={true} 
-					value={row.transactionCategoryName + (this.state.companyName ? ' - ' + this.state.companyName : '') ? row.transactionCategoryName + (this.state.companyName ? ' - ' + this.state.companyName : '') :''}
-					placeholder={strings.Select+strings.Account}
-						>						
-					</Input>
-				)}
-			/>
-		);
-	}else{
+    // 		?.options?.find((i)=>{
+    // 			i.value===row.transactionCategoryId
+    // 		})?.label
+    // }
+    let transactionCategoryList =
+      transaction_category_list && transaction_category_list && transaction_category_list.length
+        ? [
+            {
+              transactionCategoryId: '',
+              transactionCategoryName: 'Select Account',
+            },
+            ...transaction_category_list,
+          ]
+        : [];
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-		return (
-			<Field
-				name={`journalLineItems.${idx}.transactionCategoryId`}
-				render={({ field, form }) => (
-					<Select
-						styles={{
-							menu: (provided) => ({ ...provided, zIndex: 9999 }),
-						}}
-						options={transactionCategoryList ? transactionCategoryList : []}
-						id="transactionCategoryId"
-						onChange={(e) => {
-							this.selectItem(
-								e.value,
-								row,
-								'transactionCategoryId',
-								form,
-								field,
-							);
-						}}
-						isDisabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
-						value={
-							transactionCategoryList &&
-							transactionCategoryList.length > 0 &&
-							row.transactionCategoryName
-								? transactionCategoryList
-										.find(
-											(item) =>{
-												
-												return item.label === row.journalTransactionCategoryLabel
-											})?.options?.find((i)=>{
-			
-												return i.value===row.transactionCategoryId
-											})
-										
-								: row.transactionCategoryName
-						}
-						placeholder={strings.Select+strings.Account}
-						className={`${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)]
-								.transactionCategoryId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)]
-								.transactionCategoryId
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-				)}
-			/>
-		);
+    if (row && row.journalTransactionCategoryLabel === 'Bank') {
+      return (
+        <Field
+          name={`journalLineItems.${idx}.transactionCategoryId`}
+          render={({ field, form }) => (
+            <Input
+              id="transactionCategoryId"
+              disabled={true}
+              value={
+                row.journalTransactionCategoryLabel
+                  ? row.transactionCategoryName == JOURNAL.AMOUNT_IN_TRANSIT
+                    ? row.journalTransactionCategoryLabel
+                    : row.transactionCategoryName
+                  : ''
+              }
+              placeholder={strings.Select + strings.Account}
+            ></Input>
+          )}
+        />
+      );
+    } else if (row && row.transactionCategoryName === 'Petty Cash') {
+      return (
+        <Field
+          name={`journalLineItems.${idx}.transactionCategoryId`}
+          render={({ field, form }) => (
+            <Input
+              id="transactionCategoryId"
+              disabled={true}
+              value={
+                row.transactionCategoryName +
+                (this.state.companyName ? ' - ' + this.state.companyName : '')
+                  ? row.transactionCategoryName +
+                    (this.state.companyName ? ' - ' + this.state.companyName : '')
+                  : ''
+              }
+              placeholder={strings.Select + strings.Account}
+            ></Input>
+          )}
+        />
+      );
+    } else {
+      return (
+        <Field
+          name={`journalLineItems.${idx}.transactionCategoryId`}
+          render={({ field, form }) => (
+            <Select
+              styles={{
+                menu: provided => ({ ...provided, zIndex: 9999 }),
+              }}
+              options={transactionCategoryList ? transactionCategoryList : []}
+              id="transactionCategoryId"
+              onChange={e => {
+                this.selectItem(e.value, row, 'transactionCategoryId', form, field);
+              }}
+              isDisabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+              value={
+                transactionCategoryList &&
+                transactionCategoryList.length > 0 &&
+                row.transactionCategoryName
+                  ? transactionCategoryList
+                      .find(item => {
+                        return item.label === row.journalTransactionCategoryLabel;
+                      })
+                      ?.options?.find(i => {
+                        return i.value === row.transactionCategoryId;
+                      })
+                  : row.transactionCategoryName
+              }
+              placeholder={strings.Select + strings.Account}
+              className={`${
+                props.errors.journalLineItems &&
+                props.errors.journalLineItems[parseInt(idx, 10)] &&
+                props.errors.journalLineItems[parseInt(idx, 10)].transactionCategoryId &&
+                Object.keys(props.touched).length > 0 &&
+                props.touched.journalLineItems &&
+                props.touched.journalLineItems[parseInt(idx, 10)] &&
+                props.touched.journalLineItems[parseInt(idx, 10)].transactionCategoryId
+                  ? 'is-invalid'
+                  : ''
+              }`}
+            />
+          )}
+        />
+      );
+    }
+  };
 
-	}
-		
-	};
+  renderDescription = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-	renderDescription = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
-
-		return (
-			<Field
-				name={`journalLineItems.${idx}.description`}
-				render={({ field, form }) => (
-					<Input
-						type="text"
-						value={row['description'] !== '' ? row['description'] : ''}
-						disabled={
-							props.values.postingReferenceType === 'MANUAL' ? false : true
-						}
-						onChange={(e) => {
-							this.selectItem(e.target.value, row, 'description', form, field);
-						}}
-						placeholder={strings.Description}
-						className={`form-control 
+    return (
+      <Field
+        name={`journalLineItems.${idx}.description`}
+        render={({ field, form }) => (
+          <Input
+            type="text"
+            value={row['description'] !== '' ? row['description'] : ''}
+            disabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+            onChange={e => {
+              this.selectItem(e.target.value, row, 'description', form, field);
+            }}
+            placeholder={strings.Description}
+            className={`form-control 
             ${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].description &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].description
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-				)}
-			/>
-		);
-	};
+              props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].description &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].description
+                ? 'is-invalid'
+                : ''
+            }`}
+          />
+        )}
+      />
+    );
+  };
 
-	renderContact = (cell, row, props) => {
-		const { contact_list } = this.props;
-		let contactList = contact_list.length
-			? [{ value: '', label: 'Select Contact' }, ...contact_list]
-			: contact_list;
-		let idx;
+  renderContact = (cell, row, props) => {
+    const { contact_list } = this.props;
+    let contactList = contact_list.length
+      ? [{ value: '', label: 'Select Contact' }, ...contact_list]
+      : contact_list;
+    let idx;
 
-		if(this.state.data && this.state.data != undefined){
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
-	}
-	switch(row && row.postingReferenceType ?row.postingReferenceType:'')
-	{
-		case "MANUAL":
-			return (
-				<Field
-					name={`journalLineItems.${idx}.contactId`}
-					render={({ field, form }) => (
-						<Input
-							type="select"
-							onChange={(e) => {
-								this.selectItem(e.target.value, row, 'contactId', form, field);
-							}}
-							disabled={
-								props.values.postingReferenceType === 'MANUAL' ? false : true
-							}
-							value={row.contactId}
-							placeholder={strings.Select+strings.Contact}
-							className={`form-control 
+    if (this.state.data && this.state.data != undefined) {
+      this.state.data.map((obj, index) => {
+        if (obj.id === row.id) {
+          idx = index;
+        }
+        return obj;
+      });
+    }
+    switch (row && row.postingReferenceType ? row.postingReferenceType : '') {
+      case 'MANUAL':
+        return (
+          <Field
+            name={`journalLineItems.${idx}.contactId`}
+            render={({ field, form }) => (
+              <Input
+                type="select"
+                onChange={e => {
+                  this.selectItem(e.target.value, row, 'contactId', form, field);
+                }}
+                disabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+                value={row.contactId}
+                placeholder={strings.Select + strings.Contact}
+                className={`form-control 
 							${
-								props.errors.journalLineItems &&
-								props.errors.journalLineItems[parseInt(idx, 10)] &&
-								props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
-								Object.keys(props.touched).length > 0 &&
-								props.touched.journalLineItems &&
-								props.touched.journalLineItems[parseInt(idx, 10)] &&
-								props.touched.journalLineItems[parseInt(idx, 10)].contactId
-									? 'is-invalid'
-									: ''
-							}`}
-						>
-							{contactList
-								? contactList.map((obj) => {
-										return (
-											<option value={obj.value} key={obj.value}>
-												{obj && obj.label && obj.label.contactName ? obj.label.contactName : ''}
-											</option>
-										);
-								  })
-								: ''}
-						</Input>
-					)}
-				/>
-			);
+                props.errors.journalLineItems &&
+                props.errors.journalLineItems[parseInt(idx, 10)] &&
+                props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
+                Object.keys(props.touched).length > 0 &&
+                props.touched.journalLineItems &&
+                props.touched.journalLineItems[parseInt(idx, 10)] &&
+                props.touched.journalLineItems[parseInt(idx, 10)].contactId
+                  ? 'is-invalid'
+                  : ''
+              }`}
+              >
+                {contactList
+                  ? contactList.map(obj => {
+                      return (
+                        <option value={obj.value} key={obj.value}>
+                          {obj && obj.label && obj.label.contactName ? obj.label.contactName : ''}
+                        </option>
+                      );
+                    })
+                  : ''}
+              </Input>
+            )}
+          />
+        );
 
-			break;
-		
-		case "BANK_ACCOUNT":
-			return (
-				<Field
-					name={`journalLineItems.${idx}.contactId`}
-					render={({ field, form }) => (
-						<Input
-						
-							disabled={
-								props.values.postingReferenceType === 'MANUAL' ? false : true
-							}
-							value={"-"}
-							placeholder={strings.Select+strings.Contact}
-							className={`form-control 
+        break;
+
+      case 'BANK_ACCOUNT':
+        return (
+          <Field
+            name={`journalLineItems.${idx}.contactId`}
+            render={({ field, form }) => (
+              <Input
+                disabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+                value={'-'}
+                placeholder={strings.Select + strings.Contact}
+                className={`form-control 
 				${
-								props.errors.journalLineItems &&
-								props.errors.journalLineItems[parseInt(idx, 10)] &&
-								props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
-								Object.keys(props.touched).length > 0 &&
-								props.touched.journalLineItems &&
-								props.touched.journalLineItems[parseInt(idx, 10)] &&
-								props.touched.journalLineItems[parseInt(idx, 10)].contactId
-									? 'is-invalid'
-									: ''
-							}`}
-						>
-						</Input>
-					)}
-				/>
-			);
-			break;
-		
-		default :
-		return (
-			<Field
-				name={`journalLineItems.${idx}.contactId`}
-				render={({ field, form }) => (
-					<Input
-					
-						disabled={
-							props.values.postingReferenceType === 'MANUAL' ? false : true
-						}
-						value={row.contactId ? row.contactId:'-'}
-						placeholder={strings.Select+strings.Contact}
-						className={`form-control 
+          props.errors.journalLineItems &&
+          props.errors.journalLineItems[parseInt(idx, 10)] &&
+          props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
+          Object.keys(props.touched).length > 0 &&
+          props.touched.journalLineItems &&
+          props.touched.journalLineItems[parseInt(idx, 10)] &&
+          props.touched.journalLineItems[parseInt(idx, 10)].contactId
+            ? 'is-invalid'
+            : ''
+        }`}
+              ></Input>
+            )}
+          />
+        );
+        break;
+
+      default:
+        return (
+          <Field
+            name={`journalLineItems.${idx}.contactId`}
+            render={({ field, form }) => (
+              <Input
+                disabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+                value={row.contactId ? row.contactId : '-'}
+                placeholder={strings.Select + strings.Contact}
+                className={`form-control 
 			${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].contactId
-								? 'is-invalid'
-								: ''
-						}`}
-					>
-								{contactList
-								? contactList.map((obj) => {
-										return (
-											<option value={obj.value} key={obj.value}>
-												{obj && obj.label && obj.label.contactName ? obj.label.contactName : ''}
-											</option>
-										);
-								  })
-								: '-'}
-					</Input>
-				)}
-			/>
-		);
-		break;
-	}
-		// return (
-		// 	<Field
-		// 		name={`journalLineItems.${idx}.contactId`}
-		// 		render={({ field, form }) => (
-		// 			<Input
-		// 				type="select"
-		// 				onChange={(e) => {
-		// 					this.selectItem(e.target.value, row, 'contactId', form, field);
-		// 				}}
-		// 				disabled={
-		// 					props.values.postingReferenceType === 'MANUAL' ? false : true
-		// 				}
-		// 				value={row.contactId}
-		// 				placeholder={strings.Select+strings.Contact}
-		// 				className={`form-control 
-        //     ${
-		// 					props.errors.journalLineItems &&
-		// 					props.errors.journalLineItems[parseInt(idx, 10)] &&
-		// 					props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
-		// 					Object.keys(props.touched).length > 0 &&
-		// 					props.touched.journalLineItems &&
-		// 					props.touched.journalLineItems[parseInt(idx, 10)] &&
-		// 					props.touched.journalLineItems[parseInt(idx, 10)].contactId
-		// 						? 'is-invalid'
-		// 						: ''
-		// 				}`}
-		// 			>
-		// 				{contactList
-		// 					? contactList.map((obj) => {
-		// 							return (
-		// 								<option value={obj.value} key={obj.value}>
-		// 									{obj && obj.label && obj.label.contactName ? obj.label.contactName : ''}
-		// 								</option>
-		// 							);
-		// 					  })
-		// 					: ''}
-		// 			</Input>
-		// 		)}
-		// 	/>
-		// );
-	};
+        props.errors.journalLineItems &&
+        props.errors.journalLineItems[parseInt(idx, 10)] &&
+        props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
+        Object.keys(props.touched).length > 0 &&
+        props.touched.journalLineItems &&
+        props.touched.journalLineItems[parseInt(idx, 10)] &&
+        props.touched.journalLineItems[parseInt(idx, 10)].contactId
+          ? 'is-invalid'
+          : ''
+      }`}
+              >
+                {contactList
+                  ? contactList.map(obj => {
+                      return (
+                        <option value={obj.value} key={obj.value}>
+                          {obj && obj.label && obj.label.contactName ? obj.label.contactName : ''}
+                        </option>
+                      );
+                    })
+                  : '-'}
+              </Input>
+            )}
+          />
+        );
+        break;
+    }
+    // return (
+    // 	<Field
+    // 		name={`journalLineItems.${idx}.contactId`}
+    // 		render={({ field, form }) => (
+    // 			<Input
+    // 				type="select"
+    // 				onChange={(e) => {
+    // 					this.selectItem(e.target.value, row, 'contactId', form, field);
+    // 				}}
+    // 				disabled={
+    // 					props.values.postingReferenceType === 'MANUAL' ? false : true
+    // 				}
+    // 				value={row.contactId}
+    // 				placeholder={strings.Select+strings.Contact}
+    // 				className={`form-control
+    //     ${
+    // 					props.errors.journalLineItems &&
+    // 					props.errors.journalLineItems[parseInt(idx, 10)] &&
+    // 					props.errors.journalLineItems[parseInt(idx, 10)].contactId &&
+    // 					Object.keys(props.touched).length > 0 &&
+    // 					props.touched.journalLineItems &&
+    // 					props.touched.journalLineItems[parseInt(idx, 10)] &&
+    // 					props.touched.journalLineItems[parseInt(idx, 10)].contactId
+    // 						? 'is-invalid'
+    // 						: ''
+    // 				}`}
+    // 			>
+    // 				{contactList
+    // 					? contactList.map((obj) => {
+    // 							return (
+    // 								<option value={obj.value} key={obj.value}>
+    // 									{obj && obj.label && obj.label.contactName ? obj.label.contactName : ''}
+    // 								</option>
+    // 							);
+    // 					  })
+    // 					: ''}
+    // 			</Input>
+    // 		)}
+    // 	/>
+    // );
+  };
 
-	renderDebits = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
+  renderDebits = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-		return (
-			<Field
-				name={`journalLineItems.${idx}.debitAmount`}
-				render={({ field, form }) => (
-					<>
-					<Input
-					type="number"
-min="0"
-					
-						value={row['debitAmount'] !== 0 ? row['debitAmount'] : 0}
-						disabled={
-							props.values.postingReferenceType === 'MANUAL' ? false : true
-						}
-						onChange={(e) => {
-							if (
-								e.target.value === '' ||
-								this.regDecimal.test(e.target.value)
-							) {
-								this.selectItem(
-									e.target.value,
-									row,
-									'debitAmount',
-									form,
-									field,
-								);
-							}
-						}}
-						placeholder={strings.Debit+" "+strings.Amount }
-						className={`form-control 
+    return (
+      <Field
+        name={`journalLineItems.${idx}.debitAmount`}
+        render={({ field, form }) => (
+          <>
+            <Input
+              type="number"
+              min="0"
+              value={row['debitAmount'] !== 0 ? row['debitAmount'] : 0}
+              disabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+              onChange={e => {
+                if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                  this.selectItem(e.target.value, row, 'debitAmount', form, field);
+                }
+              }}
+              placeholder={strings.Debit + ' ' + strings.Amount}
+              className={`form-control 
             ${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].debitAmount
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-					{props.errors.journalLineItems &&
-						props.errors.journalLineItems[parseInt(idx, 10)] &&
-						props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
-						Object.keys(props.touched).length > 0 &&
-						props.touched.journalLineItems &&
-						props.touched.journalLineItems[parseInt(idx, 10)] &&
-						props.touched.journalLineItems[parseInt(idx, 10)].debitAmount && (
-							<div className='invalid-feedback'>
-								{props.errors.journalLineItems[parseInt(idx, 10)].debitAmount}
-							</div>
+              props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].debitAmount
+                ? 'is-invalid'
+                : ''
+            }`}
+            />
+            {props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].debitAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].debitAmount && (
+                <div className="invalid-feedback">
+                  {props.errors.journalLineItems[parseInt(idx, 10)].debitAmount}
+                </div>
+              )}
+          </>
+        )}
+      />
+    );
+  };
 
-						)}
-						</>
-				)}
-			/>
-		);
-	};
+  renderCredits = (cell, row, props) => {
+    let idx;
+    this.state.data.map((obj, index) => {
+      if (obj.id === row.id) {
+        idx = index;
+      }
+      return obj;
+    });
 
-	renderCredits = (cell, row, props) => {
-		let idx;
-		this.state.data.map((obj, index) => {
-			if (obj.id === row.id) {
-				idx = index;
-			}
-			return obj;
-		});
-
-		return (
-			<Field
-				name={`journalLineItems.${idx}.creditAmount`}
-				render={({ field, form }) => (
-					<>
-					<Input
-					type="number"
-min="0"
-				
-						value={row['creditAmount'] !== 0 ? row['creditAmount'] : 0}
-						disabled={
-							props.values.postingReferenceType === 'MANUAL' ? false : true
-						}
-						onChange={(e) => {
-							if (
-								e.target.value === '' ||
-								this.regDecimal.test(e.target.value)
-							) {
-								this.selectItem(
-									e.target.value,
-									row,
-									'creditAmount',
-									form,
-									field,
-								);
-							}
-						}}
-						placeholder={strings.Credit+" "+strings.Amount}
-						className={`form-control 
+    return (
+      <Field
+        name={`journalLineItems.${idx}.creditAmount`}
+        render={({ field, form }) => (
+          <>
+            <Input
+              type="number"
+              min="0"
+              value={row['creditAmount'] !== 0 ? row['creditAmount'] : 0}
+              disabled={props.values.postingReferenceType === 'MANUAL' ? false : true}
+              onChange={e => {
+                if (e.target.value === '' || this.regDecimal.test(e.target.value)) {
+                  this.selectItem(e.target.value, row, 'creditAmount', form, field);
+                }
+              }}
+              placeholder={strings.Credit + ' ' + strings.Amount}
+              className={`form-control 
             ${
-							props.errors.journalLineItems &&
-							props.errors.journalLineItems[parseInt(idx, 10)] &&
-							props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
-							Object.keys(props.touched).length > 0 &&
-							props.touched.journalLineItems &&
-							props.touched.journalLineItems[parseInt(idx, 10)] &&
-							props.touched.journalLineItems[parseInt(idx, 10)].creditAmount
-								? 'is-invalid'
-								: ''
-						}`}
-					/>
-					{props.errors.journalLineItems &&
-						props.errors.journalLineItems[parseInt(idx, 10)] &&
-						props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
-						Object.keys(props.touched).length > 0 &&
-						props.touched.journalLineItems &&
-						props.touched.journalLineItems[parseInt(idx, 10)] &&
-						props.touched.journalLineItems[parseInt(idx, 10)].creditAmount && (
-							<div className='invalid-feedback'>
-								{props.errors.journalLineItems[parseInt(idx, 10)].creditAmount}
-							</div>
+              props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].creditAmount
+                ? 'is-invalid'
+                : ''
+            }`}
+            />
+            {props.errors.journalLineItems &&
+              props.errors.journalLineItems[parseInt(idx, 10)] &&
+              props.errors.journalLineItems[parseInt(idx, 10)].creditAmount &&
+              Object.keys(props.touched).length > 0 &&
+              props.touched.journalLineItems &&
+              props.touched.journalLineItems[parseInt(idx, 10)] &&
+              props.touched.journalLineItems[parseInt(idx, 10)].creditAmount && (
+                <div className="invalid-feedback">
+                  {props.errors.journalLineItems[parseInt(idx, 10)].creditAmount}
+                </div>
+              )}
+          </>
+        )}
+      />
+    );
+  };
 
-						)}
-				</>
-				)}
-			/>
-		);
-	};
+  addRow = () => {
+    const data = [...this.state.data];
+    this.setState(
+      {
+        data: data.concat({
+          id: this.state.idCount + 1,
+          description: '',
+          transactionCategoryId: '',
+          contactId: '',
+          debitAmount: 0,
+          creditAmount: 0,
+        }),
+        idCount: this.state.idCount + 1,
+      },
+      () => {
+        this.formRef.current.setFieldValue('journalLineItems', this.state.data, true);
+      }
+    );
+  };
 
-	addRow = () => {
-		const data = [...this.state.data];
-		this.setState(
-			{
-				data: data.concat({
-					id: this.state.idCount + 1,
-					description: '',
-					transactionCategoryId: '',
-					contactId: '',
-					debitAmount: 0,
-					creditAmount: 0,
-				}),
-				idCount: this.state.idCount + 1,
-			},
-			() => {
-				this.formRef.current.setFieldValue(
-					'journalLineItems',
-					this.state.data,
-					true,
-				);
-			},
-		);
-	};
+  selectItem = (e, row, name, form, field) => {
+    //	e.preventDefault();
+    let idx;
+    const data = this.state.data;
+    data.map((obj, index) => {
+      if (obj.id === row.id) {
+        if (name === 'debitAmount') {
+          obj[`${name}`] = e;
+          obj['creditAmount'] = 0;
+        } else if (name === 'creditAmount') {
+          obj[`${name}`] = e;
+          obj['debitAmount'] = 0;
+        } else {
+          obj[`${name}`] = e;
+        }
+        idx = index;
+      }
+      return obj;
+    });
+    if (name === 'debitAmount') {
+      form.setFieldValue(`journalLineItems.[${idx}].creditAmount`, 0, true);
+      form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
+      this.updateAmount(data);
+    } else if (name === 'creditAmount') {
+      form.setFieldValue(field.name, this.state.data[parseInt(idx, 10)][`${name}`], true);
+      form.setFieldValue(`journalLineItems.[${idx}].debitAmount`, 0, true);
+      this.updateAmount(data);
+    } else {
+      this.setState({ data }, () => {
+        this.formRef.current.setFieldValue(
+          field.name,
+          this.state.data[parseInt(idx, 10)][`${name}`],
+          true
+        );
+      });
+    }
+  };
 
-	selectItem = (e, row, name, form, field) => {
-		//	e.preventDefault();
-		let idx;
-		const data = this.state.data;
-		data.map((obj, index) => {
-			if (obj.id === row.id) {
-				if (name === 'debitAmount') {
-					obj[`${name}`] = e;
-					obj['creditAmount'] = 0;
-				} else if (name === 'creditAmount') {
-					obj[`${name}`] = e;
-					obj['debitAmount'] = 0;
-				} else {
-					obj[`${name}`] = e;
-				}
-				idx = index;
-			}
-			return obj;
-		});
-		if (name === 'debitAmount') {
-			form.setFieldValue(`journalLineItems.[${idx}].creditAmount`, 0, true);
-			form.setFieldValue(
-				field.name,
-				this.state.data[parseInt(idx, 10)][`${name}`],
-				true,
-			);
-			this.updateAmount(data);
-		} else if (name === 'creditAmount') {
-			form.setFieldValue(
-				field.name,
-				this.state.data[parseInt(idx, 10)][`${name}`],
-				true,
-			);
-			form.setFieldValue(`journalLineItems.[${idx}].debitAmount`, 0, true);
-			this.updateAmount(data);
-		} else {
-			this.setState({ data }, () => {
-				this.formRef.current.setFieldValue(
-					field.name,
-					this.state.data[parseInt(idx, 10)][`${name}`],
-					true,
-				);
-			});
-		}
-	};
+  deleteRow = (e, row, props) => {
+    const id = row['id'];
+    let newData = [];
+    e.preventDefault();
+    const data = this.state.data;
+    newData = data.filter(obj => obj.id !== id);
+    props.setFieldValue('journalLineItems', newData, true);
+    this.updateAmount(newData);
+  };
 
-	deleteRow = (e, row, props) => {
-		const id = row['id'];
-		let newData = [];
-		e.preventDefault();
-		const data = this.state.data;
-		newData = data.filter((obj) => obj.id !== id);
-		props.setFieldValue('journalLineItems', newData, true);
-		this.updateAmount(newData);
-	};
+  updateAmount = data => {
+    let subTotalDebitAmount = 0;
+    let subTotalCreditAmount = 0;
+    // let totalDebitAmount = 0;
+    // let totalCreditAmount = 0;
 
-	updateAmount = (data) => {
-		let subTotalDebitAmount = 0;
-		let subTotalCreditAmount = 0;
-		// let totalDebitAmount = 0;
-		// let totalCreditAmount = 0;
+    data.map(obj => {
+      if (obj.debitAmount || obj.creditAmount) {
+        subTotalDebitAmount = subTotalDebitAmount + +obj.debitAmount;
+        subTotalCreditAmount = subTotalCreditAmount + +obj.creditAmount;
+      }
+      return obj;
+    });
 
-		data.map((obj) => {
-			if (obj.debitAmount || obj.creditAmount) {
-				subTotalDebitAmount = subTotalDebitAmount + +obj.debitAmount;
-				subTotalCreditAmount = subTotalCreditAmount + +obj.creditAmount;
-			}
-			return obj;
-		});
+    this.setState({
+      data,
+      initValue: {
+        ...this.state.initValue,
+        ...{
+          subTotalDebitAmount,
+          totalDebitAmount: subTotalDebitAmount,
+          totalCreditAmount: subTotalCreditAmount,
+          subTotalCreditAmount,
+        },
+      },
+    });
+  };
 
-		this.setState({
-			data,
-			initValue: {
-				...this.state.initValue,
-				...{
-					subTotalDebitAmount,
-					totalDebitAmount: subTotalDebitAmount,
-					totalCreditAmount: subTotalCreditAmount,
-					subTotalCreditAmount,
-				},
-			},
-		});
-	};
+  deleteJournal = () => {
+    const message1 = (
+      <text>
+        <b>Delete Journal?</b>
+      </text>
+    );
+    const message = 'This Journal will be deleted permanently and cannot be recovered. ';
+    this.setState({
+      dialog: (
+        <ConfirmDeleteModal
+          isOpen={true}
+          okHandler={this.removeJournal}
+          cancelHandler={this.removeDialog}
+          message={message}
+          message1={message1}
+        />
+      ),
+    });
+  };
 
-	deleteJournal = () => {
-		const message1 =
-			<text>
-			<b>Delete Journal?</b>
-			</text>
-			const message = 'This Journal will be deleted permanently and cannot be recovered. ';
-		this.setState({
-			dialog: (
-				<ConfirmDeleteModal
-					isOpen={true}
-					okHandler={this.removeJournal}
-					cancelHandler={this.removeDialog}
-					message={message}
-					message1={message1}
-				/>
-			),
-		});
-	};
+  removeJournal = () => {
+    this.setState({ disabled1: true, disableLeavePage: true });
+    const { current_journal_id } = this.state;
+    this.props.journalDetailActions
+      .deleteJournal(current_journal_id)
+      .then(res => {
+        if (res.status === 200) {
+          this.props.commonActions.tostifyAlert(
+            'success',
+            res.data ? res.data.message : 'Journal Deleted Successfully'
+          );
+          this.props.history.push('/admin/accountant/journal');
+        }
+      })
+      .catch(err => {
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err && err.data ? err.data.message : 'Journal Deleted Unsuccessfully'
+        );
+      });
+  };
 
-	removeJournal = () => {
-		this.setState({ disabled1: true,disableLeavePage : true });
-		const { current_journal_id } = this.state;
-		this.props.journalDetailActions
-			.deleteJournal(current_journal_id)
-			.then((res) => {
-				if (res.status === 200) {
-					this.props.commonActions.tostifyAlert(
-						'success',
-						res.data ? res.data.message :'Journal Deleted Successfully',
-					);
-					this.props.history.push('/admin/accountant/journal');
-				}
-			})
-			.catch((err) => {
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err && err.data ? err.data.message : 'Journal Deleted Unsuccessfully',
-				);
-			});
-	};
+  removeDialog = () => {
+    this.setState({
+      dialog: null,
+    });
+  };
 
-	removeDialog = () => {
-		this.setState({
-			dialog: null,
-		});
-	};
+  handleSubmit = values => {
+    const { data, initValue } = this.state;
+    if (initValue.totalCreditAmount === initValue.totalDebitAmount) {
+      data.map(item => {
+        delete item.id;
+        item.transactionCategoryId = item.transactionCategoryId ? item.transactionCategoryId : '';
+        item.contactId = item.contactId ? item.contactId : '';
 
-	handleSubmit = (values) => {
-		const { data, initValue } = this.state;
-		if (initValue.totalCreditAmount === initValue.totalDebitAmount) {
-			data.map((item) => {
-				delete item.id;
-				item.transactionCategoryId = item.transactionCategoryId
-					? item.transactionCategoryId
-					: '';
-				item.contactId = item.contactId ? item.contactId : '';
+        return item;
+      });
+      let currency = '';
+      if (values.currencyCode && values.currencyCode.value) {
+        currency = values.currencyCode.value;
+      } else {
+        if (values.currencyCode) {
+          currency = values.currencyCode;
+        }
+      }
+      const postData = {
+        journalId: values.journalId,
+        journalDate: values.journalDate ? values.journalDate : '',
+        journalReferenceNo: values.journalReferenceNo ? values.journalReferenceNo : '',
+        description: values.description ? values.description : '',
+        currencyCode: currency,
+        subTotalCreditAmount: initValue.subTotalCreditAmount,
+        subTotalDebitAmount: initValue.subTotalDebitAmount,
+        totalCreditAmount: initValue.totalCreditAmount,
+        totalDebitAmount: initValue.totalDebitAmount,
+        journalLineItems: data,
+      };
+      this.setState({ disabled2: true });
+      this.setState({ loading: true, disableLeavePage: true, loadingMsg: 'Updating Journal...' });
+      this.props.journalDetailActions
 
-				return item;
-			});
-			let currency='';
-			if(values.currencyCode && values.currencyCode.value )
-			{
-				currency=values.currencyCode.value
-			}
-			else{
-				if(values.currencyCode)
-				{
-					currency=values.currencyCode
-				}			
-			}
-			const postData = {
-				journalId: values.journalId,
-				journalDate: values.journalDate ? values.journalDate : '',
-				journalReferenceNo: values.journalReferenceNo
-					? values.journalReferenceNo
-					: '',
-				description: values.description ? values.description : '',
-				currencyCode: currency,
-				subTotalCreditAmount: initValue.subTotalCreditAmount,
-				subTotalDebitAmount: initValue.subTotalDebitAmount,
-				totalCreditAmount: initValue.totalCreditAmount,
-				totalDebitAmount: initValue.totalDebitAmount,
-				journalLineItems: data,
-			};
-				this.setState({ disabled2: true });
-				this.setState({ loading:true, disableLeavePage:true,loadingMsg:"Updating Journal..."});
-			this.props.journalDetailActions
-		
-				.updateJournal(postData)
-				.then((res) => {
-					if (res.status === 200) {
-							this.setState({ disabled2: false });
-						this.props.commonActions.tostifyAlert(
-							'success',
-							res.data ? res.data.message :'Journal Updated Successfully',
-						);
-						this.props.history.push('/admin/accountant/journal');
-						this.setState({ loading:false,});
-					}
-				})
-				.catch((err) => {
-					this.props.commonActions.tostifyAlert(
-						'error',
-						err.data ? err.data.message : 'Journal Updated Unsuccessfully'
-					);
-				});
-		}
-	};
+        .updateJournal(postData)
+        .then(res => {
+          if (res.status === 200) {
+            this.setState({ disabled2: false });
+            this.props.commonActions.tostifyAlert(
+              'success',
+              res.data ? res.data.message : 'Journal Updated Successfully'
+            );
+            this.props.history.push('/admin/accountant/journal');
+            this.setState({ loading: false });
+          }
+        })
+        .catch(err => {
+          this.props.commonActions.tostifyAlert(
+            'error',
+            err.data ? err.data.message : 'Journal Updated Unsuccessfully'
+          );
+        });
+    }
+  };
 
-	render() {
-		strings.setLanguage(this.state.language);
-		const { data, initValue, dialog, loading,loadingMsg } = this.state;
-		const { currency_list,universal_currency_list, } = this.props;
-		const { state } = this.props.location;
+  render() {
+    strings.setLanguage(this.state.language);
+    const { data, initValue, dialog, loading, loadingMsg } = this.state;
+    const { currency_list, universal_currency_list } = this.props;
+    const { state } = this.props.location;
 
-		return (
-			loading ==true? <Loader loadingMsg={loadingMsg}/> :
-		
-<div>
-			<div className="detail-journal-screen">
-				<div className="animated fadeIn">
-					<Row>
-						<Col lg={12} className="mx-auto">
-							<Card>
-								<CardHeader>
-									<Row>
-										<Col lg={12}>
-											<div className="h4 mb-0 d-flex align-items-center">
-												<i className="fa fa-diamond" />
-												{/* <span className="ml-2">{strings.UpdateJournal}</span> */}
-												<span className="ml-2">{initValue.postingReferenceType !== 'MANUAL' ? strings.ViewJournal : strings.UpdateJournal}</span>
-											</div>
-										</Col>
-									</Row>
-								</CardHeader>
-								<CardBody>
-									{dialog}
-									{loading ? (
-										<Loader />
-									) : (
-										<Row>
-											<Col lg={12}>
-												<Formik
-													initialValues={initValue}
-													ref={this.formRef}
-													onSubmit={(values, { resetForm }) => {
-														this.handleSubmit(values);
-													}}
-													validationSchema={Yup.object().shape({
-														journalDate: Yup.date().required(
-															'Journal date is required',
-														),
-														journalLineItems: Yup.array()
-															.of(
-																Yup.object().shape({
-																	transactionCategoryId: Yup.string().required(
-																		'Account is required',
-																	),
-																	debitAmount: Yup.string().required('Debit is required'),
-																creditAmount: Yup.string().required('Credit is required'),
-																}),
-															)
-															.min(
-																2,
-																'Atleast Two Journal Debit and Credit Details is mandatory',
-															),
-													})}
-												>
-													{(props) => (
-														<Form onSubmit={props.handleSubmit}>
-															<Row>
-																<Col lg={4}>
-																	<FormGroup className="mb-3">
-																		<Label htmlFor="date">
-																			<span className="text-danger">* </span>
-																			{strings.JournalDate}
-																		</Label>
-																		<DatePicker
-																			className="form-control"
-																			id="journalDate"
-																			name="journalDate"
-																			placeholderText={strings.JournalDate}
-																			disabled={
-																				props.values.postingReferenceType ===
-																				'MANUAL'
-																					? false
-																					: true
-																			}
-																			showMonthDropdown
-																			showYearDropdown
-																			dateFormat="dd-MM-yyyy"
-																			minDate={new Date()}
-																			dropdownMode="select"
-																			autoComplete="off"
-																			value={
-																				props.values.journalDate
-																					? dayjs(
-																							props.values.journalDate,
-																					  ).format('DD-MM-YYYY')
-																					: ''
-																			}
-																			onChange={(value) => {
-																				props.handleChange('journalDate')(
-																					value,
-																				);
-																			}}
-																		/>
-																	</FormGroup>
-																</Col>
-															</Row>
-															<Row>
-																<Col lg={4}>
-																	<FormGroup className="mb-3">
-																		<Label htmlFor="journalReferenceNo">
-																		{strings.JournalReference}
-																		</Label>
-																		<Input
-																			type="text"
-																			id="journalReferenceNo"
-																			name="journalReferenceNo"
-																			disabled
-																			placeholder={strings.ReceiptNumber}
-																			value={props.values.journalReferenceNo}
-																			onChange={(option) => {
-																				if (
-																					option.target.value === '' ||
-																					this.regExBoth.test(
-																						option.target.value,
-																					)
-																				) {
-																					props.handleChange(
-																						'journalReferenceNo',
-																					)(option);
-																				}
-																			}}
-																		/>
-																	</FormGroup>
-																</Col>
-															</Row>
-															<Row>
-																<Col lg={8}>
-																	<FormGroup className="mb-3">
-																		<Label htmlFor="description">{strings.Notes}</Label>
-																		<Input
-																			type="textarea"
-																			name="description"
-																			id="description"
-																			rows="5"
-																			disabled={
-																				props.values.postingReferenceType ===
-																				'MANUAL'
-																					? false
-																					: true
-																			}
-																			placeholder={strings.DeliveryNotes}
-																			value={props.values.description}
-																			onChange={(value) => {
-																				props.handleChange('description')(
-																					value,
-																				);
-																			}}
-																		/>
-																	</FormGroup>
-																</Col>
-															</Row>
-															<Row>
-																<Col lg={4}>
-																	<FormGroup className="mb-3">
-																		<Label htmlFor="currencyCode">
-																			 {strings.Currency}
-																		</Label>
-																		{console.log(currency_list,selectCurrencyFactory
-																					.renderOptions(
-																						'currencyName',
-																						'currencyCode',
-																						currency_list,
-																						'Currency',
-																					)?.[1])}
-																		<Select
-																			styles={customStyles}
-																			className="select-default-width"
-																			options={
-																				currency_list
-																					? selectCurrencyFactory.renderOptions(
-																							'currencyName',
-																							'currencyCode',
-																							currency_list,
-																							'Currency',
-																					  )
-																					: []
-																			}
-																			id="currencyCode"
-																			name="currencyCode"
-																			isDisabled={true}
-																			value={
-																				currency_list &&
-																				selectCurrencyFactory
-																					.renderOptions(
-																						'currencyName',
-																						'currencyCode',
-																						currency_list,
-																						'Currency',
-																					)?.[1]
-																					
-																			}
-																			onChange={(option) => {
-																				if (option && option.value) {
-																					props.handleChange('currencyCode')(
-																						option,
-																					);
-																				} else {
-																					props.handleChange('currencyCode')(
-																						'',
-																					);
-																				}
-																			}}
-																		/>
-																	</FormGroup>
-																</Col>
-															</Row>
-															{props.values.postingReferenceType ===
-																'MANUAL' && <hr />}
-															<Row>
-																<Col lg={12} className="mb-3">
-																	{props.values.postingReferenceType ===
-																		'MANUAL' && (
-																		<Button
-																			color="primary"
-																			className="btn-square mr-3"
-																			onClick={this.addRow}
-																		>
-																			<i className="fa fa-plus"></i> {strings.Addmore}
-																		</Button>
-																	)}
-																</Col>
-															</Row>
+    return loading == true ? (
+      <Loader loadingMsg={loadingMsg} />
+    ) : (
+      <div>
+        <div className="detail-journal-screen">
+          <div className="animated fadeIn">
+            <Row>
+              <Col lg={12} className="mx-auto">
+                <Card>
+                  <CardHeader>
+                    <Row>
+                      <Col lg={12}>
+                        <div className="h4 mb-0 d-flex align-items-center">
+                          <i className="fa fa-diamond" />
+                          {/* <span className="ml-2">{strings.UpdateJournal}</span> */}
+                          <span className="ml-2">
+                            {initValue.postingReferenceType !== 'MANUAL'
+                              ? strings.ViewJournal
+                              : strings.UpdateJournal}
+                          </span>
+                        </div>
+                      </Col>
+                    </Row>
+                  </CardHeader>
+                  <CardBody>
+                    {dialog}
+                    {loading ? (
+                      <Loader />
+                    ) : (
+                      <Row>
+                        <Col lg={12}>
+                          <Formik
+                            initialValues={initValue}
+                            ref={this.formRef}
+                            onSubmit={(values, { resetForm }) => {
+                              this.handleSubmit(values);
+                            }}
+                            validationSchema={Yup.object().shape({
+                              journalDate: Yup.date().required('Journal date is required'),
+                              journalLineItems: Yup.array()
+                                .of(
+                                  Yup.object().shape({
+                                    transactionCategoryId:
+                                      Yup.string().required('Account is required'),
+                                    debitAmount: Yup.string().required('Debit is required'),
+                                    creditAmount: Yup.string().required('Credit is required'),
+                                  })
+                                )
+                                .min(
+                                  2,
+                                  'Atleast Two Journal Debit and Credit Details is mandatory'
+                                ),
+                            })}
+                          >
+                            {props => (
+                              <Form onSubmit={props.handleSubmit}>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="date">
+                                        <span className="text-danger">* </span>
+                                        {strings.JournalDate}
+                                      </Label>
+                                      <DatePicker
+                                        className="form-control"
+                                        id="journalDate"
+                                        name="journalDate"
+                                        placeholderText={strings.JournalDate}
+                                        disabled={
+                                          props.values.postingReferenceType === 'MANUAL'
+                                            ? false
+                                            : true
+                                        }
+                                        showMonthDropdown
+                                        showYearDropdown
+                                        dateFormat="dd-MM-yyyy"
+                                        minDate={new Date()}
+                                        dropdownMode="select"
+                                        autoComplete="off"
+                                        value={
+                                          props.values.journalDate
+                                            ? dayjs(props.values.journalDate).format('DD-MM-YYYY')
+                                            : ''
+                                        }
+                                        onChange={value => {
+                                          props.handleChange('journalDate')(value);
+                                        }}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="journalReferenceNo">
+                                        {strings.JournalReference}
+                                      </Label>
+                                      <Input
+                                        type="text"
+                                        id="journalReferenceNo"
+                                        name="journalReferenceNo"
+                                        disabled
+                                        placeholder={strings.ReceiptNumber}
+                                        value={props.values.journalReferenceNo}
+                                        onChange={option => {
+                                          if (
+                                            option.target.value === '' ||
+                                            this.regExBoth.test(option.target.value)
+                                          ) {
+                                            props.handleChange('journalReferenceNo')(option);
+                                          }
+                                        }}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={8}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="description">{strings.Notes}</Label>
+                                      <Input
+                                        type="textarea"
+                                        name="description"
+                                        id="description"
+                                        rows="5"
+                                        disabled={
+                                          props.values.postingReferenceType === 'MANUAL'
+                                            ? false
+                                            : true
+                                        }
+                                        placeholder={strings.DeliveryNotes}
+                                        value={props.values.description}
+                                        onChange={value => {
+                                          props.handleChange('description')(value);
+                                        }}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                <Row>
+                                  <Col lg={4}>
+                                    <FormGroup className="mb-3">
+                                      <Label htmlFor="currencyCode">{strings.Currency}</Label>
+                                      {console.log(
+                                        currency_list,
+                                        selectCurrencyFactory.renderOptions(
+                                          'currencyName',
+                                          'currencyCode',
+                                          currency_list,
+                                          'Currency'
+                                        )?.[1]
+                                      )}
+                                      <Select
+                                        styles={customStyles}
+                                        className="select-default-width"
+                                        options={
+                                          currency_list
+                                            ? selectCurrencyFactory.renderOptions(
+                                                'currencyName',
+                                                'currencyCode',
+                                                currency_list,
+                                                'Currency'
+                                              )
+                                            : []
+                                        }
+                                        id="currencyCode"
+                                        name="currencyCode"
+                                        isDisabled={true}
+                                        value={
+                                          currency_list &&
+                                          selectCurrencyFactory.renderOptions(
+                                            'currencyName',
+                                            'currencyCode',
+                                            currency_list,
+                                            'Currency'
+                                          )?.[1]
+                                        }
+                                        onChange={option => {
+                                          if (option && option.value) {
+                                            props.handleChange('currencyCode')(option);
+                                          } else {
+                                            props.handleChange('currencyCode')('');
+                                          }
+                                        }}
+                                      />
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                                {props.values.postingReferenceType === 'MANUAL' && <hr />}
+                                <Row>
+                                  <Col lg={12} className="mb-3">
+                                    {props.values.postingReferenceType === 'MANUAL' && (
+                                      <Button
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        onClick={this.addRow}
+                                      >
+                                        <i className="fa fa-plus"></i> {strings.Addmore}
+                                      </Button>
+                                    )}
+                                  </Col>
+                                </Row>
 
-															{props.errors.journalLineItems &&
-																typeof props.errors.journalLineItems ===
-																	'string' && (
-																	<div
-																		className={
-																			props.errors.journalLineItems
-																				? 'is-invalid'
-																				: ''
-																		}
-																	>
-																		<div className="invalid-feedback">
-																			<Badge
-																				color="danger"
-																				style={{
-																					padding: '10px',
-																					marginBottom: '5px',
-																				}}
-																			>
-																				{props.errors.journalLineItems}
-																			</Badge>
-																		</div>
-																	</div>
-																)}
-															{this.state.submitJournal &&
-																this.state.initValue.totalCreditAmount.toFixed(
-																	2,
-																) !==
-																	this.state.initValue.totalDebitAmount.toFixed(
-																		2,
-																	) && (
-																	<div
-																		className={
-																			this.state.initValue.totalDebitAmount !==
-																			this.state.initValue.totalCreditAmount
-																				? 'is-invalid'
-																				: ''
-																		}
-																	>
-																		<div className="invalid-feedback">
-																			<Badge
-																				color="danger"
-																				style={{
-																					padding: '10px',
-																					marginBottom: '5px',
-																				}}
-																			>
-																				*Total Credit Amount and Total Debit
-																				Amount Should be Equal
-																			</Badge>
-																		</div>
-																	</div>
-																)}
+                                {props.errors.journalLineItems &&
+                                  typeof props.errors.journalLineItems === 'string' && (
+                                    <div
+                                      className={props.errors.journalLineItems ? 'is-invalid' : ''}
+                                    >
+                                      <div className="invalid-feedback">
+                                        <Badge
+                                          color="danger"
+                                          style={{
+                                            padding: '10px',
+                                            marginBottom: '5px',
+                                          }}
+                                        >
+                                          {props.errors.journalLineItems}
+                                        </Badge>
+                                      </div>
+                                    </div>
+                                  )}
+                                {this.state.submitJournal &&
+                                  this.state.initValue.totalCreditAmount.toFixed(2) !==
+                                    this.state.initValue.totalDebitAmount.toFixed(2) && (
+                                    <div
+                                      className={
+                                        this.state.initValue.totalDebitAmount !==
+                                        this.state.initValue.totalCreditAmount
+                                          ? 'is-invalid'
+                                          : ''
+                                      }
+                                    >
+                                      <div className="invalid-feedback">
+                                        <Badge
+                                          color="danger"
+                                          style={{
+                                            padding: '10px',
+                                            marginBottom: '5px',
+                                          }}
+                                        >
+                                          *Total Credit Amount and Total Debit Amount Should be
+                                          Equal
+                                        </Badge>
+                                      </div>
+                                    </div>
+                                  )}
 
-															<Row>
-																<Col lg={12}>
-																	<BootstrapTable
-																		options={this.options}
-																		data={data}
-																		version="4"
-																		hover
-																		keyField="id"
-																		className="journal-create-table"
-																	>
-																		<TableHeaderColumn
-																			width="55"
-																			dataAlign="center"
-																			dataFormat={(cell, rows) =>
-																				this.renderActions(cell, rows, props)
-																			}
-																		></TableHeaderColumn>
-																		<TableHeaderColumn
-																			dataField="transactionCategoryId"
-																			width="400"
-																			dataFormat={(cell, rows) =>
-																				this.renderAccount(cell, rows, props)
-																			}
-																		>
-																			 {strings.ACCOUNT}
-																		</TableHeaderColumn>
-																		<TableHeaderColumn
-																			dataField="description"
-																			dataFormat={(cell, rows) =>
-																				this.renderDescription(
-																					cell,
-																					rows,
-																					props,
-																				)
-																			}
-																		>
-																			{strings.DESCRIPTION}
-																		</TableHeaderColumn>
-																		<TableHeaderColumn
-																			dataField="contactId"
-																			dataFormat={(cell, rows) =>
-																				this.renderContact(cell, rows, props)
-																			}
-																		>
-																			 {strings.CONTACT}
-																		</TableHeaderColumn>
-																		<TableHeaderColumn
-																			dataField="debitAmount"
-																			dataFormat={(cell, rows) =>
-																				this.renderDebits(cell, rows, props)
-																			}
-																		>
-																			 {strings.DEBIT}
-																		</TableHeaderColumn>
-																		<TableHeaderColumn
-																			dataField="creditAmount"
-																			dataFormat={(cell, rows) =>
-																				this.renderCredits(cell, rows, props)
-																			}
-																		>
-																			{strings.CREDIT}
-																		</TableHeaderColumn>
-																	</BootstrapTable>
-																</Col>
-															</Row>
-															{data.length > 0 ? (
-																<Row>
-																	<Col lg={4} className="ml-auto">
-																		<div className="total-item p-2">
-																			<Row>
-																				<Col xs={4}></Col>
-																				<Col xs={4}>
-																					<h5 className="mb-0 text-right">
-																						 {strings.Debit}
-																					</h5>
-																				</Col>
-																				<Col xs={4}>
-																					<h5 className="mb-0 text-right">
-																					     {strings.Credit}
-																					</h5>
-																				</Col>
-																			</Row>
-																		</div>
-																		<div className="total-item p-2">
-																			<Row>
-																				<Col xs={4}>
-																					<h5 className="mb-0 text-right">
-																						   {strings.SubTotal}
-																					</h5>
-																				</Col>
-																				<Col xs={4} className="text-right">
-																					<label className="mb-0">
-																					{universal_currency_list[0] && (
-																						<Currency
-																						value={
-																							this.state.initValue
-																								.subTotalDebitAmount
-																						}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																					</label>
-																				</Col>
-																				<Col xs={4} className="text-right">
-																					<label className="mb-0">
-																					{universal_currency_list[0] && (
-																						<Currency
-																						value={
-																							this.state.initValue
-																								.subTotalCreditAmount
-																						}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																					</label>
-																				</Col>
-																			</Row>
-																		</div>
-																		<div className="total-item p-2">
-																			<Row>
-																				<Col xs={4}>
-																					<h5 className="mb-0 text-right">
-																						 {strings.Total}
-																					</h5>
-																				</Col>
-																				<Col xs={4} className="text-right">
-																					<label className="mb-0">
-																					{universal_currency_list[0] && (
-																						<Currency
-																						value={
-																							this.state.initValue
-																								.subTotalDebitAmount
-																						}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																					</label>
-																				</Col>
-																				<Col xs={4} className="text-right">
-																					<label className="mb-0">
-																					{universal_currency_list[0] && (
-																						<Currency
-																						value={
-																							this.state.initValue
-																								.subTotalCreditAmount
-																						}
-																						currencySymbol={
-																						universal_currency_list[0]
-																						? universal_currency_list[0].currencyIsoCode
-																						: 'USD'
-																							}
-																							/>
-																							)}
-																					</label>
-																				</Col>
-																			</Row>
-																		</div>
-																	</Col>
-																</Row>
-															) : null}
-															<Row>
-																<Col
-																	lg={12}
-																	className="mt-5 d-flex flex-wrap align-items-center justify-content-between"
-																>
-																	<FormGroup>
-																		{props.values.postingReferenceType ===
-																			'MANUAL' && (
-																			<Button
-																				type="button"
-																				color="danger"
-																				className="btn-square"
-																						disabled1={this.state.disabled1}
-																				disabled={
-																					props.values.postingReferenceType ===
-																					'MANUAL'
-																						? false
-																						: true
-																				}
-																				onClick={this.deleteJournal}
-																			>
-																				<i className="fa fa-trash"></i>  {this.state.disabled1
-																			? 'Deleting...'
-																			: strings.Delete }
-																			</Button>
-																		)}
-																	</FormGroup>
-																	<FormGroup className="text-right">
-																		{props.values.postingReferenceType ===
-																			'MANUAL' && (
-																			<Button
-																				type="button"
-																				color="primary"
-																				disabled={
-																					props.values.postingReferenceType ===
-																					'MANUAL'
-																						? false
-																						: true
-																				}
-																				className="btn-square mr-3"
-																					disabled2={this.state.disabled2}
-																				onClick={() => {
-																					this.setState(
-																						{
-																							submitJournal: true,
-																						},
-																						() => {
-																							props.handleSubmit();
-																						},
-																					);
-																				}}
-																			>
-																				<i className="fa fa-dot-circle-o"></i>{' '}
-																				{this.state.disabled2
-																			? 'Updating...'
-																			: strings.Update }
-																			</Button>
-																		)}
-																		<Button
-																			color="secondary"
-																			className="btn-square"
-																			onClick={() => {
-																				this.props.journalActions.setCancelFlag(true);
-																				this.props.history.push(
-																					'/admin/accountant/journal',
-																				);
-																				if (state.renderURL) {
-																					this.props.history.push(state.renderURL, {
-																						id: state.renderId,
-																						isCNWithoutProduct: state.renderCN,
-																						expenseId: state.renderId,
-																					})
-																				}
-																			}}
-																		>
-																			<i className="fa fa-ban"></i> {this.state.disabled1
-																			? 'Deleting...'
-																			: strings.Cancel }
-																		</Button>
-																	</FormGroup>
-																</Col>
-															</Row>
-														</Form>
-													)}
-												</Formik>
-											</Col>
-										</Row>
-									)}
-								</CardBody>
-							</Card>
-						</Col>
-					</Row>
-				</div>
-			</div>
-			{this.state.disableLeavePage ?"":<LeavePage/>}
-			</div>
-		);
-	}
+                                <Row>
+                                  <Col lg={12}>
+                                    <BootstrapTable
+                                      options={this.options}
+                                      data={data}
+                                      version="4"
+                                      hover
+                                      keyField="id"
+                                      className="journal-create-table"
+                                    >
+                                      <TableHeaderColumn
+                                        width="55"
+                                        dataAlign="center"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderActions(cell, rows, props)
+                                        }
+                                      ></TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="transactionCategoryId"
+                                        width="400"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderAccount(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.ACCOUNT}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="description"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderDescription(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.DESCRIPTION}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="contactId"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderContact(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.CONTACT}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="debitAmount"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderDebits(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.DEBIT}
+                                      </TableHeaderColumn>
+                                      <TableHeaderColumn
+                                        dataField="creditAmount"
+                                        dataFormat={(cell, rows) =>
+                                          this.renderCredits(cell, rows, props)
+                                        }
+                                      >
+                                        {strings.CREDIT}
+                                      </TableHeaderColumn>
+                                    </BootstrapTable>
+                                  </Col>
+                                </Row>
+                                {data.length > 0 ? (
+                                  <Row>
+                                    <Col lg={4} className="ml-auto">
+                                      <div className="total-item p-2">
+                                        <Row>
+                                          <Col xs={4}></Col>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.Debit}</h5>
+                                          </Col>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.Credit}</h5>
+                                          </Col>
+                                        </Row>
+                                      </div>
+                                      <div className="total-item p-2">
+                                        <Row>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.SubTotal}</h5>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalDebitAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalCreditAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                        </Row>
+                                      </div>
+                                      <div className="total-item p-2">
+                                        <Row>
+                                          <Col xs={4}>
+                                            <h5 className="mb-0 text-right">{strings.Total}</h5>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalDebitAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                          <Col xs={4} className="text-right">
+                                            <label className="mb-0">
+                                              {universal_currency_list[0] && (
+                                                <Currency
+                                                  value={this.state.initValue.subTotalCreditAmount}
+                                                  currencySymbol={
+                                                    universal_currency_list[0]
+                                                      ? universal_currency_list[0].currencyIsoCode
+                                                      : 'USD'
+                                                  }
+                                                />
+                                              )}
+                                            </label>
+                                          </Col>
+                                        </Row>
+                                      </div>
+                                    </Col>
+                                  </Row>
+                                ) : null}
+                                <Row>
+                                  <Col
+                                    lg={12}
+                                    className="mt-5 d-flex flex-wrap align-items-center justify-content-between"
+                                  >
+                                    <FormGroup>
+                                      {props.values.postingReferenceType === 'MANUAL' && (
+                                        <Button
+                                          type="button"
+                                          color="danger"
+                                          className="btn-square"
+                                          disabled1={this.state.disabled1}
+                                          disabled={
+                                            props.values.postingReferenceType === 'MANUAL'
+                                              ? false
+                                              : true
+                                          }
+                                          onClick={this.deleteJournal}
+                                        >
+                                          <i className="fa fa-trash"></i>{' '}
+                                          {this.state.disabled1 ? 'Deleting...' : strings.Delete}
+                                        </Button>
+                                      )}
+                                    </FormGroup>
+                                    <FormGroup className="text-right">
+                                      {props.values.postingReferenceType === 'MANUAL' && (
+                                        <Button
+                                          type="button"
+                                          color="primary"
+                                          disabled={
+                                            props.values.postingReferenceType === 'MANUAL'
+                                              ? false
+                                              : true
+                                          }
+                                          className="btn-square mr-3"
+                                          disabled2={this.state.disabled2}
+                                          onClick={() => {
+                                            this.setState(
+                                              {
+                                                submitJournal: true,
+                                              },
+                                              () => {
+                                                props.handleSubmit();
+                                              }
+                                            );
+                                          }}
+                                        >
+                                          <i className="fa fa-dot-circle-o"></i>{' '}
+                                          {this.state.disabled2 ? 'Updating...' : strings.Update}
+                                        </Button>
+                                      )}
+                                      <Button
+                                        color="secondary"
+                                        className="btn-square"
+                                        onClick={() => {
+                                          this.props.journalActions.setCancelFlag(true);
+                                          this.props.history.push('/admin/accountant/journal');
+                                          if (state.renderURL) {
+                                            this.props.history.push(state.renderURL, {
+                                              id: state.renderId,
+                                              isCNWithoutProduct: state.renderCN,
+                                              expenseId: state.renderId,
+                                            });
+                                          }
+                                        }}
+                                      >
+                                        <i className="fa fa-ban"></i>{' '}
+                                        {this.state.disabled1 ? 'Deleting...' : strings.Cancel}
+                                      </Button>
+                                    </FormGroup>
+                                  </Col>
+                                </Row>
+                              </Form>
+                            )}
+                          </Formik>
+                        </Col>
+                      </Row>
+                    )}
+                  </CardBody>
+                </Card>
+              </Col>
+            </Row>
+          </div>
+        </div>
+        {this.state.disableLeavePage ? '' : <LeavePage />}
+      </div>
+    );
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(DetailJournal);

--- a/apps/frontend/src/screens/opening_balance/screens/create/screen.js
+++ b/apps/frontend/src/screens/opening_balance/screens/create/screen.js
@@ -1,23 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Input,
-	FormGroup,
-	Label,
-	Row,
-	Col,
-} from 'reactstrap';
+import { Card, CardHeader, CardBody, Button, Input, FormGroup, Label, Row, Col } from 'reactstrap';
 import Select from 'react-select';
 import DatePicker from 'react-datepicker';
 import _ from 'lodash';
-import { Loader ,LeavePage} from 'components';
+import { Loader, LeavePage } from 'components';
 import dayjs from '@/utils/date';
-import { AuthActions,CommonActions } from 'services/global';
+import { AuthActions, CommonActions } from 'services/global';
 import * as OpeningBalanceActions from '../../actions';
 import 'react-datepicker/dist/react-datepicker.css';
 import 'react-toastify/dist/ReactToastify.css';
@@ -25,431 +15,438 @@ import './style.scss';
 import * as CreateOpeningBalancesActions from './actions';
 import { selectOptionsFactory } from 'utils';
 import { Formik } from 'formik';
-import {data}  from '../../../Language/index'
+import { data } from '../../../Language/index';
 import LocalizedStrings from 'react-localization';
 
-const mapStateToProps = (state) => {
-	return {
-		
-		currency_list: state.common.currency_list,
-		transaction_category_list: state.opening_balance.transaction_category_list,
-	};
+const mapStateToProps = state => {
+  return {
+    currency_list: state.common.currency_list,
+    transaction_category_list: state.opening_balance.transaction_category_list,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		openingBalanceActions: bindActionCreators(OpeningBalanceActions, dispatch),
-		createOpeningBalancesActions: bindActionCreators(CreateOpeningBalancesActions, dispatch),
-		commonActions: bindActionCreators(CommonActions, dispatch),
-		authActions: bindActionCreators(AuthActions, dispatch),
-	}
+const mapDispatchToProps = dispatch => {
+  return {
+    openingBalanceActions: bindActionCreators(OpeningBalanceActions, dispatch),
+    createOpeningBalancesActions: bindActionCreators(CreateOpeningBalancesActions, dispatch),
+    commonActions: bindActionCreators(CommonActions, dispatch),
+    authActions: bindActionCreators(AuthActions, dispatch),
+  };
 };
 let strings = new LocalizedStrings(data);
 
 class CreateOpeningBalance extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			language: window['localStorage'].getItem('language'),
-			initValue: {
-				effectiveDate : new Date(),
-				openingBalance : '',
-				transactionCategoryId : '',
-			},
-			data: '',
-			basecurrency:[],
-			loading: false,
-			createMore: false,
-			disabled: false,
-			loadingMsg:"Loading...",
-			disableLeavePage:false, 
-			openingbalancelist:"",
-		};
-		this.regEx = /^[0-9\d]+$/;
-		this.regExAlpha = /^[a-zA-Z ]+$/;
-		this.regExBoth = /[a-zA-Z0-9]+$/;
-		this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
-		this.formRef = React.createRef();
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: window['localStorage'].getItem('language'),
+      initValue: {
+        effectiveDate: new Date(),
+        openingBalance: '',
+        transactionCategoryId: '',
+      },
+      data: '',
+      basecurrency: [],
+      loading: false,
+      createMore: false,
+      disabled: false,
+      loadingMsg: 'Loading...',
+      disableLeavePage: false,
+      openingbalancelist: '',
+    };
+    this.regEx = /^[0-9\d]+$/;
+    this.regExAlpha = /^[a-zA-Z ]+$/;
+    this.regExBoth = /[a-zA-Z0-9]+$/;
+    this.regDecimal = /^[0-9][0-9]*[.]?[0-9]{0,2}$$/;
+    this.formRef = React.createRef();
+  }
 
-		
-	}
-	
+  componentDidMount = () => {
+    this.props.authActions.getCurrencylist();
+    //this.getCompanyCurrency();
+    this.getOpeningBalanceList();
+    this.initializeData();
+  };
+  getOpeningBalanceList = () => {
+    this.props.createOpeningBalancesActions
+      .getOpeningBalanceList()
+      .then(res => {
+        if (res.status === 200) {
+          this.setState({ openingbalancelist: res.data });
+        }
+      })
+      .catch(err => {
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err && err.data ? err.data.message : 'Something Went Wrong'
+        );
+      });
+  };
+  checkIfOpeningBalanceAlreadyExist = transactioncategorylist => {
+    let openingbalancelist = this.state.openingbalancelist.data;
+    if (openingbalancelist && openingbalancelist.length && openingbalancelist.length !== 0) {
+      let transactioncategorynewlist = [];
+      transactioncategorylist.map(category => {
+        let openingbalance = openingbalancelist.find(
+          element => category.transactionCategoryId === element.transactionCategoryId
+        );
+        if (!openingbalance) {
+          transactioncategorynewlist.push(category);
+        }
+      });
+      return transactioncategorynewlist;
+    } else {
+      return transactioncategorylist;
+    }
+  };
+  initializeData = () => {
+    this.props.openingBalanceActions.getTransactionCategoryList();
+    this.props.commonActions.getCompanyDetails().then(action => {
+      // Redux Toolkit thunks return action objects
+      if (action && action.type && action.type.includes('fulfilled')) {
+        const isRegisteredVat = action.payload.isRegisteredVat;
 
-	componentDidMount = () => {
-		this.props.authActions.getCurrencylist() ;
-		//this.getCompanyCurrency();
-		this.getOpeningBalanceList();
-		this.initializeData();
-	};
-	getOpeningBalanceList = () => {
-		this.props.createOpeningBalancesActions.getOpeningBalanceList()
-		.then((res) => {
-			if (res.status === 200) {
-				this.setState({openingbalancelist:res.data,});
-			}
-		})
-		.catch((err) => {
-			this.props.commonActions.tostifyAlert(
-				'error',
-				err && err.data ? err.data.message : 'Something Went Wrong',
-			);
-		});
-	}; 
-	checkIfOpeningBalanceAlreadyExist = (transactioncategorylist) =>{
-		let openingbalancelist = this.state.openingbalancelist.data;
-		if(openingbalancelist && openingbalancelist.length && openingbalancelist.length !== 0){
-			let transactioncategorynewlist=[];
-			transactioncategorylist.map((category)=> {
-				let openingbalance = openingbalancelist.find((element) => category.transactionCategoryId === element.transactionCategoryId)
-				if(!openingbalance){
-					transactioncategorynewlist.push(category);
-				}
-			});
-			return transactioncategorynewlist;
-		}
-		else{
-			return transactioncategorylist;
-		}
-	}
-	initializeData = () => {
-		this.props.openingBalanceActions.getTransactionCategoryList();
-		this.props.commonActions.getCompanyDetails().then((res) => {
-			if (res.status === 200) {
-			  const isRegisteredVat = res.data.isRegisteredVat;
-	  
-			  this.props.history.replace({
-				pathname: this.props.location.pathname,
-				state: {
-				  ...this.props.location.state,
-				  isRegisteredVat: isRegisteredVat,
-				},
-			  });
-	  
-			  this.setState({
-				companyDetails: res.data,
-				isRegisteredVat: isRegisteredVat,
-			  });
-			}
-		  });
-	}
+        this.props.history.replace({
+          pathname: this.props.location.pathname,
+          state: {
+            ...this.props.location.state,
+            isRegisteredVat: isRegisteredVat,
+          },
+        });
 
-	// Create  Currency conversion
-	handleSubmit = (data,resetForm) =>{
-		this.setState({ disabled: true });
-		// const postData = {
-		// 	openingBalance: data.openingBalance,
-		// 	transactionCategoryId: data.transactionCategoryId.value,
-		// 	effectiveDate:data.effectiveDate,
-		// };
-		let formData =new FormData()
-			formData.append(`persistModelList[${0}].transactionCategoryId`, data.transactionCategoryId.value);
-		    formData.append(`persistModelList[${0}].effectiveDate`, dayjs(data.effectiveDate));
-			formData.append(`persistModelList[${0}].openingBalance`, data.openingBalance);
-		
-			this.setState({ loading:true, disableLeavePage:true,loadingMsg:"Creating New Opening Balance..."});
-			this.props.createOpeningBalancesActions
-				.addOpeningBalance(formData)
-				.then((res) => {
-					this.setState({ disabled: false });
-					if (res.status === 200) {
-						resetForm(this.state.initValue);
-						this.props.commonActions.tostifyAlert(
-							'success',
-							res.data ? res.data.message : 'New Opening Balance Created Successfully.',
-						);
-						if (this.state.createMore) {
-							this.setState({
-								createMore: false,
-							});
-						} else {
-							this.props.history.push('/admin/accountant/opening-balance');
-							this.setState({ loading:false,});
-						}
-					}
-				})
-				.catch((err) => {
-					this.setState({ disabled: false });
-					this.props.commonActions.tostifyAlert(
-						'error',
-						err.data ? err.data.message : 'New Opening Balance Created Unsuccessfully',
-					);
-				});
-		
-	};
+        this.setState({
+          companyDetails: action.payload,
+          isRegisteredVat: isRegisteredVat,
+        });
+      }
+    });
+  };
 
-	render() {
-		strings.setLanguage(this.state.language);
-		const { loading, initValue,loadingMsg} = this.state;
-		let{transaction_category_list} = this.props;
-		if(transaction_category_list && transaction_category_list?.length !== 0){
-			transaction_category_list = this.checkIfOpeningBalanceAlreadyExist(transaction_category_list);
-		}
-		const customStyles = {
-			control: (base, state) => ({
-				...base,
-				borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-				boxShadow: state.isFocused ? null : null,
-				'&:hover': {
-					borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
-				},
-			}),
-		};
-		return (
-			loading ==true? <Loader loadingMsg={loadingMsg}/> :
-			<div>
-			<div className="vat-code-create-screen">
-				<div className="animated fadeIn">
-					<Row>
-						<Col lg={12}>
-							<Card>
-								<CardHeader>
-									<div className="h4 mb-0 d-flex align-items-center">
-									<i className="fas fa-balance-scale" />
-										<span className="ml-2">{strings.NewOpeningBalance}</span>
-									</div>
-								</CardHeader>
-								<CardBody>
-								{loading ? (
-										<Row>
-											<Col lg={12}>
-												<Loader />
-											</Col>
-										</Row>
-									) : (
-									<Row>
-										<Col lg={10}>
-											<Formik
-												initialValues={initValue}
-												ref={this.formRef}
-												onSubmit={(values, { resetForm }) => {
-													this.handleSubmit(values, resetForm);
-												}}
-												validate={(values) => {
-													let errors = {};
-													if (!values.transactionCategoryId) {
-														errors.transactionCategoryId =
-															'Transaction category is  required';
-													}
-													if (!values.effectiveDate) {
-														errors.effectiveDate =
-															'Date is  required';
-													}
-													if (!values.openingBalance) {
-														errors.openingBalance =
-															'Amount is  required';
-													}
-													if (values.transactionCategoryId && values.transactionCategoryId.label && values.transactionCategoryId.label === "Select Transaction Category") {
-														errors.transactionCategoryId =
-														'Transaction category is required';
-													}
-													return errors;
-												}}
-											>
-												{(props) => {
-													const {
-														values,
-														touched,
-														errors,
-														handleChange,
-														handleSubmit,
-														handleBlur,
-													} = props;
-													return (
-														<form onSubmit={handleSubmit}>
-																<Row>
-																<Col lg={4}>
-																<FormGroup className="mb-3">
-																<Label htmlFor="transactionCategoryBalanceId">
-																<span className="text-danger">* </span>
-																{strings.TransactionCategory}
-																<div className="tooltip-icon nav-icon fas fa-question-circle ml-1">
-																	<span className="tooltiptext">This list will only include categories for which an opening balance has not been created.</span>
-																</div>
-																</Label>
-																		<Select
-																		id="transactionCategoryId"
-																		name="transactionCategoryId"
-																		placeholder={strings.Select+strings.TransactionCategory}
-																		options={
-																			transaction_category_list
-																			  ? selectOptionsFactory.renderOptions(
-																				  'transactionCategoryName',
-																				  'transactionCategoryId',
-																				  transaction_category_list.filter(category =>
-																					  this.state.isRegisteredVat ||
-																					  ![
-																						'VAT Penalty',
-																						'Output VAT Adjustment',
-																						'Input VAT Adjustment',
-																						'VAT Payable',
-																						'GCC VAT Payable',
-																						'Output VAT',
-																						'Input VAT'
-																						
-																					  ].includes(category.transactionCategoryName.trim()) 
-																					)
-																					.sort((a, b) => a.transactionCategoryName.localeCompare(b.transactionCategoryName)), 
-																				  'Transaction Category'
-																				)
-																			  : []
-																		  }
-																		value={props.values.transactionCategoryId}
-																		className={
-																			props.errors.transactionCategoryId &&
-																			props.touched.transactionCategoryId
-																				? 'is-invalid'
-																				: ''
-																		}
-																		onChange={(option) =>{
-																			props.handleChange('transactionCategoryId')(
-																				option,
-																			)
-																		}}
-																	/>
-																	{props.errors.transactionCategoryId &&
-																		props.touched.transactionCategoryId && (
-																			<div className="invalid-feedback">
-																				{props.errors.transactionCategoryId}
-																			</div>
-																		)}
-																			</FormGroup>
-																				</Col>
-															
-																<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="effectiveDate">
-																		<span className="text-danger">* </span>
-																		{strings.OpeningDate}
-																	</Label>
-																	<DatePicker
-																		id="date"
-																		name="effectiveDate"
-																		className={`form-control ${
-																			props.errors.effectiveDate &&
-																			props.touched.effectiveDate
-																				? 'is-invalid'
-																				: ''
-																		}`}
-																		placeholderText={strings.Enter+strings.EffectiveDate}
-																		selected={props.values.effectiveDate}
-																		showMonthDropdown
-																		showYearDropdown
-																		dropdownMode="select"
-																		dateFormat="dd-MM-yyyy"
-																		// maxDate={new Date()}
-																		// minDate={new Date()}
-																		onChange={(value) => {
-																			props.handleChange('effectiveDate')(value);
-																		}}
-																	/>
-																	{props.errors.effectiveDate &&
-																		props.touched.effectiveDate && (
-																			<div className="invalid-feedback">
-																				{props.errors.effectiveDate.includes("nullable()") ? "Opening date is required" :props.errors.effectiveDate}
+  // Create  Currency conversion
+  handleSubmit = (data, resetForm) => {
+    this.setState({ disabled: true });
+    // const postData = {
+    // 	openingBalance: data.openingBalance,
+    // 	transactionCategoryId: data.transactionCategoryId.value,
+    // 	effectiveDate:data.effectiveDate,
+    // };
+    let formData = new FormData();
+    formData.append(
+      `persistModelList[${0}].transactionCategoryId`,
+      data.transactionCategoryId.value
+    );
+    formData.append(`persistModelList[${0}].effectiveDate`, dayjs(data.effectiveDate));
+    formData.append(`persistModelList[${0}].openingBalance`, data.openingBalance);
 
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
+    this.setState({
+      loading: true,
+      disableLeavePage: true,
+      loadingMsg: 'Creating New Opening Balance...',
+    });
+    this.props.createOpeningBalancesActions
+      .addOpeningBalance(formData)
+      .then(res => {
+        this.setState({ disabled: false });
+        if (res.status === 200) {
+          resetForm(this.state.initValue);
+          this.props.commonActions.tostifyAlert(
+            'success',
+            res.data ? res.data.message : 'New Opening Balance Created Successfully.'
+          );
+          if (this.state.createMore) {
+            this.setState({
+              createMore: false,
+            });
+          } else {
+            this.props.history.push('/admin/accountant/opening-balance');
+            this.setState({ loading: false });
+          }
+        }
+      })
+      .catch(err => {
+        this.setState({ disabled: false });
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err.data ? err.data.message : 'New Opening Balance Created Unsuccessfully'
+        );
+      });
+  };
 
-																
-															</Row>
-															<Row>
-															<Col lg={4}>
-																<FormGroup className="mb-3">
-																	<Label htmlFor="openingBalance">
-																		<span className="text-danger">* </span>{strings.Amount}
-																	</Label>
-																	<Input
-																		type="text"
-																		maxLength="14,2"
-																		name="openingBalance"
-																		id="openingBalance"
-																		rows="5"
-																		className={
-																			props.errors.openingBalance &&
-																			props.touched.openingBalance
-																				? 'is-invalid'
-																				: ''
-																		}
-																		onChange={(option) => {
-																			if (
-																				option.target.value === '' ||
-																				this.regEx.test(
-																					option.target.value,
-																				)
-																			)
-																			props.handleChange('openingBalance')(
-																				option,
-																			);
-																		}}
-																		value={props.values.openingBalance}
-																		placeholder={strings.Enter+strings.Amount}
-																	/>
-																	{props.errors.openingBalance &&
-																		props.touched.openingBalance && (
-																			<div className="invalid-feedback">
-																				{props.errors.openingBalance}
-																			</div>
-																		)}
-																</FormGroup>
-															</Col>
-															</Row>
-														<Row>
-														{/* <Col lg={12} className="mt-5"> */}
-																<FormGroup className="text-right ml-3 mt-5">
-																<Button 
-																	type="submit"
-																	name="submit"
-																	color="primary"
-																	className="btn-square mr-3"
-																	disabled={this.state.disabled}
-																	onClick={() => {
-																		//  added validation popup  msg                                                                
-																		props.handleBlur();
-																		if(props.errors &&  Object.keys(props.errors).length != 0)
-																		this.props.commonActions.fillManDatoryDetails();
-																	}}
-																>
-																	<i className="fa fa-dot-circle-o"></i> 	{this.state.disabled
-																			? 'Creating...'
-																			: strings.Create }
-																</Button>
+  render() {
+    strings.setLanguage(this.state.language);
+    const { loading, initValue, loadingMsg } = this.state;
+    let { transaction_category_list } = this.props;
+    if (transaction_category_list && transaction_category_list?.length !== 0) {
+      transaction_category_list = this.checkIfOpeningBalanceAlreadyExist(transaction_category_list);
+    }
+    const customStyles = {
+      control: (base, state) => ({
+        ...base,
+        borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+        boxShadow: state.isFocused ? null : null,
+        '&:hover': {
+          borderColor: state.isFocused ? '#2064d8' : '#c7c7c7',
+        },
+      }),
+    };
+    return loading == true ? (
+      <Loader loadingMsg={loadingMsg} />
+    ) : (
+      <div>
+        <div className="vat-code-create-screen">
+          <div className="animated fadeIn">
+            <Row>
+              <Col lg={12}>
+                <Card>
+                  <CardHeader>
+                    <div className="h4 mb-0 d-flex align-items-center">
+                      <i className="fas fa-balance-scale" />
+                      <span className="ml-2">{strings.NewOpeningBalance}</span>
+                    </div>
+                  </CardHeader>
+                  <CardBody>
+                    {loading ? (
+                      <Row>
+                        <Col lg={12}>
+                          <Loader />
+                        </Col>
+                      </Row>
+                    ) : (
+                      <Row>
+                        <Col lg={10}>
+                          <Formik
+                            initialValues={initValue}
+                            ref={this.formRef}
+                            onSubmit={(values, { resetForm }) => {
+                              this.handleSubmit(values, resetForm);
+                            }}
+                            validate={values => {
+                              let errors = {};
+                              if (!values.transactionCategoryId) {
+                                errors.transactionCategoryId = 'Transaction category is  required';
+                              }
+                              if (!values.effectiveDate) {
+                                errors.effectiveDate = 'Date is  required';
+                              }
+                              if (!values.openingBalance) {
+                                errors.openingBalance = 'Amount is  required';
+                              }
+                              if (
+                                values.transactionCategoryId &&
+                                values.transactionCategoryId.label &&
+                                values.transactionCategoryId.label === 'Select Transaction Category'
+                              ) {
+                                errors.transactionCategoryId = 'Transaction category is required';
+                              }
+                              return errors;
+                            }}
+                          >
+                            {props => {
+                              const {
+                                values,
+                                touched,
+                                errors,
+                                handleChange,
+                                handleSubmit,
+                                handleBlur,
+                              } = props;
+                              return (
+                                <form onSubmit={handleSubmit}>
+                                  <Row>
+                                    <Col lg={4}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="transactionCategoryBalanceId">
+                                          <span className="text-danger">* </span>
+                                          {strings.TransactionCategory}
+                                          <div className="tooltip-icon nav-icon fas fa-question-circle ml-1">
+                                            <span className="tooltiptext">
+                                              This list will only include categories for which an
+                                              opening balance has not been created.
+                                            </span>
+                                          </div>
+                                        </Label>
+                                        <Select
+                                          id="transactionCategoryId"
+                                          name="transactionCategoryId"
+                                          placeholder={strings.Select + strings.TransactionCategory}
+                                          options={
+                                            transaction_category_list
+                                              ? selectOptionsFactory.renderOptions(
+                                                  'transactionCategoryName',
+                                                  'transactionCategoryId',
+                                                  transaction_category_list
+                                                    .filter(
+                                                      category =>
+                                                        this.state.isRegisteredVat ||
+                                                        ![
+                                                          'VAT Penalty',
+                                                          'Output VAT Adjustment',
+                                                          'Input VAT Adjustment',
+                                                          'VAT Payable',
+                                                          'GCC VAT Payable',
+                                                          'Output VAT',
+                                                          'Input VAT',
+                                                        ].includes(
+                                                          category.transactionCategoryName.trim()
+                                                        )
+                                                    )
+                                                    .sort((a, b) =>
+                                                      a.transactionCategoryName.localeCompare(
+                                                        b.transactionCategoryName
+                                                      )
+                                                    ),
+                                                  'Transaction Category'
+                                                )
+                                              : []
+                                          }
+                                          value={props.values.transactionCategoryId}
+                                          className={
+                                            props.errors.transactionCategoryId &&
+                                            props.touched.transactionCategoryId
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                          onChange={option => {
+                                            props.handleChange('transactionCategoryId')(option);
+                                          }}
+                                        />
+                                        {props.errors.transactionCategoryId &&
+                                          props.touched.transactionCategoryId && (
+                                            <div className="invalid-feedback">
+                                              {props.errors.transactionCategoryId}
+                                            </div>
+                                          )}
+                                      </FormGroup>
+                                    </Col>
 
-																<Button
-																	type="button"
-																	color="secondary"
-																	className="btn-square"
-																	onClick={() => {
-																		this.props.history.push(
-																			'/admin/accountant/opening-balance',
-																		);
-																	}}
-																>
-																	<i className="fa fa-ban"></i>  {strings.Cancel}
-																</Button>
-																</FormGroup>
-																{/* </Col> */}
-																</Row></form>
-													);
-												}}
-											</Formik>
-										</Col>
-									</Row>
-									)}
-								</CardBody>
-							</Card>
-						</Col>
-					</Row>
-					{loading ? <Loader></Loader> : ''}
-				</div>
-			</div>
-			{this.state.disableLeavePage ?"":<LeavePage/>}
-			</div>
-		);
-	}
+                                    <Col lg={4}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="effectiveDate">
+                                          <span className="text-danger">* </span>
+                                          {strings.OpeningDate}
+                                        </Label>
+                                        <DatePicker
+                                          id="date"
+                                          name="effectiveDate"
+                                          className={`form-control ${
+                                            props.errors.effectiveDate &&
+                                            props.touched.effectiveDate
+                                              ? 'is-invalid'
+                                              : ''
+                                          }`}
+                                          placeholderText={strings.Enter + strings.EffectiveDate}
+                                          selected={props.values.effectiveDate}
+                                          showMonthDropdown
+                                          showYearDropdown
+                                          dropdownMode="select"
+                                          dateFormat="dd-MM-yyyy"
+                                          // maxDate={new Date()}
+                                          // minDate={new Date()}
+                                          onChange={value => {
+                                            props.handleChange('effectiveDate')(value);
+                                          }}
+                                        />
+                                        {props.errors.effectiveDate &&
+                                          props.touched.effectiveDate && (
+                                            <div className="invalid-feedback">
+                                              {props.errors.effectiveDate.includes('nullable()')
+                                                ? 'Opening date is required'
+                                                : props.errors.effectiveDate}
+                                            </div>
+                                          )}
+                                      </FormGroup>
+                                    </Col>
+                                  </Row>
+                                  <Row>
+                                    <Col lg={4}>
+                                      <FormGroup className="mb-3">
+                                        <Label htmlFor="openingBalance">
+                                          <span className="text-danger">* </span>
+                                          {strings.Amount}
+                                        </Label>
+                                        <Input
+                                          type="text"
+                                          maxLength="14,2"
+                                          name="openingBalance"
+                                          id="openingBalance"
+                                          rows="5"
+                                          className={
+                                            props.errors.openingBalance &&
+                                            props.touched.openingBalance
+                                              ? 'is-invalid'
+                                              : ''
+                                          }
+                                          onChange={option => {
+                                            if (
+                                              option.target.value === '' ||
+                                              this.regEx.test(option.target.value)
+                                            )
+                                              props.handleChange('openingBalance')(option);
+                                          }}
+                                          value={props.values.openingBalance}
+                                          placeholder={strings.Enter + strings.Amount}
+                                        />
+                                        {props.errors.openingBalance &&
+                                          props.touched.openingBalance && (
+                                            <div className="invalid-feedback">
+                                              {props.errors.openingBalance}
+                                            </div>
+                                          )}
+                                      </FormGroup>
+                                    </Col>
+                                  </Row>
+                                  <Row>
+                                    {/* <Col lg={12} className="mt-5"> */}
+                                    <FormGroup className="text-right ml-3 mt-5">
+                                      <Button
+                                        type="submit"
+                                        name="submit"
+                                        color="primary"
+                                        className="btn-square mr-3"
+                                        disabled={this.state.disabled}
+                                        onClick={() => {
+                                          //  added validation popup  msg
+                                          props.handleBlur();
+                                          if (props.errors && Object.keys(props.errors).length != 0)
+                                            this.props.commonActions.fillManDatoryDetails();
+                                        }}
+                                      >
+                                        <i className="fa fa-dot-circle-o"></i>{' '}
+                                        {this.state.disabled ? 'Creating...' : strings.Create}
+                                      </Button>
+
+                                      <Button
+                                        type="button"
+                                        color="secondary"
+                                        className="btn-square"
+                                        onClick={() => {
+                                          this.props.history.push(
+                                            '/admin/accountant/opening-balance'
+                                          );
+                                        }}
+                                      >
+                                        <i className="fa fa-ban"></i> {strings.Cancel}
+                                      </Button>
+                                    </FormGroup>
+                                    {/* </Col> */}
+                                  </Row>
+                                </form>
+                              );
+                            }}
+                          </Formik>
+                        </Col>
+                      </Row>
+                    )}
+                  </CardBody>
+                </Card>
+              </Col>
+            </Row>
+            {loading ? <Loader></Loader> : ''}
+          </div>
+        </div>
+        {this.state.disableLeavePage ? '' : <LeavePage />}
+      </div>
+    );
+  }
 }
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps,
-)(CreateOpeningBalance);
+export default connect(mapStateToProps, mapDispatchToProps)(CreateOpeningBalance);

--- a/apps/frontend/src/screens/product/screen.js
+++ b/apps/frontend/src/screens/product/screen.js
@@ -2,17 +2,17 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	Button,
-	Row,
-	Col,
-	ButtonGroup,
-	ButtonDropdown,
-	DropdownToggle,
-	DropdownMenu,
-	DropdownItem,
+  Card,
+  CardHeader,
+  CardBody,
+  Button,
+  Row,
+  Col,
+  ButtonGroup,
+  ButtonDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
 } from 'reactstrap';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import { Loader, ConfirmDeleteModal, Currency } from 'components';
@@ -21,512 +21,486 @@ import 'react-bootstrap-table/dist/react-bootstrap-table-all.min.css';
 import * as ProductActions from './actions';
 import { CommonActions } from 'services/global';
 import './style.scss';
-import {data}  from '../Language/index'
+import { data } from '../Language/index';
 import LocalizedStrings from 'react-localization';
 // import { AgGridReact,AgGridColumn } from 'ag-grid-react/lib/agGridReact';
 // import 'ag-grid-community/dist/styles/ag-grid.css';
 // import 'ag-grid-community/dist/styles/ag-theme-alpine.css';
 
-const mapStateToProps = (state) => {
-	return {
-		product_list: state.product.product_list,
-		vat_list: state.product.vat_list,
-		universal_currency_list: state.common.universal_currency_list,
-	};
+const mapStateToProps = state => {
+  return {
+    product_list: state.product.product_list,
+    vat_list: state.product.vat_list,
+    universal_currency_list: state.common.universal_currency_list,
+  };
 };
-const mapDispatchToProps = (dispatch) => {
-	return {
-		productActions: bindActionCreators(ProductActions, dispatch),
-		commonActions: bindActionCreators(CommonActions, dispatch),
-	};
+const mapDispatchToProps = dispatch => {
+  return {
+    productActions: bindActionCreators(ProductActions, dispatch),
+    commonActions: bindActionCreators(CommonActions, dispatch),
+  };
 };
 
 let strings = new LocalizedStrings(data);
 class Product extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			language: window['localStorage'].getItem('language'),
-			loading: true,
-			selectedRows: [],
-			dialog: null,
-			filterData: {
-				name: '',
-				productCode: '',
-				vatPercentage: '',
-			},
-			selectedVat: '',
-			csvData: [],
-			view: false,
-			actionButtons: {},
-			paginationPageSize:10,
-		};
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: window['localStorage'].getItem('language'),
+      loading: true,
+      selectedRows: [],
+      dialog: null,
+      filterData: {
+        name: '',
+        productCode: '',
+        vatPercentage: '',
+      },
+      selectedVat: '',
+      csvData: [],
+      view: false,
+      actionButtons: {},
+      paginationPageSize: 10,
+    };
 
-		this.options = {
-			onRowClick: this.goToDetail,
-			page: 1,
-			sizePerPage: 10,
-			onSizePerPageList: this.onSizePerPageList,
-			onPageChange: this.onPageChange,
-			sortName: '',
-			sortOrder: '',
-			onSortChange: this.sortColumn,
-		};
+    this.options = {
+      onRowClick: this.goToDetail,
+      page: 1,
+      sizePerPage: 10,
+      onSizePerPageList: this.onSizePerPageList,
+      onPageChange: this.onPageChange,
+      sortName: '',
+      sortOrder: '',
+      onSortChange: this.sortColumn,
+    };
 
-		this.selectRowProp = {
-			//mode: 'checkbox',
-			bgColor: 'rgba(0,0,0, 0.05)',
-			clickToSelect: false,
-			onSelect: this.onRowSelect,
-			onSelectAll: this.onSelectAll,
-		};
-		this.csvLink = React.createRef();
-	}
+    this.selectRowProp = {
+      //mode: 'checkbox',
+      bgColor: 'rgba(0,0,0, 0.05)',
+      clickToSelect: false,
+      onSelect: this.onRowSelect,
+      onSelectAll: this.onSelectAll,
+    };
+    this.csvLink = React.createRef();
+  }
 
-	componentDidMount = () => {
+  componentDidMount = () => {
+    this.props.productActions.getProductVatCategoryList();
+    this.initializeData();
+  };
 
-		this.props.productActions.getProductVatCategoryList();
-		this.initializeData();
-	};
+  // componentWillUnmount = () => {
+  // 	this.setState({
+  // 		selectedRows: [],
+  // 	});
+  // };
 
-	// componentWillUnmount = () => {
-	// 	this.setState({
-	// 		selectedRows: [],
-	// 	});
-	// };
-
-	initializeData = (search) => {
-		const { filterData } = this.state;
-		const paginationData = {
-			pageNo: this.options.page ? this.options.page - 1 : 0,
-			pageSize: this.options.sizePerPage,
-		};
-		const sortingData = {
-			order: this.options.sortOrder ? this.options.sortOrder : '',
-			sortingCol: this.options.sortName ? this.options.sortName : '',
-		};
-		const postData = { ...filterData, ...paginationData, ...sortingData };
-		this.props.productActions
-			.getProductList(postData)
-			.then((res) => {
-				if (res.status === 200) {
-					this.setState({ loading: false });
-				}
-			})
-			.catch((err) => {
-				this.setState({ loading: false });
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err && err.data ? err.data.message : 'Something Went Wrong',
-				);
-			});
-	};
-
-	goToDetail = (row) => {
-		this.props.history.push('/admin/master/product/detail', { id: row.id });
-	};
-
-	sortColumn = (sortName, sortOrder) => {
-		this.options.sortName = sortName;
-		this.options.sortOrder = sortOrder;
-		this.initializeData();
-	};
-
-	onRowSelect = (row, isSelected, e) => {
-		let tempList = [];
-		if (isSelected) {
-			tempList = Object.assign([], this.state.selectedRows);
-			tempList.push(row.id);
-		} else {
-			this.state.selectedRows.map((item) => {
-				if (item !== row.id) {
-					tempList.push(item);
-				}
-				return item;
-			});
-		}
-		this.setState({
-			selectedRows: tempList,
-		});
-	};
-
-	onSelectAll = (isSelected, rows) => {
-		let tempList = [];
-		if (isSelected) {
-			rows.map((item) => tempList.push(item.id));
-		}
-		this.setState({
-			selectedRows: tempList,
-		});
-	};
-
-	bulkDelete = () => {
-		const { selectedRows } = this.state;
-		console.log(selectedRows);
-		this.props.productActions
-			.getInvoicesCountProduct(selectedRows)
-			.then((res) => {
-				if (res.data > 0) {
-					this.props.commonActions.tostifyAlert(
-						'error',
-						'You need to delete invoices to delete the product',
-					);
-				} else {
-					const message1 =
-			<text>
-			<b>Delete Invoices?</b>
-			</text>
-			const message = 'This Invoices will be deleted permanently and cannot be recovered. ';
-					if (selectedRows.length > 0) {
-						this.setState({
-							dialog: (
-								<ConfirmDeleteModal
-									isOpen={true}
-									okHandler={this.removeBulk}
-									cancelHandler={this.removeDialog}
-									message={message}
-									message1={message1}
-								/>
-							),
-						});
-					} else {
-						this.props.commonActions.tostifyAlert(
-							'info',
-							'Please select the rows of the table and try again.',
-						);
-					}
-				}
-			});
-	};
-
-	removeBulk = () => {
-		this.removeDialog();
-		let { selectedRows } = this.state;
-		const { product_list } = this.props;
-		let obj = {
-			ids: selectedRows,
-		};
-		this.props.productActions
-			.removeBulk(obj)
-			.then((res) => {
-				if (res.status === 200) {
-					this.props.commonActions.tostifyAlert(
-						'success',
-						res.data ? res.data.message : 'Product Deleted Successfully',
-					);
-					this.initializeData();
-					if (
-						product_list &&
-						product_list.data &&
-						product_list.data.length > 0
-					) {
-						this.setState({
-							selectedRows: [],
-						});
-					}
-				}
-			})
-			.catch((err) => {
-				this.props.commonActions.tostifyAlert(
-					'error',
-					err && err.data ? err.data.message : 'Product Deleted Unsuccessfully',
-				);
-			});
-	};
-
-	removeDialog = () => {
-		this.setState({
-			dialog: null,
-		});
-	};
-
-	vatCategoryFormatter = (cell, row) => {
-		return row['vatCategory'] !== null ? row['vatCategory']['name'] : '';
-	};
-
-	handleChange = (val, name) => {
-		this.setState({
-			filterData: Object.assign(this.state.filterData, {
-				[name]: val,
-			}),
-		});
-	};
-
-	handleSearch = () => {
-		this.initializeData();
-		// this.setState({})
-	};
-
-	onPageSizeChanged = (newPageSize) => {
-		var value = document.getElementById('page-size').value;
-		this.gridApi.paginationSetPageSize(Number(value));
-	};
-	onGridReady = (params) => {
-
-		this.gridApi = params.api;
-		this.gridColumnApi = params.columnApi;
-	
-	};
-	onFirstDataRendered = (params) => {
-		params.api.sizeColumnsToFit();
-		this.autoSizeAll(true);
-	  };
-
-	onSizePerPageList = (sizePerPage) => {
-		if (this.options.sizePerPage !== sizePerPage) {
-			this.options.sizePerPage = sizePerPage;
-			this.initializeData();
-		}
-	};
-
-	onPageChange = (page, sizePerPage) => {
-		if (this.options.page !== page) {
-			this.options.page = page;
-			this.initializeData();
-		}
-	};
-	getCsvData = () => {
-		if (this.state.csvData.length === 0) {
-			let obj = {
-				paginationDisable: true,
-			};
-			this.props.productActions.getProductList(obj).then((res) => {
-				if (res.status === 200) {
-					this.setState({ csvData: res.data.data, view: true }, () => {
-						setTimeout(() => {
-							this.csvLink.current.link.click();
-						}, 0);
-					});
-				}
-			});
-		} else {
-			this.csvLink.current.link.click();
-		}
-	};
-
-	clearAll = () => {
-		this.setState(
-			{
-				filterData: {
-					name: '',
-					productCode: '',
-					vatPercentage: '',
-				},
-			},
-			() => {
-				this.initializeData();
-			},
-		);
-	};
-
-	unitPrice(cell, row, extraData) {
-		return row.unitPrice === 0 ? (
-			<Currency
-				value={row.unitPrice}
-				currencySymbol={extraData[0] ? extraData[0].currencyIsoCode : 'USD'}
-			/>
-		) : (
-			<Currency
-				value={row.unitPrice}
-				currencySymbol={extraData[0] ? extraData[0].currencyIsoCode : 'USD'}
-			/>
-		);
-	}
-	toggleActionButton = (index) => {
-		let temp = Object.assign({}, this.state.actionButtons);
-		if (temp[parseInt(index, 10)]) {
-			temp[parseInt(index, 10)] = false;
-		} else {
-			temp[parseInt(index, 10)] = true;
-		}
-		this.setState({
-			actionButtons: temp,
-		});
-	};
-
-	renderStatus = (cell, row) => {
-        let classname = '';
-        if (row.isActive === true) {
-            classname = 'label-success';
-        } else {
-            classname = 'label-due';
+  initializeData = search => {
+    const { filterData } = this.state;
+    const paginationData = {
+      pageNo: this.options.page ? this.options.page - 1 : 0,
+      pageSize: this.options.sizePerPage,
+    };
+    const sortingData = {
+      order: this.options.sortOrder ? this.options.sortOrder : '',
+      sortingCol: this.options.sortName ? this.options.sortName : '',
+    };
+    const postData = { ...filterData, ...paginationData, ...sortingData };
+    this.props.productActions
+      .getProductList(postData)
+      .then(res => {
+        if (res.status === 200) {
+          this.setState({ loading: false });
         }
-        return (
-            <span className={`badge ${classname} mb-0`} style={{ color: 'white' }}>
-                {
-                    row.isActive === true ?
-                        "Active" :
-                        "InActive"
-                }
-            </span>
+      })
+      .catch(err => {
+        this.setState({ loading: false });
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err && err.data ? err.data.message : 'Something Went Wrong'
         );
-    };
+      });
+  };
 
-	renderInventory = (cell, row) => {
-        let classname = '';
-        if (row.isInventoryEnabled === true) {
-            classname = 'label-success';
-        } else {
-            classname = 'label-due';
+  goToDetail = row => {
+    this.props.history.push('/admin/master/product/detail', { id: row.id });
+  };
+
+  sortColumn = (sortName, sortOrder) => {
+    this.options.sortName = sortName;
+    this.options.sortOrder = sortOrder;
+    this.initializeData();
+  };
+
+  onRowSelect = (row, isSelected, e) => {
+    let tempList = [];
+    if (isSelected) {
+      tempList = Object.assign([], this.state.selectedRows);
+      tempList.push(row.id);
+    } else {
+      this.state.selectedRows.map(item => {
+        if (item !== row.id) {
+          tempList.push(item);
         }
-        return (
-            <span className={`badge ${classname} mb-0`} style={{ color: 'white' }}>
-                {
-                    row.isInventoryEnabled === true ?
-                        "Enabled" :
-                        "Disabled"
-                }
-            </span>
+        return item;
+      });
+    }
+    this.setState({
+      selectedRows: tempList,
+    });
+  };
+
+  onSelectAll = (isSelected, rows) => {
+    let tempList = [];
+    if (isSelected) {
+      rows.map(item => tempList.push(item.id));
+    }
+    this.setState({
+      selectedRows: tempList,
+    });
+  };
+
+  bulkDelete = () => {
+    const { selectedRows } = this.state;
+    console.log(selectedRows);
+    this.props.productActions.getInvoicesCountProduct(selectedRows).then(res => {
+      if (res.data > 0) {
+        this.props.commonActions.tostifyAlert(
+          'error',
+          'You need to delete invoices to delete the product'
         );
+      } else {
+        const message1 = (
+          <text>
+            <b>Delete Invoices?</b>
+          </text>
+        );
+        const message = 'This Invoices will be deleted permanently and cannot be recovered. ';
+        if (selectedRows.length > 0) {
+          this.setState({
+            dialog: (
+              <ConfirmDeleteModal
+                isOpen={true}
+                okHandler={this.removeBulk}
+                cancelHandler={this.removeDialog}
+                message={message}
+                message1={message1}
+              />
+            ),
+          });
+        } else {
+          this.props.commonActions.tostifyAlert(
+            'info',
+            'Please select the rows of the table and try again.'
+          );
+        }
+      }
+    });
+  };
+
+  removeBulk = () => {
+    this.removeDialog();
+    let { selectedRows } = this.state;
+    const { product_list } = this.props;
+    let obj = {
+      ids: selectedRows,
     };
-	exciseSlabFormatter  = (cell, row) => {
-        let exciseTax='';
-		if(row.exciseTaxId !=null){
-			exciseTax=row.exciseTax
-		}
-		else{
-			exciseTax="-"
-		}
-        return exciseTax;
-    };
+    this.props.productActions
+      .removeBulk(obj)
+      .then(res => {
+        if (res.status === 200) {
+          this.props.commonActions.tostifyAlert(
+            'success',
+            res.data ? res.data.message : 'Product Deleted Successfully'
+          );
+          this.initializeData();
+          if (product_list && product_list.data && product_list.data.length > 0) {
+            this.setState({
+              selectedRows: [],
+            });
+          }
+        }
+      })
+      .catch(err => {
+        this.props.commonActions.tostifyAlert(
+          'error',
+          err && err.data ? err.data.message : 'Product Deleted Unsuccessfully'
+        );
+      });
+  };
 
-	goToProductDetail = (productId) => {
-		
-				this.props.history.push('/admin/master/product/detail', {
-			id: productId,
-		})
-		
-	}
-	renderType  = (cell, row) => {
-        let type='';
-		if(row.exciseTaxId !=null  && row.exciseTaxId !=""){
-			type="EXCISE "+row.productType
-		}
-		else{
-			type=row.productType
-		}
-        return type;
-    };
-	productType = (cell, row) => {
-		return row['producttype'] !== null ? row['producttype']['type'] : '';
-	};
+  removeDialog = () => {
+    this.setState({
+      dialog: null,
+    });
+  };
 
-	renderActions = (cell, row) => {
-		return (
-			<div>
-				<ButtonDropdown
-					isOpen={this.state.actionButtons[row.id]}
-					toggle={() => this.toggleActionButton(row.id)}
-				>
-					<DropdownToggle size="sm" color="primary" className="btn-brand icon">
-						{this.state.actionButtons[row.id] === true ? (
-							<i className="fas fa-chevron-up" />
-						) : (
-							<i className="fas fa-chevron-down" />
-						)}
-					</DropdownToggle>
-					<DropdownMenu right>
-							<DropdownItem>
-								<div
-									onClick={() => {
-										this.props.history.push(
-											'/admin/master/product/detail',
-											{ id: row.id },
-										);
-									}}
-								>
-									<i className="fas fa-edit" /> {strings.Edit}
-								</div>
-							</DropdownItem>
-					</DropdownMenu>
-				</ButtonDropdown>
-			</div>
-		);
-	};
+  vatCategoryFormatter = (cell, row) => {
+    return row['vatCategory'] !== null ? row['vatCategory']['name'] : '';
+  };
 
-	getActionButtons = (params) => {
-		return (
-	<>
-	{/* BUTTON ACTIONS */}
-			{/* View */}
-			
-			<Button
-				className="Ag-gridActionButtons btn-sm"
-				title='Edit'
-				color="secondary"
-					onClick={()=>
-						this.goToProductDetail(params.data.id)  }
-			
-			>		<i className="fas fa-edit"/> </Button> 
-	</>
-		)
-	}
+  handleChange = (val, name) => {
+    this.setState({
+      filterData: Object.assign(this.state.filterData, {
+        [name]: val,
+      }),
+    });
+  };
 
-	sizeToFit = () => {
-		this.gridApi.sizeColumnsToFit();
-	  };
-	
-	  autoSizeAll = (skipHeader) => {
-		const allColumnIds = [];
-		this.gridColumnApi.getAllColumns().forEach((column) => {
-		  allColumnIds.push(column.getId());
-		});
-		this.gridColumnApi.autoSizeColumns(allColumnIds, skipHeader);
-	  };
+  handleSearch = () => {
+    this.initializeData();
+    // this.setState({})
+  };
 
-	render() {
-		strings.setLanguage(this.state.language);
-		const {
-			loading,
-			dialog,
-			filterData,
-			selectedRows,
-			csvData,
-			view,
-		} = this.state;
-		const { product_list, vat_list, universal_currency_list } = this.props;
+  onPageSizeChanged = newPageSize => {
+    var value = document.getElementById('page-size').value;
+    this.gridApi.paginationSetPageSize(Number(value));
+  };
+  onGridReady = params => {
+    this.gridApi = params.api;
+    this.gridColumnApi = params.columnApi;
+  };
+  onFirstDataRendered = params => {
+    params.api.sizeColumnsToFit();
+    this.autoSizeAll(true);
+  };
 
-		return (
-			loading ==true? <Loader/> :
-<div>
-			<div className="product-screen">
-				<div className="animated fadeIn">
-					 <div className="button-bar">
-            {/* <button onClick={() => this.sizeToFit()}>Size to Fit</button>
+  onSizePerPageList = sizePerPage => {
+    if (this.options.sizePerPage !== sizePerPage) {
+      this.options.sizePerPage = sizePerPage;
+      this.initializeData();
+    }
+  };
+
+  onPageChange = (page, sizePerPage) => {
+    if (this.options.page !== page) {
+      this.options.page = page;
+      this.initializeData();
+    }
+  };
+  getCsvData = () => {
+    if (this.state.csvData.length === 0) {
+      let obj = {
+        paginationDisable: true,
+      };
+      this.props.productActions.getProductList(obj).then(action => {
+        // Redux Toolkit thunks return action objects
+        // When paginationDisable is true, payload contains the full response
+        if (action && action.type && action.type.includes('fulfilled') && action.payload) {
+          const data = action.payload.data ? action.payload.data.data : action.payload;
+          this.setState({ csvData: data, view: true }, () => {
+            setTimeout(() => {
+              this.csvLink.current.link.click();
+            }, 0);
+          });
+        }
+      });
+    } else {
+      this.csvLink.current.link.click();
+    }
+  };
+
+  clearAll = () => {
+    this.setState(
+      {
+        filterData: {
+          name: '',
+          productCode: '',
+          vatPercentage: '',
+        },
+      },
+      () => {
+        this.initializeData();
+      }
+    );
+  };
+
+  unitPrice(cell, row, extraData) {
+    return row.unitPrice === 0 ? (
+      <Currency
+        value={row.unitPrice}
+        currencySymbol={extraData[0] ? extraData[0].currencyIsoCode : 'USD'}
+      />
+    ) : (
+      <Currency
+        value={row.unitPrice}
+        currencySymbol={extraData[0] ? extraData[0].currencyIsoCode : 'USD'}
+      />
+    );
+  }
+  toggleActionButton = index => {
+    let temp = Object.assign({}, this.state.actionButtons);
+    if (temp[parseInt(index, 10)]) {
+      temp[parseInt(index, 10)] = false;
+    } else {
+      temp[parseInt(index, 10)] = true;
+    }
+    this.setState({
+      actionButtons: temp,
+    });
+  };
+
+  renderStatus = (cell, row) => {
+    let classname = '';
+    if (row.isActive === true) {
+      classname = 'label-success';
+    } else {
+      classname = 'label-due';
+    }
+    return (
+      <span className={`badge ${classname} mb-0`} style={{ color: 'white' }}>
+        {row.isActive === true ? 'Active' : 'InActive'}
+      </span>
+    );
+  };
+
+  renderInventory = (cell, row) => {
+    let classname = '';
+    if (row.isInventoryEnabled === true) {
+      classname = 'label-success';
+    } else {
+      classname = 'label-due';
+    }
+    return (
+      <span className={`badge ${classname} mb-0`} style={{ color: 'white' }}>
+        {row.isInventoryEnabled === true ? 'Enabled' : 'Disabled'}
+      </span>
+    );
+  };
+  exciseSlabFormatter = (cell, row) => {
+    let exciseTax = '';
+    if (row.exciseTaxId != null) {
+      exciseTax = row.exciseTax;
+    } else {
+      exciseTax = '-';
+    }
+    return exciseTax;
+  };
+
+  goToProductDetail = productId => {
+    this.props.history.push('/admin/master/product/detail', {
+      id: productId,
+    });
+  };
+  renderType = (cell, row) => {
+    let type = '';
+    if (row.exciseTaxId != null && row.exciseTaxId != '') {
+      type = 'EXCISE ' + row.productType;
+    } else {
+      type = row.productType;
+    }
+    return type;
+  };
+  productType = (cell, row) => {
+    return row['producttype'] !== null ? row['producttype']['type'] : '';
+  };
+
+  renderActions = (cell, row) => {
+    return (
+      <div>
+        <ButtonDropdown
+          isOpen={this.state.actionButtons[row.id]}
+          toggle={() => this.toggleActionButton(row.id)}
+        >
+          <DropdownToggle size="sm" color="primary" className="btn-brand icon">
+            {this.state.actionButtons[row.id] === true ? (
+              <i className="fas fa-chevron-up" />
+            ) : (
+              <i className="fas fa-chevron-down" />
+            )}
+          </DropdownToggle>
+          <DropdownMenu right>
+            <DropdownItem>
+              <div
+                onClick={() => {
+                  this.props.history.push('/admin/master/product/detail', { id: row.id });
+                }}
+              >
+                <i className="fas fa-edit" /> {strings.Edit}
+              </div>
+            </DropdownItem>
+          </DropdownMenu>
+        </ButtonDropdown>
+      </div>
+    );
+  };
+
+  getActionButtons = params => {
+    return (
+      <>
+        {/* BUTTON ACTIONS */}
+        {/* View */}
+
+        <Button
+          className="Ag-gridActionButtons btn-sm"
+          title="Edit"
+          color="secondary"
+          onClick={() => this.goToProductDetail(params.data.id)}
+        >
+          {' '}
+          <i className="fas fa-edit" />{' '}
+        </Button>
+      </>
+    );
+  };
+
+  sizeToFit = () => {
+    this.gridApi.sizeColumnsToFit();
+  };
+
+  autoSizeAll = skipHeader => {
+    const allColumnIds = [];
+    this.gridColumnApi.getAllColumns().forEach(column => {
+      allColumnIds.push(column.getId());
+    });
+    this.gridColumnApi.autoSizeColumns(allColumnIds, skipHeader);
+  };
+
+  render() {
+    strings.setLanguage(this.state.language);
+    const { loading, dialog, filterData, selectedRows, csvData, view } = this.state;
+    const { product_list, vat_list, universal_currency_list } = this.props;
+
+    return loading == true ? (
+      <Loader />
+    ) : (
+      <div>
+        <div className="product-screen">
+          <div className="animated fadeIn">
+            <div className="button-bar">
+              {/* <button onClick={() => this.sizeToFit()}>Size to Fit</button>
             <button onClick={() => this.autoSizeAll(false)}>
               Auto-Size All
             </button>
             <button onClick={() => this.autoSizeAll(true)}>
               Auto-Size All (Skip Header)
             </button> */}
-          </div>
-					{dialog}
-					{/* <ToastContainer position="top-right" autoClose={5000} style={containerStyle} /> */}
-					<Card>
-						<CardHeader>
-							<Row>
-								<Col lg={12}>
-									<div className="h4 mb-0 d-flex align-items-center">
-										<i className="fas fa-box" />
-										<span className="ml-2">{strings.Products} </span>
-									</div>
-								</Col>
-							</Row>
-						</CardHeader>
-						<CardBody>
-							{loading ? (
-								<Row>
-									<Col lg={12}>
-										<Loader />
-									</Col>
-								</Row>
-							) : (
-								<Row>
-									<Col lg={12}>
-								
-										<div className="d-flex justify-content-end">
-											<ButtonGroup size="sm">
-												{/* <Button
+            </div>
+            {dialog}
+            {/* <ToastContainer position="top-right" autoClose={5000} style={containerStyle} /> */}
+            <Card>
+              <CardHeader>
+                <Row>
+                  <Col lg={12}>
+                    <div className="h4 mb-0 d-flex align-items-center">
+                      <i className="fas fa-box" />
+                      <span className="ml-2">{strings.Products} </span>
+                    </div>
+                  </Col>
+                </Row>
+              </CardHeader>
+              <CardBody>
+                {loading ? (
+                  <Row>
+                    <Col lg={12}>
+                      <Loader />
+                    </Col>
+                  </Row>
+                ) : (
+                  <Row>
+                    <Col lg={12}>
+                      <div className="d-flex justify-content-end">
+                        <ButtonGroup size="sm">
+                          {/* <Button
 													color="primary"
 													className="btn-square mr-1"
 													onClick={() => this.getCsvData()}
@@ -543,7 +517,7 @@ class Product extends React.Component {
 														target="_blank"
 													/>
 												)} */}
-												{/* <Button
+                          {/* <Button
 													color="primary"
 													className="btn-square mr-1"
 													onClick={this.bulkDelete}
@@ -552,144 +526,133 @@ class Product extends React.Component {
 													<i className="fa glyphicon glyphicon-trash fa-trash mr-1" />
 													Bulk Delete
 												</Button> */}
-											</ButtonGroup>
-											<Button
-											color="primary"
-											className="btn-square pull-right"
-											style={{ marginBottom: '10px' }}
-											onClick={() =>
-												this.props.history.push(`/admin/master/product/create`)
-											}
-										>
-											<i className="fas fa-plus mr-1" />
-											{strings.AddnewProduct}
-										</Button>
-										
-										</div>
-										
-										
-										
-										<div>
-											<BootstrapTable
-												selectRow={this.selectRowProp}
-												search={false}
-												options={this.options}
-												data={
-													product_list && product_list.data
-														? product_list.data
-														: []
-												}
-												version="4"
-												hover
-												pagination={
-													product_list &&
-													product_list.data &&
-													product_list.data.length > 0
-														? true
-														: false
-												}
-												remote
-												fetchInfo={{
-													dataTotalSize: product_list.count
-														? product_list.count
-														: 0,
-												}}
-												className="product-table"
-												trClassName="cursor-pointer"
-												csvFileName="product_list.csv"
-												ref={(node) => (this.table = node)}
-											>
-												<TableHeaderColumn 
-													width="10%"
-													dataField="productCode" 
-													dataSort className="table-header-bg">
-													{strings.PRODUCTCODE}
-												</TableHeaderColumn>
-												<TableHeaderColumn 
-													tdStyle={{ whiteSpace: 'normal' }}
-													width="15%"
-													isKey dataField="name" 
-													dataSort className="table-header-bg">
-													{strings.PRODUCTNAME}
-												</TableHeaderColumn >
-												<TableHeaderColumn
-													tdStyle={{ whiteSpace: 'normal' }}
-													width="10%"
-                                                    className="table-header-bg"
-                                                    dataField="productType"
-                                                    dataSort
-                                                    dataFormat={this.renderType}
-                                                    >
-                                                    {strings.ProductType}
+                        </ButtonGroup>
+                        <Button
+                          color="primary"
+                          className="btn-square pull-right"
+                          style={{ marginBottom: '10px' }}
+                          onClick={() => this.props.history.push(`/admin/master/product/create`)}
+                        >
+                          <i className="fas fa-plus mr-1" />
+                          {strings.AddnewProduct}
+                        </Button>
+                      </div>
 
-                          						</TableHeaderColumn>
-												<TableHeaderColumn
-													width="10%"
-													dataAlign="center"
-                                                    className="table-header-bg"
-                                                    dataField="isInventoryEnabled"
-                                                    dataSort
-                                                    dataFormat={this.renderInventory}
-                                                    >
-                                                        {strings.Inventory}
-
-                          						</TableHeaderColumn>
-												  <TableHeaderColumn
-													width="8%"
-													dataAlign="right"
-													dataField="unitPrice"
-													dataSort
-													dataFormat={this.unitPrice}
-													formatExtraData={universal_currency_list}
-													className="table-header-bg"
-												>
-													 {strings.UNITPRICE}
-												</TableHeaderColumn>
-												{/* <TableHeaderColumn dataField="description" dataSort> 
+                      <div>
+                        <BootstrapTable
+                          selectRow={this.selectRowProp}
+                          search={false}
+                          options={this.options}
+                          data={product_list && product_list.data ? product_list.data : []}
+                          version="4"
+                          hover
+                          pagination={
+                            product_list && product_list.data && product_list.data.length > 0
+                              ? true
+                              : false
+                          }
+                          remote
+                          fetchInfo={{
+                            dataTotalSize: product_list.count ? product_list.count : 0,
+                          }}
+                          className="product-table"
+                          trClassName="cursor-pointer"
+                          csvFileName="product_list.csv"
+                          ref={node => (this.table = node)}
+                        >
+                          <TableHeaderColumn
+                            width="10%"
+                            dataField="productCode"
+                            dataSort
+                            className="table-header-bg"
+                          >
+                            {strings.PRODUCTCODE}
+                          </TableHeaderColumn>
+                          <TableHeaderColumn
+                            tdStyle={{ whiteSpace: 'normal' }}
+                            width="15%"
+                            isKey
+                            dataField="name"
+                            dataSort
+                            className="table-header-bg"
+                          >
+                            {strings.PRODUCTNAME}
+                          </TableHeaderColumn>
+                          <TableHeaderColumn
+                            tdStyle={{ whiteSpace: 'normal' }}
+                            width="10%"
+                            className="table-header-bg"
+                            dataField="productType"
+                            dataSort
+                            dataFormat={this.renderType}
+                          >
+                            {strings.ProductType}
+                          </TableHeaderColumn>
+                          <TableHeaderColumn
+                            width="10%"
+                            dataAlign="center"
+                            className="table-header-bg"
+                            dataField="isInventoryEnabled"
+                            dataSort
+                            dataFormat={this.renderInventory}
+                          >
+                            {strings.Inventory}
+                          </TableHeaderColumn>
+                          <TableHeaderColumn
+                            width="8%"
+                            dataAlign="right"
+                            dataField="unitPrice"
+                            dataSort
+                            dataFormat={this.unitPrice}
+                            formatExtraData={universal_currency_list}
+                            className="table-header-bg"
+                          >
+                            {strings.UNITPRICE}
+                          </TableHeaderColumn>
+                          {/* <TableHeaderColumn dataField="description" dataSort> 
 													Description
 												</TableHeaderColumn>  */}
-												<TableHeaderColumn
-												tdStyle={{ whiteSpace: 'normal' }}
-													width="18%"
-													// dataAlign="right"
-													dataField="vatPercentage"
-													dataSort
-													// dataFormat={this.vatCategoryFormatter}
-													className="table-header-bg"
-												>
-													 {strings.VAT+" "+strings.Type}
-												</TableHeaderColumn>
-												<TableHeaderColumn
-													dataAlign="center"
-													dataField="exciseTax"
-													dataSort
-												    dataFormat={this.exciseSlabFormatter}
-													className="table-header-bg"
-												>
-													 Excise Slab
-												</TableHeaderColumn>
-												
-												<TableHeaderColumn
-													// width="10%"
-													dataAlign="center"
-                                                    className="table-header-bg"
-                                                    dataField="isActive"
-                                                    dataSort
-                                                    dataFormat={this.renderStatus}
-                                                    >
-                                                        {strings.Status}
+                          <TableHeaderColumn
+                            tdStyle={{ whiteSpace: 'normal' }}
+                            width="18%"
+                            // dataAlign="right"
+                            dataField="vatPercentage"
+                            dataSort
+                            // dataFormat={this.vatCategoryFormatter}
+                            className="table-header-bg"
+                          >
+                            {strings.VAT + ' ' + strings.Type}
+                          </TableHeaderColumn>
+                          <TableHeaderColumn
+                            dataAlign="center"
+                            dataField="exciseTax"
+                            dataSort
+                            dataFormat={this.exciseSlabFormatter}
+                            className="table-header-bg"
+                          >
+                            Excise Slab
+                          </TableHeaderColumn>
 
-                          						</TableHeaderColumn>  
-												<TableHeaderColumn
-											className="text-right table-header-bg"
-											columnClassName="text-right"
-											width="5%"
-											// dataFormat={this.renderActions}
-										></TableHeaderColumn>
-											</BootstrapTable>
-										</div>
+                          <TableHeaderColumn
+                            // width="10%"
+                            dataAlign="center"
+                            className="table-header-bg"
+                            dataField="isActive"
+                            dataSort
+                            dataFormat={this.renderStatus}
+                          >
+                            {strings.Status}
+                          </TableHeaderColumn>
+                          <TableHeaderColumn
+                            className="text-right table-header-bg"
+                            columnClassName="text-right"
+                            width="5%"
+                            // dataFormat={this.renderActions}
+                          ></TableHeaderColumn>
+                        </BootstrapTable>
+                      </div>
 
-										{/* <div className="ag-theme-alpine mb-3 col-lg-12" style={{ height: 590 }}>
+                      {/* <div className="ag-theme-alpine mb-3 col-lg-12" style={{ height: 590 }}>
 			<AgGridReact
 				rowData={product_list && product_list.data
 					? product_list.data
@@ -824,7 +787,7 @@ class Product extends React.Component {
 										}
 									></AgGridColumn>
 			</AgGridReact>   */}
-			{/* <div className="example-header mt-1">
+                      {/* <div className="example-header mt-1">
 					{strings.page_size}
 					<select onChange={() => this.onPageSizeChanged()} id="page-size">
 					<option value="10" selected={true}>10</option>
@@ -833,17 +796,17 @@ class Product extends React.Component {
 					<option value="1000">1000</option>
 					</select>
 				</div>   																	 */}
-		{/* </div>	 */}
-									</Col>
-								</Row>
-							)}
-						</CardBody>
-					</Card>
-				</div>
-			</div>
-			</div>
-		);
-	}
+                      {/* </div>	 */}
+                    </Col>
+                  </Row>
+                )}
+              </CardBody>
+            </Card>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Product);


### PR DESCRIPTION
## Summary
- Updates components consuming `createAsyncThunk` actions to properly handle Redux Toolkit action objects
- Fixes incorrect pattern where thunk responses were treated as direct API responses

## Problem
Components were using the legacy pattern:
```javascript
.then((res) => {
  if (res.status === 200) {
    this.setState({ data: res.data });
  }
});
```

When `createAsyncThunk` actually returns action objects, not axios responses.

## Solution
Updated to the correct Redux Toolkit pattern:
```javascript
.then((action) => {
  if (action && action.type && action.type.includes('fulfilled')) {
    this.setState({ data: action.payload });
  }
});
```

## Files Changed (11 files)
| File | Function Fixed |
|------|----------------|
| `bank_account/screens/create/screen.js` | `getCurrencyConversionList` |
| `bank_account/screens/transactions/screen.js` | `getCompanyDetails` |
| `bank_account/screens/transactions/screens/create/screen.js` | `getCompanyDetails`, `getCurrencyConversionList` |
| `creditNotes/screens/create/screen.js` | `getCurrencyConversionList` |
| `debitNotes/screens/detail/screen.js` | `getCustomerList` |
| `debitNotes/screens/view/screen.js` | `getCompanyDetails` |
| `expense/screens/create/screen.js` | `getCurrencyConversionList` |
| `journal/screens/create/screen.js` | `getCompanyDetails` |
| `journal/screens/detail/screen.js` | `getCompanyDetails` |
| `opening_balance/screens/create/screen.js` | `getCompanyDetails` |
| `product/screen.js` | `getProductList` |

## Test plan
- [x] All existing tests pass (137 suites, 2304 tests)
- [ ] Manual testing of affected screens

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)