### PR TITLE
fix: create host directories before mounting to devcontainer

### DIFF
--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -156,6 +156,12 @@ resource "coder_agent" "main" {
 
     echo "🚀 Starting SimpleAccounts-UAE workspace..."
 
+    # Fix ownership of workspace directory (needed when switching from root to vscode user)
+    echo "🔧 Fixing workspace permissions..."
+    if [ -d /workspaces/SimpleAccounts-UAE ]; then
+      sudo chown -R vscode:vscode /workspaces/SimpleAccounts-UAE 2>/dev/null || true
+    fi
+
     # Configure git to trust workspace directory (prevents dubious ownership warning)
     echo "🔧 Configuring git safe directory..."
     if [ -d /workspaces/SimpleAccounts-UAE ]; then

--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -156,10 +156,27 @@ resource "coder_agent" "main" {
 
     echo "🚀 Starting SimpleAccounts-UAE workspace..."
 
-    # Fix ownership of workspace directory (needed when switching from root to vscode user)
+    # Fix ownership of workspace and config directories (needed when switching from root to vscode user)
     echo "🔧 Fixing workspace permissions..."
     if [ -d /workspaces/SimpleAccounts-UAE ]; then
       sudo chown -R vscode:vscode /workspaces/SimpleAccounts-UAE 2>/dev/null || true
+    fi
+
+    # Fix ownership of bind-mounted config directories
+    for dir in /home/vscode/.claude /home/vscode/.gemini /home/vscode/.config/gh \
+               /home/vscode/.bash_history_dir /home/vscode/.gitconfig_dir \
+               /home/vscode/.ssh /home/vscode/.docker /home/vscode/.kube; do
+      if [ -d "$dir" ]; then
+        sudo chown -R vscode:vscode "$dir" 2>/dev/null || true
+      fi
+    done
+
+    # Ensure SSH directory has correct permissions if it exists
+    if [ -d /home/vscode/.ssh ]; then
+      sudo chmod 700 /home/vscode/.ssh 2>/dev/null || true
+      # Fix key permissions if any exist
+      find /home/vscode/.ssh -type f -name "id_*" ! -name "*.pub" -exec sudo chmod 600 {} \; 2>/dev/null || true
+      find /home/vscode/.ssh -type f -name "*.pub" -exec sudo chmod 644 {} \; 2>/dev/null || true
     fi
 
     # Configure git to trust workspace directory (prevents dubious ownership warning)

--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -45,6 +45,73 @@ provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
 
+# Create host directories for bind mounts before container starts
+resource "null_resource" "host_directories" {
+  # Re-run when workspace is rebuilt
+  triggers = {
+    workspace_id = data.coder_workspace.me.id
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      #!/bin/bash
+      set -e
+
+      # Create base directory structure
+      BASE_DIR="/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}"
+
+      # Create directories for config files
+      mkdir -p "$BASE_DIR/claude"
+      mkdir -p "$BASE_DIR/claude/.claude"  # Claude data directory
+      mkdir -p "$BASE_DIR/gemini/.gemini"  # Gemini data directory
+      mkdir -p "$BASE_DIR/.config/gh"
+      mkdir -p "$BASE_DIR/.ssh"
+      mkdir -p "$BASE_DIR/.docker"
+      mkdir -p "$BASE_DIR/.kube"
+      mkdir -p "$BASE_DIR/bash_history"
+      mkdir -p "$BASE_DIR/gitconfig"
+
+      # Create .claude.json if it doesn't exist
+      if [ ! -f "$BASE_DIR/claude/.claude.json" ]; then
+        echo '{}' > "$BASE_DIR/claude/.claude.json"
+        echo "✅ Created empty .claude.json file"
+      fi
+
+      # Create .gemini/config.json if it doesn't exist
+      if [ ! -f "$BASE_DIR/gemini/.gemini/config.json" ]; then
+        echo '{}' > "$BASE_DIR/gemini/.gemini/config.json"
+        echo "✅ Created empty gemini config.json file"
+      fi
+
+      # Create .bash_history if it doesn't exist
+      if [ ! -f "$BASE_DIR/bash_history/.bash_history" ]; then
+        touch "$BASE_DIR/bash_history/.bash_history"
+        echo "✅ Created .bash_history file"
+      fi
+
+      # Create .gitconfig if it doesn't exist
+      if [ ! -f "$BASE_DIR/gitconfig/.gitconfig" ]; then
+        cat > "$BASE_DIR/gitconfig/.gitconfig" << 'EOF'
+[user]
+	name = ${data.coder_workspace_owner.me.name}
+	email = ${data.coder_workspace_owner.me.email}
+[init]
+	defaultBranch = main
+[pull]
+	rebase = false
+EOF
+        echo "✅ Created .gitconfig file"
+      fi
+
+      # Ensure proper permissions (coder user should own these)
+      chown -R coder:coder "$BASE_DIR" 2>/dev/null || true
+
+      echo "✅ Host directories prepared for user: ${data.coder_workspace_owner.me.name}"
+    EOT
+    interpreter = ["bash", "-c"]
+  }
+}
+
 # Random password for PostgreSQL (generated once per workspace)
 resource "random_password" "postgres" {
   length  = 32
@@ -162,12 +229,12 @@ resource "coder_agent" "main" {
       sudo chown -R vscode:vscode /workspaces/SimpleAccounts-UAE 2>/dev/null || true
     fi
 
-    # Fix ownership of bind-mounted config directories
-    for dir in /home/vscode/.claude /home/vscode/.gemini /home/vscode/.config/gh \
-               /home/vscode/.bash_history_dir /home/vscode/.gitconfig_dir \
-               /home/vscode/.ssh /home/vscode/.docker /home/vscode/.kube; do
-      if [ -d "$dir" ]; then
-        sudo chown -R vscode:vscode "$dir" 2>/dev/null || true
+    # Fix ownership of bind-mounted config files and directories
+    for path in /home/vscode/.claude.json /home/vscode/.claude /home/vscode/.gemini \
+                /home/vscode/.config/gh /home/vscode/.bash_history_dir /home/vscode/.gitconfig_dir \
+                /home/vscode/.ssh /home/vscode/.docker /home/vscode/.kube; do
+      if [ -e "$path" ]; then
+        sudo chown -R vscode:vscode "$path" 2>/dev/null || true
       fi
     done
 
@@ -342,12 +409,20 @@ resource "docker_container" "workspace" {
     container_path = "/home/vscode/.npm"
   }
 
-  # User credentials (persistent across host)
+  # User credentials (persistent across host) - mount both file and directory
+  # Claude config file
+  volumes {
+    host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude.json"
+    container_path = "/home/vscode/.claude.json"
+  }
+
+  # Claude data directory (for cache, sessions, etc.)
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude"
     container_path = "/home/vscode/.claude"
   }
 
+  # Gemini directory (contains config.json and other data)
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/gemini/.gemini"
     container_path = "/home/vscode/.gemini"
@@ -432,10 +507,11 @@ resource "docker_container" "workspace" {
     value = "8080"
   }
 
-  # Depend on database containers
+  # Depend on database containers and host directory setup
   depends_on = [
     docker_container.postgres,
-    docker_container.redis
+    docker_container.redis,
+    null_resource.host_directories
   ]
 
   # Auto-restart on failure


### PR DESCRIPTION
## Summary

- Add `null_resource` provisioner to create host directories and files before container starts
- Create `.claude.json` and `.gemini/config.json` on host if they don't exist
- Mount both `.claude.json` (file) and `.claude/` (directory) for Claude CLI
- Mount `.gemini/` directory containing `config.json` (simplified from separate file mount)
- Update startup script to fix permissions for both files and directories
- Add dependency on `host_directories` resource to ensure proper mount order

## Problem Solved

Previously, when Docker tried to mount files that didn't exist on the host, it would create them as directories with root ownership, causing permission issues. This fix ensures:

1. Host directories are created **before** the container starts
2. Config files (`.claude.json`, `.gemini/config.json`) are initialized with empty `{}`
3. Files are mounted with proper ownership
4. Changes in the container persist back to the host

## Changes

### Host Directory Structure
```
/home/coder/.coder-mount/<user>/
├── claude/
│   ├── .claude.json          → /home/vscode/.claude.json
│   └── .claude/              → /home/vscode/.claude/
└── gemini/
    └── .gemini/              → /home/vscode/.gemini/
        └── config.json
```

### Volume Mounts
- ✅ `.claude.json` → Mounted as **file**
- ✅ `.claude/` → Mounted as **directory** (for cache, sessions)
- ✅ `.gemini/` → Mounted as **directory** (contains `config.json`)

## Test Plan

- [ ] Stop and rebuild the Coder workspace
- [ ] Verify `/home/coder/.coder-mount/<user>/claude/.claude.json` exists on host
- [ ] Verify `/home/vscode/.claude.json` exists in container with `vscode:vscode` ownership
- [ ] Verify `/home/vscode/.claude/` directory exists in container
- [ ] Verify `/home/vscode/.gemini/config.json` exists in container
- [ ] Test that changes to `.claude.json` in container persist to host

🤖 Generated with [Claude Code](https://claude.com/claude-code)