### PR TITLE
fix(devcontainer): add postgresql password synchronization on startup

### DIFF
--- a/.coder/template.tf
+++ b/.coder/template.tf
@@ -113,6 +113,12 @@ EOF
 }
 
 # Random password for PostgreSQL (generated once per workspace)
+# NOTE: This password persists in Terraform state across workspace stop/start cycles.
+# However, if Terraform state is reset while the volume persists, password mismatch occurs.
+#
+# The sync-db-password.sh script in post-start attempts to fix this by updating
+# the password in the database to match the environment variable.
+# If that fails, the user needs to rebuild with: coder restart --build
 resource "random_password" "postgres" {
   length  = 32
   special = false # Avoid special chars that might cause shell escaping issues
@@ -159,7 +165,7 @@ resource "docker_container" "postgres" {
     "POSTGRES_USER=simpleaccounts",
     "POSTGRES_PASSWORD=${random_password.postgres.result}",
     "POSTGRES_DB=simpleaccounts",
-    # Application database user credentials (used by init-db.sh)
+    # Application database user credentials (used by init-db.sh and password sync)
     "SIMPLEACCOUNTS_DB_USER=simpleaccounts",
     "SIMPLEACCOUNTS_DB_PASSWORD=${random_password.postgres.result}"
   ]
@@ -176,6 +182,13 @@ resource "docker_container" "postgres" {
     read_only      = true
   }
 
+  # Password sync hook (runs on every startup to fix password mismatch)
+  volumes {
+    host_path      = "/workspaces/SimpleAccounts-UAE/.devcontainer/postgres-startup-hook.sh"
+    container_path = "/usr/local/bin/password-sync.sh"
+    read_only      = true
+  }
+
   networks_advanced {
     name    = docker_network.workspace.name
     aliases = ["db", "postgres"]
@@ -187,6 +200,13 @@ resource "docker_container" "postgres" {
     timeout  = "5s"
     retries  = 5
   }
+
+  # Custom command: start postgres normally, then run password sync in background
+  # This ensures passwords are synchronized on EVERY container start, not just first init
+  command = [
+    "bash", "-c",
+    "docker-entrypoint.sh postgres & PG_PID=$!; sleep 5; chmod +x /usr/local/bin/password-sync.sh && /usr/local/bin/password-sync.sh || true; wait $PG_PID"
+  ]
 
   restart = "unless-stopped"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -82,14 +82,24 @@ services:
       - postgres-data:/var/lib/postgresql/data
       # Use shell script instead of SQL for dynamic environment variable support
       - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
+      # Password sync hook (runs on every startup to fix password mismatch)
+      - ./postgres-startup-hook.sh:/usr/local/bin/password-sync.sh:ro
     environment:
       # PostgreSQL initialization variables (required for container startup)
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      # Additional variables for init script
+      # Additional variables for init script and password sync
       SIMPLEACCOUNTS_DB_USER: ${SIMPLEACCOUNTS_DB_USER}
       SIMPLEACCOUNTS_DB_PASSWORD: ${SIMPLEACCOUNTS_DB_PASSWORD}
+    # Custom command: start postgres normally, then run password sync in background
+    # This ensures passwords are synchronized on EVERY container start, not just first init
+    command: >
+      bash -c "docker-entrypoint.sh postgres &
+      PG_PID=$$!;
+      sleep 5;
+      chmod +x /usr/local/bin/password-sync.sh && /usr/local/bin/password-sync.sh || true;
+      wait $$PG_PID"
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-simpleaccounts}']
       interval: 10s

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -52,6 +52,15 @@ done
 if [ $ELAPSED -lt $TIMEOUT ]; then
     echo "✅ PostgreSQL is ready"
 
+    # Synchronize database password (fixes mismatch after workspace rebuild)
+    echo ""
+    echo "🔄 Synchronizing database password..."
+    if bash /workspaces/SimpleAccounts-UAE/.devcontainer/sync-db-password.sh; then
+        echo "✅ Database password synchronized"
+    else
+        echo "⚠️  Database password sync failed - may need manual intervention"
+    fi
+
     # Validate database configuration
     echo ""
     echo "🔍 Validating database setup..."

--- a/.devcontainer/postgres-startup-hook.sh
+++ b/.devcontainer/postgres-startup-hook.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# =============================================================================
+# PostgreSQL Startup Hook
+# =============================================================================
+# This script runs INSIDE the PostgreSQL container AFTER the database is ready.
+# It synchronizes user passwords from environment variables.
+#
+# Mount this script and call it from a custom entrypoint or use postgres's
+# notify mechanism.
+#
+# Usage in docker-compose.yml:
+#   command: >
+#     bash -c "
+#       docker-entrypoint.sh postgres &
+#       sleep 5
+#       /docker-entrypoint-initdb.d/postgres-startup-hook.sh
+#       wait
+#     "
+# =============================================================================
+
+set -e
+
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL to be ready..."
+until pg_isready -U "${POSTGRES_USER:-postgres}" -q; do
+    sleep 1
+done
+echo "PostgreSQL is ready"
+
+# Sync passwords from environment variables
+DB_USER="${SIMPLEACCOUNTS_DB_USER:-simpleaccounts}"
+DB_PASSWORD="${SIMPLEACCOUNTS_DB_PASSWORD}"
+
+if [ -n "$DB_PASSWORD" ]; then
+    echo "Synchronizing password for user: $DB_USER"
+    psql -U "${POSTGRES_USER:-postgres}" -d postgres -c "
+        DO \$\$
+        BEGIN
+            -- Update the user password if user exists
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = '$DB_USER') THEN
+                ALTER USER $DB_USER WITH PASSWORD '$DB_PASSWORD';
+                RAISE NOTICE 'Updated password for user: $DB_USER';
+            ELSE
+                RAISE NOTICE 'User does not exist: $DB_USER';
+            END IF;
+        END
+        \$\$;
+    " || echo "Warning: Could not update password"
+fi
+
+echo "Password sync complete"

--- a/.devcontainer/sync-db-password.sh
+++ b/.devcontainer/sync-db-password.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# =============================================================================
+# Database Password Synchronization Script
+# =============================================================================
+# This script ensures the PostgreSQL password matches the environment variable
+# by updating it on each startup. This fixes the password mismatch issue that
+# occurs when:
+# - Coder workspace is rebuilt (new random password generated)
+# - Local devcontainer is recreated but postgres volume persists
+#
+# The script uses pg_isready to detect if PostgreSQL is available, then
+# attempts to connect and update the application user's password.
+# =============================================================================
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Detect environment and set hostname
+if [ -n "$CODER_AGENT_TOKEN" ]; then
+    DB_HOST="${POSTGRES_HOST:-db}"
+    echo -e "${BLUE}ℹ${NC} Detected Coder environment (using '$DB_HOST' hostname)"
+else
+    DB_HOST="${SIMPLEACCOUNTS_DB_HOST:-localhost}"
+    echo -e "${BLUE}ℹ${NC} Detected local devcontainer (using '$DB_HOST' hostname)"
+fi
+
+DB_PORT="${SIMPLEACCOUNTS_DB_PORT:-5432}"
+DB_USER="${SIMPLEACCOUNTS_DB_USER:-simpleaccounts}"
+DB_PASSWORD="${SIMPLEACCOUNTS_DB_PASSWORD:-simpleaccounts_dev}"
+DB_NAME="${SIMPLEACCOUNTS_DB:-simpleaccounts}"
+POSTGRES_USER_ENV="${POSTGRES_USER:-simpleaccounts}"
+POSTGRES_PASSWORD_ENV="${POSTGRES_PASSWORD:-$DB_PASSWORD}"
+
+echo -e "${BLUE}🔄 Synchronizing database password...${NC}"
+echo "   Host: $DB_HOST:$DB_PORT"
+echo "   User: $DB_USER"
+echo "   Database: $DB_NAME"
+
+# Function to try connecting with a password
+try_connection() {
+    local password="$1"
+    local user="$2"
+    PGPASSWORD="$password" psql -h "$DB_HOST" -p "$DB_PORT" -U "$user" -d "$DB_NAME" -c "SELECT 1" > /dev/null 2>&1
+    return $?
+}
+
+# Function to update user password
+update_password() {
+    local admin_password="$1"
+    local admin_user="$2"
+    local target_user="$3"
+    local new_password="$4"
+
+    PGPASSWORD="$admin_password" psql -h "$DB_HOST" -p "$DB_PORT" -U "$admin_user" -d "$DB_NAME" -c "ALTER USER $target_user WITH PASSWORD '$new_password';" > /dev/null 2>&1
+    return $?
+}
+
+# Wait for PostgreSQL to be ready
+echo -e "${BLUE}⏳ Waiting for PostgreSQL...${NC}"
+TIMEOUT=30
+ELAPSED=0
+until pg_isready -h "$DB_HOST" -p "$DB_PORT" -q; do
+    sleep 1
+    ELAPSED=$((ELAPSED + 1))
+    if [ $ELAPSED -ge $TIMEOUT ]; then
+        echo -e "${YELLOW}⚠${NC} PostgreSQL not ready after ${TIMEOUT}s"
+        exit 0  # Don't fail, let other scripts continue
+    fi
+done
+echo -e "${GREEN}✓${NC} PostgreSQL is accepting connections"
+
+# Test connection with current environment password
+if try_connection "$DB_PASSWORD" "$DB_USER"; then
+    echo -e "${GREEN}✓${NC} Password is already synchronized"
+    exit 0
+fi
+
+echo -e "${YELLOW}⚠${NC} Password mismatch detected, attempting to synchronize..."
+
+# List of passwords to try for admin access
+# Order matters: try most likely passwords first
+ADMIN_PASSWORDS=(
+    "$POSTGRES_PASSWORD_ENV"
+    "$DB_PASSWORD"
+    "simpleaccounts_dev"
+    "postgres"
+    ""
+)
+
+# List of admin users to try
+ADMIN_USERS=(
+    "$POSTGRES_USER_ENV"
+    "postgres"
+    "simpleaccounts"
+)
+
+PASSWORD_SYNCED=false
+
+for admin_user in "${ADMIN_USERS[@]}"; do
+    for admin_password in "${ADMIN_PASSWORDS[@]}"; do
+        # Try connecting as admin
+        if try_connection "$admin_password" "$admin_user"; then
+            echo -e "${BLUE}ℹ${NC} Connected as '$admin_user'"
+
+            # Update the application user password
+            if update_password "$admin_password" "$admin_user" "$DB_USER" "$DB_PASSWORD"; then
+                echo -e "${GREEN}✓${NC} Updated password for user '$DB_USER'"
+
+                # Also update postgres user if different
+                if [ "$admin_user" != "postgres" ] && [ "$DB_USER" != "postgres" ]; then
+                    update_password "$admin_password" "$admin_user" "postgres" "$POSTGRES_PASSWORD_ENV" 2>/dev/null || true
+                fi
+
+                PASSWORD_SYNCED=true
+                break 2
+            else
+                echo -e "${YELLOW}⚠${NC} Failed to update password (may lack permissions)"
+            fi
+        fi
+    done
+done
+
+if [ "$PASSWORD_SYNCED" = true ]; then
+    # Verify the new password works
+    if try_connection "$DB_PASSWORD" "$DB_USER"; then
+        echo -e "${GREEN}✓${NC} Password synchronization complete"
+        exit 0
+    else
+        echo -e "${RED}✗${NC} Password update succeeded but verification failed"
+        exit 1
+    fi
+else
+    echo -e "${RED}✗${NC} Could not synchronize password"
+    echo ""
+    echo "This usually means the PostgreSQL volume was initialized with a different password."
+    echo "To fix this, you need to:"
+    echo ""
+    echo "  Option 1: Delete the PostgreSQL volume and let it reinitialize"
+    echo "    - Coder: coder restart --build"
+    echo "    - Local: docker compose down -v && docker compose up -d"
+    echo ""
+    echo "  Option 2: Manually reset the password"
+    echo "    - Connect to PostgreSQL as superuser"
+    echo "    - Run: ALTER USER $DB_USER WITH PASSWORD 'your-password';"
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Fixes PostgreSQL password mismatch issue that occurs when Coder workspace is rebuilt or when local devcontainer is recreated while the PostgreSQL volume persists
- Adds automatic password synchronization on every PostgreSQL container startup
- Adds client-side password recovery script for edge cases

## Root Cause

When a Coder workspace is rebuilt, Terraform generates a new random password, but the PostgreSQL volume retains credentials from the first initialization. This causes authentication failures.

## Solution

- **postgres-startup-hook.sh**: Runs inside the PostgreSQL container on every startup and syncs the password from environment variables to the database
- **sync-db-password.sh**: Client-side script that attempts password recovery using known passwords
- Updated Coder template to mount and run the startup hook
- Updated docker-compose.yml with the same mechanism for local dev
- Updated post-start.sh to call sync script before database validation

## Test plan

- [ ] Verify password sync works on fresh Coder workspace creation
- [ ] Verify password sync works after Coder workspace rebuild
- [ ] Verify local devcontainer still works with docker-compose
- [ ] Verify backend can connect to PostgreSQL after workspace restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)