### PR TITLE
fix(devcontainer): add workspace mount to docker-compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "SimpleAccounts-UAE",
   "dockerComposeFile": "docker-compose.yml",
   "service": "devcontainer",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/workspaces/SimpleAccounts-UAE",
 
   // Docker CLI, GitHub CLI, and Git are pre-installed in the image
   // No features needed - everything is baked into the Dockerfile for faster startup

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     #   context: ..
     #   dockerfile: .devcontainer/Dockerfile
     volumes:
+      - ../:/workspaces/SimpleAccounts-UAE:cached
       - devcontainer-vscode-extensions:/home/vscode/.vscode-server/extensions
       - devcontainer-maven-cache:/home/vscode/.m2
       - devcontainer-npm-cache:/home/vscode/.npm


### PR DESCRIPTION
## Summary

Fixes the DevPod startup error: `lstat /workspaces/content: no such file or directory`

## Changes

- Add explicit workspace mount `../:/workspaces/SimpleAccounts-UAE:cached` in docker-compose.yml
- Use fixed workspace path `/workspaces/SimpleAccounts-UAE` instead of variable

## Root Cause

The previous PR removed the workspace mount from docker-compose.yml, expecting DevPod to inject it automatically. However, DevPod was not properly mounting the workspace, causing the container to fail when trying to access `/workspaces/content`.

## Test plan

- [ ] Run `devpod up https://github.com/SimpleAccounts/SimpleAccounts-UAE --provider ssh --ide cursor`
- [ ] Verify container starts successfully
- [ ] Verify code is accessible in `/workspaces/SimpleAccounts-UAE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)