### PR TITLE
fix: create .claude.json in dockerfile to prevent directory creation

### DIFF
--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -45,19 +45,9 @@ provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
 
-# Create .claude.json file using Terraform (ensures it exists before Docker mounts)
-resource "local_file" "claude_config" {
-  filename = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude.json"
-  content  = "{}"
-
-  # Only create if doesn't exist, don't overwrite user's config
-  lifecycle {
-    ignore_changes = [content]
-  }
-
-  # Ensure parent directory exists first
-  depends_on = [null_resource.host_directories]
-}
+# NOTE: .claude.json file is created in two places:
+# 1. In the Docker image (Dockerfile) - ensures file exists in container before mount
+# 2. In the host_directories provisioner - creates file on host for persistence
 
 # Create host directories for bind mounts before container starts
 resource "null_resource" "host_directories" {
@@ -85,8 +75,15 @@ resource "null_resource" "host_directories" {
       mkdir -p "$BASE_DIR/bash_history"
       mkdir -p "$BASE_DIR/gitconfig"
 
-      # NOTE: .claude.json is now created by Terraform local_file resource
-      # This ensures it exists before Docker tries to mount it
+      # Create .claude.json file (remove directory if it exists from previous workspace)
+      if [ -d "$BASE_DIR/claude/.claude.json" ]; then
+        rm -rf "$BASE_DIR/claude/.claude.json"
+        echo "🗑️  Removed .claude.json directory"
+      fi
+      if [ ! -f "$BASE_DIR/claude/.claude.json" ]; then
+        echo '{}' > "$BASE_DIR/claude/.claude.json"
+        echo "✅ Created .claude.json file"
+      fi
 
       # Create .gemini/config.json if it doesn't exist
       if [ ! -f "$BASE_DIR/gemini/.gemini/config.json" ]; then
@@ -522,8 +519,7 @@ resource "docker_container" "workspace" {
   depends_on = [
     docker_container.postgres,
     docker_container.redis,
-    null_resource.host_directories,
-    local_file.claude_config  # Ensure .claude.json exists before mounting
+    null_resource.host_directories  # Ensures .claude.json is created on host before mounting
   ]
 
   # Auto-restart on failure

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -151,10 +151,13 @@ RUN . /usr/local/share/nvm/nvm.sh && (npm ci --legacy-peer-deps --ignore-scripts
 USER root
 RUN rm -rf /tmp/backend /tmp/root /tmp/frontend
 
-# Pre-create user directories to avoid permission issues in post-create
+# Pre-create user directories and files to avoid permission issues in post-create
 USER vscode
 RUN mkdir -p ~/.m2/repository ~/.m2/wrapper/dists ~/.npm ~/.cache/ms-playwright \
-    && chmod -R 755 ~/.m2 ~/.npm ~/.cache
+    && chmod -R 755 ~/.m2 ~/.npm ~/.cache \
+    # Create .claude.json file to ensure it exists before volume mount
+    && echo '{}' > ~/.claude.json \
+    && echo "Created .claude.json file in container image"
 
 # Reset working directory and user
 USER root


### PR DESCRIPTION
## Summary
Fixes the issue where `.claude.json` was being created as a directory instead of a file when mounted in Coder workspaces.

## Problem
Docker creates directories when trying to mount a file that doesn't exist in the container. Even when the file was created on the host before mounting, Docker would create it as a directory due to timing issues or because the file didn't exist in the container image.

## Solution
This PR implements a two-part solution:

1. **Create file in Docker image**: Added `.claude.json` creation during Docker image build
   - File is created at `/home/vscode/.claude.json` as the `vscode` user
   - Ensures the file exists in the container before any volume mounts

2. **Cleanup on host**: Updated the provisioner script to handle cleanup
   - Removes any existing `.claude.json` directory from previous workspaces
   - Creates the file on the host for persistence
   - File is then mounted over the existing file in the container

## Changes
- **`.devcontainer/Dockerfile`**: Added `.claude.json` creation as part of image build process
- **`.coder/template.tf`**: 
  - Updated provisioner to cleanup old directories and create file on host
  - Removed `local_file` resource (no longer needed)
  - Updated dependencies

## Testing
After merging this PR:

1. **Build and push the Docker image**:
   ```bash
   docker build -t ghcr.io/simpleaccounts/simpleaccounts-uae-devcontainer:latest -f .devcontainer/Dockerfile .
   docker push ghcr.io/simpleaccounts/simpleaccounts-uae-devcontainer:latest
   ```

2. **Deploy template** (already done):
   ```bash
   coder templates push simpleaccounts-uae --directory .coder --yes
   ```

3. **Test the fix**:
   ```bash
   # Delete existing workspace
   coder delete MohsinHashmi-DataInn/SimpleAccounts-UAE --yes
   
   # Create new workspace
   coder create MohsinHashmi-DataInn/SimpleAccounts-UAE --template simpleaccounts-uae
   
   # Verify .claude.json is a file (not directory)
   coder ssh SimpleAccounts-UAE -- 'ls -lah /home/vscode/.claude.json'
   # Expected: -rw-r--r-- (file), not drwxr-xr-x (directory)
   ```

## Related Issues
- Resolves `.claude.json` directory creation bug
- Ensures proper file mounting for Claude Code configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)