### PR TITLE
feat: add wildcard ssl certificate with cloudflare dns challenge

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -70,40 +70,24 @@ services:
     labels:
       - 'traefik.enable=true'
       - 'traefik.docker.network=dev-proxy-network'
-      # ============= HTTPS redirect middleware (for nip.io domains only) =============
-      - 'traefik.http.middlewares.${USER:-devuser}-https-redirect.redirectscheme.scheme=https'
-      - 'traefik.http.middlewares.${USER:-devuser}-https-redirect.redirectscheme.permanent=true'
       # ============= Frontend routing (port 3000) =============
-      # HTTP router (redirects to HTTPS)
-      - 'traefik.http.routers.${USER:-devuser}-frontend-http.rule=HostRegexp(`${USER:-devuser}.{ip:[0-9-]+}.nip.io`)'
-      - 'traefik.http.routers.${USER:-devuser}-frontend-http.entrypoints=web'
-      - 'traefik.http.routers.${USER:-devuser}-frontend-http.middlewares=${USER:-devuser}-https-redirect'
-      # HTTPS router with Let's Encrypt
-      - 'traefik.http.routers.${USER:-devuser}-frontend.rule=HostRegexp(`${USER:-devuser}.{ip:[0-9-]+}.nip.io`)'
+      - 'traefik.http.routers.${USER:-devuser}-frontend.rule=Host(`${USER:-devuser}.dev.simpleaccounts.io`)'
       - 'traefik.http.routers.${USER:-devuser}-frontend.entrypoints=websecure'
       - 'traefik.http.routers.${USER:-devuser}-frontend.tls=true'
       - 'traefik.http.routers.${USER:-devuser}-frontend.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.${USER:-devuser}-frontend.tls.domains[0].main=dev.simpleaccounts.io'
+      - 'traefik.http.routers.${USER:-devuser}-frontend.tls.domains[0].sans=*.dev.simpleaccounts.io'
       - 'traefik.http.routers.${USER:-devuser}-frontend.service=${USER:-devuser}-frontend'
       - 'traefik.http.services.${USER:-devuser}-frontend.loadbalancer.server.port=3000'
       # ============= Backend API routing (port 8080) =============
-      # HTTP router (redirects to HTTPS)
-      - 'traefik.http.routers.${USER:-devuser}-api-http.rule=HostRegexp(`${USER:-devuser}-api.{ip:[0-9-]+}.nip.io`)'
-      - 'traefik.http.routers.${USER:-devuser}-api-http.entrypoints=web'
-      - 'traefik.http.routers.${USER:-devuser}-api-http.middlewares=${USER:-devuser}-https-redirect'
-      # HTTPS router with Let's Encrypt
-      - 'traefik.http.routers.${USER:-devuser}-api.rule=HostRegexp(`${USER:-devuser}-api.{ip:[0-9-]+}.nip.io`)'
+      - 'traefik.http.routers.${USER:-devuser}-api.rule=Host(`${USER:-devuser}-api.dev.simpleaccounts.io`)'
       - 'traefik.http.routers.${USER:-devuser}-api.entrypoints=websecure'
       - 'traefik.http.routers.${USER:-devuser}-api.tls=true'
       - 'traefik.http.routers.${USER:-devuser}-api.tls.certresolver=letsencrypt'
       - 'traefik.http.routers.${USER:-devuser}-api.service=${USER:-devuser}-api'
       - 'traefik.http.services.${USER:-devuser}-api.loadbalancer.server.port=8080'
       # ============= Code-server / Web IDE routing (port 8443) =============
-      # HTTP router (redirects to HTTPS)
-      - 'traefik.http.routers.${USER:-devuser}-ide-http.rule=HostRegexp(`${USER:-devuser}-ide.{ip:[0-9-]+}.nip.io`)'
-      - 'traefik.http.routers.${USER:-devuser}-ide-http.entrypoints=web'
-      - 'traefik.http.routers.${USER:-devuser}-ide-http.middlewares=${USER:-devuser}-https-redirect'
-      # HTTPS router with Let's Encrypt
-      - 'traefik.http.routers.${USER:-devuser}-ide.rule=HostRegexp(`${USER:-devuser}-ide.{ip:[0-9-]+}.nip.io`)'
+      - 'traefik.http.routers.${USER:-devuser}-ide.rule=Host(`${USER:-devuser}-ide.dev.simpleaccounts.io`)'
       - 'traefik.http.routers.${USER:-devuser}-ide.entrypoints=websecure'
       - 'traefik.http.routers.${USER:-devuser}-ide.tls=true'
       - 'traefik.http.routers.${USER:-devuser}-ide.tls.certresolver=letsencrypt'

--- a/.devcontainer/proxy/docker-compose.proxy.yml
+++ b/.devcontainer/proxy/docker-compose.proxy.yml
@@ -29,6 +29,7 @@ services:
     restart: unless-stopped
     environment:
       - DOCKER_API_VERSION=1.44
+      - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
     command:
       # API and Dashboard
       - '--api.dashboard=true'
@@ -40,11 +41,13 @@ services:
       # Entrypoints
       - '--entrypoints.web.address=:80'
       - '--entrypoints.websecure.address=:443'
-      # NOTE: No blanket HTTP→HTTPS redirect here to preserve local domain HTTP access
-      # HTTPS redirect is handled per-router via middleware for nip.io domains only
-      # Let's Encrypt Certificate Resolver
-      - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true'
-      - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web'
+      # HTTP to HTTPS redirect for dev.simpleaccounts.io
+      - '--entrypoints.web.http.redirections.entryPoint.to=websecure'
+      - '--entrypoints.web.http.redirections.entryPoint.scheme=https'
+      # Let's Encrypt Certificate Resolver with Cloudflare DNS challenge
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge=true'
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=cloudflare'
+      - '--certificatesresolvers.letsencrypt.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53'
       - '--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@simpleaccounts.io}'
       - '--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json'
       # Logs

--- a/.devcontainer/proxy/docker-compose.proxy.yml
+++ b/.devcontainer/proxy/docker-compose.proxy.yml
@@ -41,9 +41,8 @@ services:
       # Entrypoints
       - '--entrypoints.web.address=:80'
       - '--entrypoints.websecure.address=:443'
-      # HTTP to HTTPS redirect for dev.simpleaccounts.io
-      - '--entrypoints.web.http.redirections.entryPoint.to=websecure'
-      - '--entrypoints.web.http.redirections.entryPoint.scheme=https'
+      # NOTE: No global HTTP→HTTPS redirect - local domains use HTTP only
+      # HTTPS is enforced by routers using websecure entrypoint
       # Let's Encrypt Certificate Resolver with Cloudflare DNS challenge
       - '--certificatesresolvers.letsencrypt.acme.dnschallenge=true'
       - '--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=cloudflare'

--- a/apps/frontend/vite.config.js
+++ b/apps/frontend/vite.config.js
@@ -113,7 +113,7 @@ export default defineConfig({
     host: true, // Listen on all interfaces (0.0.0.0 and ::)
     open: false, // Don't auto-open browser
     strictPort: false, // Allow fallback to next available port if 3000 is taken
-    allowedHosts: ['localhost', '.nip.io', '.dev.simpleaccounts.local'], // Restrict to known hosts for security
+    allowedHosts: ['localhost', '.nip.io', '.dev.simpleaccounts.local', '.dev.simpleaccounts.io'], // Restrict to known hosts for security
     // Reduce memory usage in dev
     fs: {
       // Limit file system access


### PR DESCRIPTION
## Summary
- Switch from nip.io to dev.simpleaccounts.io domain for dev environments
- Configure Cloudflare DNS challenge for Let's Encrypt wildcard certificate
- Simplify Traefik labels (remove redundant HTTP routers)
- Add dev.simpleaccounts.io to vite allowedHosts

## New HTTPS URLs
| Service | URL |
|---------|-----|
| Frontend | https://<user>.dev.simpleaccounts.io |
| Backend | https://<user>-api.dev.simpleaccounts.io |
| IDE | https://<user>-ide.dev.simpleaccounts.io |

## Setup Required
1. Add Cloudflare API token to `.devcontainer/proxy/.env`:
   ```
   CF_DNS_API_TOKEN=<your-token>
   ```
2. Add wildcard DNS record in Cloudflare:
   ```
   *.dev.simpleaccounts.io → <server-ip>
   ```

## Test plan
- [x] Verified wildcard certificate issued by Let's Encrypt
- [x] Tested all three URLs with valid SSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)