### PR TITLE
fix: coder cli installation in deployment workflow

### DIFF
--- a/.github/workflows/coder-template-push.yml
+++ b/.github/workflows/coder-template-push.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Install Coder CLI
         run: |
           curl -fsSL https://coder.com/install.sh | sh
-          sudo mv ./coder /usr/local/bin/coder
           coder version
 
       - name: Login to Coder


### PR DESCRIPTION
## Problem

The Coder template deployment workflow was failing because it tried to move a non-existent `./coder` binary after installation.

## Root Cause

The `install.sh` script installs the deb package which automatically places the `coder` binary in `/usr/bin/coder`. There is no `./coder` file to move.

## Solution

Removed the unnecessary `sudo mv ./coder /usr/local/bin/coder` command since the deb package handles installation automatically.

## Testing

- The workflow will now successfully install Coder CLI
- Template deployment will complete successfully after merge

## Related

- Fixes the failed deployment: https://github.com/SimpleAccounts/SimpleAccounts-UAE/actions/runs/20624556171