### PR TITLE
fix: ensure parent directories are created for config mounts

### DIFF
--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -65,9 +65,9 @@ resource "null_resource" "host_directories" {
       mkdir -p "$BASE_DIR/claude/.claude"  # Claude data directory
       mkdir -p "$BASE_DIR/gemini/.gemini"  # Gemini data directory
       mkdir -p "$BASE_DIR/.config/gh"
-      mkdir -p "$BASE_DIR/.ssh"
-      mkdir -p "$BASE_DIR/.docker"
-      mkdir -p "$BASE_DIR/.kube"
+      mkdir -p "$BASE_DIR/ssh/.ssh"        # SSH config and keys
+      mkdir -p "$BASE_DIR/docker/.docker"  # Docker credentials
+      mkdir -p "$BASE_DIR/kube/.kube"      # Kubernetes config
       mkdir -p "$BASE_DIR/bash_history"
       mkdir -p "$BASE_DIR/gitconfig"
 


### PR DESCRIPTION
## Summary

This PR completes the directory creation fixes to ensure all mount paths have their parent directories created correctly.

### Changes

Fixed directory creation to match volume mount paths:

| Component | Before | After |
|-----------|--------|-------|
| SSH | `$BASE_DIR/.ssh` | `$BASE_DIR/ssh/.ssh` |
| Docker | `$BASE_DIR/.docker` | `$BASE_DIR/docker/.docker` |
| Kubernetes | `$BASE_DIR/.kube` | `$BASE_DIR/kube/.kube` |

### Why These Changes

The volume mounts expect paths like `/home/coder/.coder-mount/USERNAME/ssh/.ssh`, but the directory creation was only creating `/home/coder/.coder-mount/USERNAME/.ssh`. 

This mismatch caused Docker to auto-create missing directories, potentially at wrong locations.

### Related

This completes the fixes started in PR #445 which fixed `.claude.json` and `bash_history` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)