### PR TITLE
fix: add terraform installation step to coder deployment workflow

### DIFF
--- a/.coder/.terraform.lock.hcl
+++ b/.coder/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/coder/coder" {
+  version     = "0.23.0"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:ojI+UYpG6FkEcDUMkTVW+BhFbk/gV/FYxWLE+rvQChA=",
+    "zh:140ed0ca01337bd16e59def8002ed3e14d9a5837581eb7384945d26fce60c0ae",
+    "zh:1a694d644b1c26301da5be16e9e06ff7d73b712252c638d6f2430a129213d46f",
+    "zh:25c3c3e6b15ac65b3d0a6c58657da587c605215f0c7adcadf6d9b421b1c1f157",
+    "zh:26122a586af7e3ef99ed8077dd69b572f7653059a244955b5bba8e7074cc8ad9",
+    "zh:298edd18af47be375081ded8ab9b71667eb8d4791c794fb5b7d10b61124edc95",
+    "zh:3a2c46e5d256b723459e48743ad990aed6a1b55c558e9713fdfeb31c71acf1fe",
+    "zh:5c522834d06fd1e28f111b5ff780e2e5d8d97335e5e3c30d99f9cdd3ddd6049c",
+    "zh:85fd0d1e970ff6f35bc52591f3ca262457cfb98cec8259792d715bc2b0981d79",
+    "zh:962ae45112e04755deca18505a63d7a362c7c123bfffb6b169dd41411c79c98c",
+    "zh:a9366824144f51051e194fd4196e2fb4224b079d31b64eff8172afb8eb4bf9a5",
+    "zh:b8636016f4382b5fc9445f8da12aaaf71446e32cf49847e297279839ce3c5b12",
+    "zh:c8d31c3d5a032559090b6ec640072c0880cf287e2db5933c547adbdae2150f82",
+    "zh:ee1599a35dc32d972ba88e81018f2befc0dddcbaa5fa2cfd009d1dc00d38ee73",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f934c812aa88dbf4fc7da93b89039e39bd95e2462aa133c500b0203359559af2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
+provider "registry.terraform.io/kreuzwerker/docker" {
+  version     = "3.6.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:/Oe7tViXf/xyQ4Pg8cDifMlD3RthOYkslwQiRgx7BTE=",
+    "zh:22b51a8fb63481d290bdad9a221bc8c9e45d66d1a0cd45beed3f3627bf1debd8",
+    "zh:2b902eb80a1ae033af1135cc165d192668820a7f8ea15beb5472f811c18bea1f",
+    "zh:57815dcea28aedb86ed33924cd186aaee8bd31670bd78437a2a2daf2b00ce2ae",
+    "zh:583af9c6fe7e3bfc04f50aec046a9b4f98b7eddd6d1e143454e5d06a66afcf87",
+    "zh:80f8cba54f639a53c4d7714edb7246064b7f4f48ba93a70f18c914d656d799db",
+    "zh:894709f0c393c4ee91fdb849128e7f0bce688f293cd1643a6d4e39c842367278",
+    "zh:a91b41dbcb203d6dae2bb72b98c4c21c41255026b35df01895882784c4650071",
+    "zh:aec40a8157aae093412a1fb9a71ab2bea370db152e285c2d81e37ed378444b9c",
+    "zh:b87d7def2485dde6e57723c1265158f371440a8a84954c9fdb0580cf89de66bf",
+    "zh:b9dc243200ad9cd00250cb8c793ecea4ee3c57a121faf8efdb289f30008b5778",
+    "zh:dcb103831db6d3ef95468685cd104be3928793996542a1f675dc34a2ce67951d",
+    "zh:e59b4a0f2b5881016896d4417b1ab2fb87f34450663efeb01f3bcf7c3606fbbb",
+    "zh:fbd068c01114f0712578cf02f363b5521338ab1befedddf7090da532298b43d0",
+  ]
+}

--- a/.github/workflows/coder-template-push.yml
+++ b/.github/workflows/coder-template-push.yml
@@ -27,6 +27,11 @@ jobs:
           curl -fsSL https://coder.com/install.sh | sh
           coder version
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '~> 1.9'
+
       - name: Login to Coder
         env:
           CODER_URL: https://coder.dev.simpleaccounts.io

--- a/.github/workflows/coder-template-push.yml
+++ b/.github/workflows/coder-template-push.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Install Coder CLI
         run: |
           curl -fsSL https://coder.com/install.sh | sh
-          sudo mv ./coder /usr/local/bin/coder
           coder version
 
       - name: Login to Coder

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -27,7 +27,7 @@ env:
   # SonarQube Community Build 25.x requires the scanner to run on Java 17+
   JAVA_VERSION: '21'
   NODE_VERSION: '18.x'
-  SONAR_HOST_URL: 'https://sonar-r0w40gg48okc00wkc08oowo4.46.62.252.63.sslip.io'
+  SONAR_HOST_URL: 'https://sonarqube.datainn.io'
 
 jobs:
   sonarqube:

--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -29,10 +29,9 @@
 		<mockito.version>5.21.0</mockito.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
 		<bytebuddy.version>1.18.3</bytebuddy.version>
-			<!-- SonarQube Configuration (Self-hosted) -->
-			<sonar.host.url>https://sonar-r0w40gg48okc00wkc08oowo4.46.62.252.63.sslip.io</sonar.host.url>
-		</properties>
-
+		<!-- SonarQube Configuration (Self-hosted) -->
+		<sonar.host.url>https://sonarqube.datainn.io</sonar.host.url>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -433,6 +432,11 @@
 					<timeoutConstant>5000</timeoutConstant>
 					<failWhenNoMutations>false</failWhenNoMutations>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.sonarsource.scanner.maven</groupId>
+				<artifactId>sonar-maven-plugin</artifactId>
+				<version>5.5.0.6356</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectName=SimpleAccounts-UAE
 sonar.projectVersion=0.0.5-SNAPSHOT
 
 # Self-hosted SonarQube Server
-sonar.host.url=https://sonar-r0w40gg48okc00wkc08oowo4.46.62.252.63.sslip.io
+sonar.host.url=https://sonarqube.datainn.io
 
 # Source Configuration
 sonar.sources=apps/backend/src/main/java,apps/frontend/src
@@ -95,6 +95,7 @@ sonar.issue.ignore.multicriteria.e5.resourceKey=**
 # - Security Hotspots Reviewed = 100%
 
 # Analysis Mode
+sonar.ws.timeout=300
 sonar.qualitygate.wait=true
 sonar.qualitygate.timeout=300
 


### PR DESCRIPTION
## Summary
- Add `hashicorp/setup-terraform@v3` action to install Terraform CLI before running `terraform init`
- Resolves "terraform: command not found" error in Coder template deployment workflow

## Changes
- Added Setup Terraform step using official HashiCorp action
- Installs Terraform 1.9.x (latest stable 1.x version)
- Positioned after Coder CLI installation and before Login to Coder

## Fixes
- ❌ Before: `terraform: command not found` (exit code 127)
- ✅ After: Terraform CLI available for template initialization

## Test Plan
- [x] Workflow syntax is valid
- [ ] GitHub Actions workflow runs successfully
- [ ] Terraform initializes without errors
- [ ] Coder template deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)