### PR TITLE
fix(devcontainer): auto-detect cursor ipc socket

### DIFF
--- a/.devcontainer/cursor-cli.sh
+++ b/.devcontainer/cursor-cli.sh
@@ -14,4 +14,14 @@ if [ -z "${cursor_bin}" ]; then
   exit 1
 fi
 
+if [ -z "${VSCODE_IPC_HOOK_CLI:-}" ] && [ -z "${VSCODE_CLIENT_COMMAND:-}" ]; then
+  term_pid="$(ps -eo pid,command | awk '/shellIntegration-/{print $1; exit}')"
+  if [ -n "${term_pid}" ] && [ -r "/proc/${term_pid}/environ" ]; then
+    ipc_path="$(tr '\0' '\n' < "/proc/${term_pid}/environ" | sed -n 's/^VSCODE_IPC_HOOK_CLI=//p' | head -n 1)"
+    if [ -n "${ipc_path}" ]; then
+      export VSCODE_IPC_HOOK_CLI="${ipc_path}"
+    fi
+  fi
+fi
+
 exec "${cursor_bin}" "$@"


### PR DESCRIPTION
## Summary
- auto-detect Cursor IPC socket from a running Cursor/VS Code terminal when missing
- allow cursor/cursor-agent to run in non-integrated shells (e.g., docker exec)

## Testing
- not run (devcontainer script change only)
