### PR TITLE
fix(backend): upgrade maven wrapper to apache 3.3.2

### DIFF
--- a/apps/backend/.mvn/wrapper/maven-wrapper.properties
+++ b/apps/backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
 


### PR DESCRIPTION
## Summary

Upgrade Maven Wrapper from old Takari version (0.5.6) to modern Apache Maven Wrapper (3.3.2).

**Problem**: Old Takari wrapper throws `FileNotFoundException` because it doesn't create parent directories:
```
java.io.FileNotFoundException: /home/vscode/.m2/wrapper/dists/apache-maven-3.9.9-bin/.../apache-maven-3.9.9-bin.zip.part (No such file or directory)
```

**Solution**: Apache Maven Wrapper 3.3.2 properly handles directory creation.

## Changes

- Updated `wrapperUrl` in `maven-wrapper.properties` from Takari 0.5.6 to Apache 3.3.2
- Removed old `maven-wrapper.jar` (will auto-download new version)

## Test plan

- [x] Tested locally - `./mvnw --version` works without errors
- [ ] Test in devcontainer: `devpod up "https://github.com/SimpleAccounts/SimpleAccounts-UAE@fix/maven-wrapper-upgrade" --provider ssh --ide cursor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)