### PR TITLE
fix: standardize to vscode user across all configurations

### DIFF
--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -290,8 +290,8 @@ resource "docker_container" "workspace" {
     "MAVEN_OPTS=-Xmx2g -XX:+UseG1GC -XX:+UseStringDeduplication",
     "JAVA_TOOL_OPTIONS=-XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0",
     "NODE_OPTIONS=--max-old-space-size=2048",
-    "HISTFILE=/root/.bash_history_dir/bash_history",
-    "GIT_CONFIG_GLOBAL=/root/.gitconfig_dir/gitconfig"
+    "HISTFILE=/home/vscode/.bash_history_dir/bash_history",
+    "GIT_CONFIG_GLOBAL=/home/vscode/.gitconfig_dir/gitconfig"
   ]
 
   # Workspace directory (persistent Git repository)
@@ -303,64 +303,58 @@ resource "docker_container" "workspace" {
   # Cache volumes (rebuilds are OK)
   volumes {
     volume_name    = docker_volume.vscode_extensions.name
-    container_path = "/root/.vscode-server/extensions"
+    container_path = "/home/vscode/.vscode-server/extensions"
   }
 
   volumes {
     volume_name    = docker_volume.maven_cache.name
-    container_path = "/root/.m2"
+    container_path = "/home/vscode/.m2"
   }
 
   volumes {
     volume_name    = docker_volume.npm_cache.name
-    container_path = "/root/.npm"
+    container_path = "/home/vscode/.npm"
   }
 
   # User credentials (persistent across host)
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude"
-    container_path = "/root/.claude"
-  }
-
-  # Claude configuration file (must be pre-created as a file on host)
-  volumes {
-    host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude.json"
-    container_path = "/root/.claude.json"
+    container_path = "/home/vscode/.claude"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/gemini/.gemini"
-    container_path = "/root/.gemini"
+    container_path = "/home/vscode/.gemini"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/.config/gh"
-    container_path = "/root/.config/gh"
+    container_path = "/home/vscode/.config/gh"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/bash-history/.bash_history"
-    container_path = "/root/.bash_history_dir"
+    container_path = "/home/vscode/.bash_history_dir"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/gitconfig/.gitconfig"
-    container_path = "/root/.gitconfig_dir"
+    container_path = "/home/vscode/.gitconfig_dir"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/ssh/.ssh"
-    container_path = "/root/.ssh"
+    container_path = "/home/vscode/.ssh"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/docker/.docker"
-    container_path = "/root/.docker"
+    container_path = "/home/vscode/.docker"
   }
 
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/kube/.kube"
-    container_path = "/root/.kube"
+    container_path = "/home/vscode/.kube"
   }
 
   # Docker socket for Docker-in-Docker

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -156,9 +156,13 @@ USER vscode
 RUN mkdir -p ~/.m2/repository ~/.m2/wrapper/dists ~/.npm ~/.cache/ms-playwright \
     && chmod -R 755 ~/.m2 ~/.npm ~/.cache
 
-# Reset working directory
+# Reset working directory and user
 USER root
 WORKDIR /workspaces
+
+# Set default user to vscode (non-root)
+# This ensures container starts as vscode user even without devcontainer.json
+USER vscode
 
 # Default command
 CMD ["sleep", "infinity"]

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -52,6 +52,7 @@ jobs:
           cache: maven
 
       - name: Copy Maven settings
+        shell: bash
         run: |
           mkdir -p ~/.m2
           cp .devcontainer/maven-settings.xml ~/.m2/settings.xml


### PR DESCRIPTION
## Summary

Standardizes all devcontainer and Coder configurations to use the `vscode` non-root user instead of `root` for improved security and consistency.

## Changes

### 1. Dockerfile (.devcontainer/Dockerfile)
- Added final `USER vscode` directive before CMD
- Ensures container starts as vscode user by default, even without devcontainer.json
- Critical for Coder deployments which don't use devcontainer.json

### 2. Coder Template (.coder/template.tf)  
- Updated environment variables:
  - `HISTFILE`: `/root/...` → `/home/vscode/...`
  - `GIT_CONFIG_GLOBAL`: `/root/...` → `/home/vscode/...`
- Updated all 11 volume mounts to use `/home/vscode/` instead of `/root/`:
  - `.vscode-server/extensions`, `.m2`, `.npm` (caches)
  - `.claude`, `.gemini`, `.config/gh`, `.bash_history_dir`, `.gitconfig_dir`, `.ssh`, `.docker`, `.kube` (user credentials)
- Removed duplicate `.claude.json` file mount (now part of `.claude/` directory)

## Impact

### ✅ Benefits
- **Security**: Non-root principle across all deployment methods
- **Consistency**: Same user behavior in local Docker, VS Code devcontainers, and Coder workspaces
- **Simplicity**: No permission issues with mounted files
- **Portability**: Works identically across platforms

### 🔧 Fixes
- Resolves "EISDIR: illegal operation on a directory, open '/root/.claude.json'" error
- Eliminates permission conflicts between container user and mounted volumes
- Ensures consistent file ownership across development environments

## Testing

Verified across all deployment methods:
- ✅ Local Docker with docker-compose
- ✅ VS Code Dev Containers
- ✅ Coder workspace (tested in template)

## Alignment Matrix

| Configuration | User | Env Vars | Volume Mounts | Status |
|--------------|------|----------|---------------|--------|
| Dockerfile | vscode | N/A | N/A | ✅ Updated |
| devcontainer.json | vscode | /home/vscode/ | N/A | ✅ Already correct |
| docker-compose.yml | N/A | N/A | /home/vscode/ | ✅ Already correct |
| docker-compose.override.yml | N/A | /home/vscode/ | /home/vscode/ | ✅ Already correct |
| Coder template.tf | N/A | /home/vscode/ | /home/vscode/ | ✅ Updated |

## Migration Notes

### For Existing Coder Workspaces
Existing workspaces will need to be recreated to use the new paths:
1. Update template: `coder templates push simpleaccounts-uae`
2. Recreate workspace: `coder delete <workspace>` then `coder create <workspace>`

### For Local Development
Simply rebuild the devcontainer to apply changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)