### PR TITLE
fix(devcontainer): resolve maven wrapper and npm sync errors

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -27,7 +27,13 @@ cd apps/backend
 if [ -f "./mvnw" ]; then
     chmod +x ./mvnw
     # Create Maven wrapper distribution directory (older wrapper versions don't create it)
-    mkdir -p ~/.m2/wrapper/dists
+    # Use vscode user's home explicitly since script may run as root
+    MAVEN_USER_HOME="${MAVEN_USER_HOME:-/home/vscode}"
+    mkdir -p "$MAVEN_USER_HOME/.m2/wrapper/dists" 2>/dev/null || mkdir -p ~/.m2/wrapper/dists 2>/dev/null || true
+    # Ensure vscode owns the directory if we created it as root
+    if [ "$(id -u)" = "0" ] && [ -d "$MAVEN_USER_HOME/.m2" ]; then
+        chown -R vscode:vscode "$MAVEN_USER_HOME/.m2" 2>/dev/null || true
+    fi
     ./mvnw dependency:go-offline -B -q || true
 else
     mvn dependency:go-offline -B -q || true


### PR DESCRIPTION
## Summary

- Fix Maven wrapper `FileNotFoundException` by creating `~/.m2/wrapper/dists` directory before running mvnw
- Handle root user permissions when script runs via devpod (explicitly use `/home/vscode` and set ownership)
- Sync `package-lock.json` with `package.json` to resolve missing `typescript@5.9.3` error
- Add `install-cli-tools.sh` script for CLI tools installation and updates
- Update `post-start.sh` to run CLI tools update in background
- Add `application-local.properties` to `.gitignore`

## Test plan

- [ ] Run `devpod up "https://github.com/SimpleAccounts/SimpleAccounts-UAE@fix/devcontainer-maven-wrapper" --provider ssh --ide cursor`
- [ ] Verify no `FileNotFoundException` or permission errors
- [ ] Verify setup completes with "Development environment setup complete!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)