### PR TITLE
fix: use CLAUDE_CONFIG_DIR to store .claude.json inside .claude directory

### DIFF
--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -45,19 +45,8 @@ provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
 
-# Create .claude.json file using Terraform (ensures it exists before Docker mounts)
-resource "local_file" "claude_config" {
-  filename = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude.json"
-  content  = "{}"
-
-  # Only create if doesn't exist, don't overwrite user's config
-  lifecycle {
-    ignore_changes = [content]
-  }
-
-  # Ensure parent directory exists first
-  depends_on = [null_resource.host_directories]
-}
+# NOTE: .claude.json is created inside .claude/ directory using CLAUDE_CONFIG_DIR env var
+# This avoids Docker file mount issues by keeping everything in one directory mount
 
 # Create host directories for bind mounts before container starts
 resource "null_resource" "host_directories" {
@@ -85,8 +74,8 @@ resource "null_resource" "host_directories" {
       mkdir -p "$BASE_DIR/bash_history"
       mkdir -p "$BASE_DIR/gitconfig"
 
-      # NOTE: .claude.json is now created by Terraform local_file resource
-      # This ensures it exists before Docker tries to mount it
+      # NOTE: .claude.json will be auto-created by Claude Code inside .claude/ directory
+      # via CLAUDE_CONFIG_DIR environment variable
 
       # Create .gemini/config.json if it doesn't exist
       if [ ! -f "$BASE_DIR/gemini/.gemini/config.json" ]; then
@@ -241,7 +230,7 @@ resource "coder_agent" "main" {
     fi
 
     # Fix ownership of bind-mounted config files and directories
-    for path in /home/vscode/.claude.json /home/vscode/.claude /home/vscode/.gemini \
+    for path in /home/vscode/.claude /home/vscode/.gemini \
                 /home/vscode/.config/gh /home/vscode/.bash_history_dir /home/vscode/.gitconfig_dir \
                 /home/vscode/.ssh /home/vscode/.docker /home/vscode/.kube; do
       if [ -e "$path" ]; then
@@ -395,7 +384,9 @@ resource "docker_container" "workspace" {
     "JAVA_TOOL_OPTIONS=-XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0",
     "NODE_OPTIONS=--max-old-space-size=2048",
     "HISTFILE=/home/vscode/.bash_history_dir/.bash_history",
-    "GIT_CONFIG_GLOBAL=/home/vscode/.gitconfig_dir/.gitconfig"
+    "GIT_CONFIG_GLOBAL=/home/vscode/.gitconfig_dir/.gitconfig",
+    # Claude Code configuration directory (puts .claude.json inside .claude/ directory)
+    "CLAUDE_CONFIG_DIR=/home/vscode/.claude"
   ]
 
   # Workspace directory (persistent Git repository)
@@ -420,14 +411,9 @@ resource "docker_container" "workspace" {
     container_path = "/home/vscode/.npm"
   }
 
-  # User credentials (persistent across host) - mount both file and directory
-  # Claude config file
-  volumes {
-    host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude.json"
-    container_path = "/home/vscode/.claude.json"
-  }
-
-  # Claude data directory (for cache, sessions, etc.)
+  # User credentials (persistent across host)
+  # Claude directory (contains .claude.json, settings.json, and cache)
+  # CLAUDE_CONFIG_DIR env var tells Claude to look for .claude.json here
   volumes {
     host_path      = "/home/coder/.coder-mount/${data.coder_workspace_owner.me.name}/claude/.claude"
     container_path = "/home/vscode/.claude"
@@ -522,8 +508,7 @@ resource "docker_container" "workspace" {
   depends_on = [
     docker_container.postgres,
     docker_container.redis,
-    null_resource.host_directories,
-    local_file.claude_config  # Ensure .claude.json exists before mounting
+    null_resource.host_directories
   ]
 
   # Auto-restart on failure


### PR DESCRIPTION
## Summary
Fixes the issue where `.claude.json` was being created as a directory instead of a file in Coder workspaces.

## Problem
When Docker tries to mount a file that doesn't exist in the container image, it creates a directory instead. This was happening with `.claude.json` because we were mounting it as a separate file.

## Solution
Use the `CLAUDE_CONFIG_DIR` environment variable to tell Claude Code to store `.claude.json` inside the `.claude/` directory instead of at the workspace root.

This means:
- Only mount the `.claude/` directory (not the file separately)
- Claude Code auto-creates `.claude.json` inside `.claude/` when needed
- No Docker file mount issues since we're not mounting a file
- Simpler code - removed all file creation logic from provisioner

## Changes
- Added `CLAUDE_CONFIG_DIR=/home/vscode/.claude` environment variable to container
- Removed `.claude.json` file mount (kept only `.claude/` directory mount)
- Removed `local_file` resource that was creating `.claude.json`
- Removed file creation code from provisioner script
- Removed `.claude.json` from ownership fix loop

## Testing
After merging and deploying:
1. Delete existing workspace
2. Create new workspace
3. Verify `.claude.json` is created as a file inside `~/.claude/` directory

Closes #447