### PR TITLE
fix(devcontainer): add npm install fallback in post-create script

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,12 +7,12 @@ echo "🚀 Setting up SimpleAccounts-UAE development environment..."
 
 # Install root dependencies
 echo "📦 Installing root npm dependencies..."
-npm ci --prefer-offline
+npm ci --prefer-offline || npm install
 
 # Install frontend dependencies
 echo "📦 Installing frontend dependencies..."
 cd apps/frontend
-npm ci --legacy-peer-deps --prefer-offline
+npm ci --legacy-peer-deps --prefer-offline || npm install --legacy-peer-deps
 cd ../..
 
 # Install Playwright browsers (using system Chromium)


### PR DESCRIPTION
## Summary

Fixes devpod setup failures when `package-lock.json` is out of sync with `package.json`.

## Problem

The `post-create.sh` script uses `npm ci` which requires lockfiles to be in sync. When they're not (e.g., missing `typescript@5.9.3`), the devcontainer setup fails:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: typescript@5.9.3 from lock file
```

## Solution

Add fallback from `npm ci` to `npm install` when lockfiles are out of sync, matching the same resilience pattern already used in the Dockerfile.

## Test plan

- [ ] Test devpod setup: `devpod up https://github.com/SimpleAccounts/SimpleAccounts-UAE --provider ssh --ide cursor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)