### PR TITLE
fix: devcontainer network configuration and env file setup

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,7 +25,8 @@ services:
     #   context: ..
     #   dockerfile: .devcontainer/Dockerfile
     env_file:
-      - .env
+      - path: .env
+        required: false
     volumes:
       - ../:/workspaces/SimpleAccounts-UAE:cached
       # Cache volumes (can be rebuilt, use Docker named volumes)

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -126,6 +126,13 @@ npm run prepare 2>/dev/null || true
 # ============================================
 # Create local environment files
 # ============================================
+# Create .devcontainer/.env if it doesn't exist
+if [ ! -f ".devcontainer/.env" ]; then
+    echo "📝 Creating .devcontainer/.env from example..."
+    cp .devcontainer/.env.example .devcontainer/.env
+    echo "  ✅ Created .devcontainer/.env"
+fi
+
 if [ ! -f "apps/frontend/.env.local" ]; then
     echo "📝 Creating frontend .env.local..."
     cat > apps/frontend/.env.local << 'EOF'

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -7,7 +7,7 @@ echo "🔄 Starting SimpleAccounts-UAE development environment..."
 echo "⏳ Waiting for PostgreSQL..."
 TIMEOUT=60
 ELAPSED=0
-until pg_isready -h db -p 5432 -U simpleaccounts -q; do
+until pg_isready -h localhost -p 5432 -U simpleaccounts -q; do
     sleep 1
     ELAPSED=$((ELAPSED + 1))
     if [ $ELAPSED -ge $TIMEOUT ]; then
@@ -22,7 +22,7 @@ fi
 # Wait for Redis to be ready (with timeout)
 echo "⏳ Waiting for Redis..."
 ELAPSED=0
-until redis-cli -h redis ping > /dev/null 2>&1; do
+until redis-cli -h localhost ping > /dev/null 2>&1; do
     sleep 1
     ELAPSED=$((ELAPSED + 1))
     if [ $ELAPSED -ge $TIMEOUT ]; then
@@ -156,15 +156,15 @@ echo "🎉 Development environment is ready!"
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Database connection:"
-echo "  Host: db (internal network hostname)"
+echo "  Host: localhost (shared network namespace)"
 echo "  Port: 5432"
 echo "  User: simpleaccounts"
 echo "  Pass: simpleaccounts_dev"
 echo "  DB:   simpleaccounts"
-echo "  URL:  jdbc:postgresql://db:5432/simpleaccounts"
+echo "  URL:  jdbc:postgresql://localhost:5432/simpleaccounts"
 echo ""
 echo "Redis connection:"
-echo "  Host: redis (internal network hostname)"
+echo "  Host: localhost (shared network namespace)"
 echo "  Port: 6379"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ scripts/pre-pull-docker-images.sh
 apps/backend/.dockerignore
 apps/frontend/.dockerignore
 .coder/.terraform/
+
+# Auto Claude data directory
+.auto-claude/


### PR DESCRIPTION
## Summary
Fixes devcontainer startup failures with two critical issues:
1. **Network hostname mismatch** causing "exit status 127" errors
2. **Missing .env file** causing docker-compose config errors

## Root Causes

### Issue 1: Network Configuration Mismatch
The `post-start.sh` script was attempting to connect to PostgreSQL and Redis using service hostnames (`db`, `redis`), but the docker-compose.yml uses `network_mode: service:db` which means all containers share the same network namespace and must communicate via `localhost`.

### Issue 2: Missing Environment File
Docker Compose expects a `.env` file but it wasn't being created in new workspace environments, causing:
```
env file /workspaces/SimpleAccounts-UAE/.devcontainer/.env not found
```

## Changes

### 1. Network Hostname Fixes (.devcontainer/post-start.sh)
```diff
# PostgreSQL connection
-until pg_isready -h db -p 5432 -U simpleaccounts -q; do
+until pg_isready -h localhost -p 5432 -U simpleaccounts -q; do

# Redis connection  
-until redis-cli -h redis ping > /dev/null 2>&1; do
+until redis-cli -h localhost ping > /dev/null 2>&1; do

# Connection info messages
-echo "  Host: db (internal network hostname)"
+echo "  Host: localhost (shared network namespace)"
-echo "  URL:  jdbc:postgresql://db:5432/simpleaccounts"
+echo "  URL:  jdbc:postgresql://localhost:5432/simpleaccounts"
```

### 2. Environment File Setup
**docker-compose.yml**:
```diff
 env_file:
-  - .env
+  - path: .env
+    required: false
```

**post-create.sh**:
```bash
# Auto-create .env from example if missing
if [ ! -f ".devcontainer/.env" ]; then
    echo "📝 Creating .devcontainer/.env from example..."
    cp .devcontainer/.env.example .devcontainer/.env
fi
```

## Impact

✅ **Resolves**:
- "exit status 127" errors during devcontainer startup
- "env file not found" docker-compose errors
- PostgreSQL and Redis health check failures
- Devcontainer lifecycle script failures

✅ **Enables**:
- Automatic workspace environment setup
- Proper service connectivity via localhost
- Seamless devcontainer startup for both local and Coder environments

## Technical Details

**Network Architecture** (docker-compose.yml):
- `devcontainer`: `network_mode: service:db`
- `redis`: `network_mode: service:db`
- `db`: Primary container

All three services share:
- Same network namespace
- Same hostname: `simpleaccounts-dev`
- Same IP address and network interfaces
- Communication via `localhost` (not service names)

## Test Plan
- [x] Created .env file in workspace manually (verified working)
- [ ] Rebuild devcontainer from scratch
- [ ] Verify .env file auto-creates from example
- [ ] Confirm PostgreSQL connects via localhost
- [ ] Confirm Redis connects via localhost
- [ ] Validate post-create script completes
- [ ] Validate post-start script completes
- [ ] Test frontend and backend connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)