### PR TITLE
docs: add vnc browser documentation

### DIFF
--- a/.coder/README.md
+++ b/.coder/README.md
@@ -40,12 +40,14 @@ After workspace creation, you'll have:
 ```
 Frontend:  https://<username>-<workspace>.dev.simpleaccounts.io
 Backend:   https://<username>-<workspace>-api.dev.simpleaccounts.io
+VNC:       https://<username>-<workspace>-vnc.dev.simpleaccounts.io/vnc.html
 ```
 
 Example for user `john` with workspace `dev`:
 
 - Frontend: https://john-dev.dev.simpleaccounts.io
 - Backend: https://john-dev-api.dev.simpleaccounts.io
+- VNC: https://john-dev-vnc.dev.simpleaccounts.io/vnc.html
 
 ## What's Included
 
@@ -57,6 +59,7 @@ Example for user `john` with workspace `dev`:
 | Redis                 | 7       | `redis:6379` |
 | Frontend (Vite)       | -       | Port 3000    |
 | Backend (Spring Boot) | -       | Port 8080    |
+| VNC Browser           | -       | Port 6080    |
 
 ### Database Connection
 
@@ -153,6 +156,31 @@ cd apps/frontend && npm test
 
 # Backend tests
 cd apps/backend && ./mvnw test
+```
+
+### VNC Browser (UI Testing)
+
+VNC provides a virtual browser for UI testing and Playwright headed tests.
+
+**Access Methods:**
+
+- **Workspace App**: Click "VNC Browser" icon in the workspace apps panel
+- **External URL**: `https://<username>-<workspace>-vnc.dev.simpleaccounts.io/vnc.html`
+
+**Run Playwright Tests in Headed Mode:**
+
+```bash
+# Watch tests execute in VNC
+DISPLAY=:99 npx playwright test --headed --project=chromium
+
+# Run specific test
+DISPLAY=:99 npx playwright test e2e/my-test.spec.ts --headed --project=chromium --workers=1
+```
+
+**VNC starts automatically** when your workspace starts. If needed manually:
+
+```bash
+start-vnc
 ```
 
 ### Install Dependencies
@@ -379,6 +407,7 @@ If you need more resources, contact your Coder admin.
 │ Traefik Reverse Proxy                                        │
 │ - john-dev.dev.simpleaccounts.io        → :3000             │
 │ - john-dev-api.dev.simpleaccounts.io    → :8080             │
+│ - john-dev-vnc.dev.simpleaccounts.io    → :6080             │
 └─────────────────────────────────────────────────────────────┘
 ```
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -41,6 +41,7 @@ This means all services (devcontainer, postgres, redis) are accessible via `loca
 │  │              │  │              │  │              │       │
 │  │ localhost:3000 (frontend)                        │       │
 │  │ localhost:8080 (backend)                         │       │
+│  │ localhost:6080 (vnc)                             │       │
 │  │              │  │ localhost:5432                 │       │
 │  │              │  │              │  │ localhost:6379       │
 │  └──────────────┘  └──────────────┘  └──────────────┘       │
@@ -55,6 +56,59 @@ This means all services (devcontainer, postgres, redis) are accessible via `loca
 | Redis      | `localhost:6379`      |
 | Frontend   | `localhost:3000`      |
 | Backend    | `localhost:8080`      |
+| VNC        | `localhost:6080`      |
+
+## VNC Browser Access
+
+The devcontainer includes a VNC server for browser testing and UI preview. This allows you to run headed Playwright tests and visually debug the application.
+
+### Accessing VNC
+
+**In Coder Workspaces:**
+
+- Click the **"VNC Browser"** icon in the workspace apps panel
+- Or use the external URL: `https://{owner}-{workspace}-vnc.dev.simpleaccounts.io/vnc.html`
+
+**In Local Dev Container:**
+
+- Open `http://localhost:6080/vnc.html` in your browser
+- Click **Connect** to view the virtual desktop
+
+### Starting VNC Manually
+
+VNC starts automatically in Coder workspaces. For local development:
+
+```bash
+# Start VNC server
+start-vnc
+
+# Or manually:
+Xvfb :99 -screen 0 1400x900x24 &
+export DISPLAY=:99
+x11vnc -display :99 -forever -nopw -shared -rfbport 5900 &
+/usr/share/novnc/utils/novnc_proxy --vnc localhost:5900 --listen 6080 &
+```
+
+### Running Playwright Tests in Headed Mode
+
+With VNC running, you can watch Playwright tests execute:
+
+```bash
+# Run tests in headed mode (visible in VNC)
+DISPLAY=:99 npx playwright test --headed --project=chromium
+
+# Run a specific test file
+DISPLAY=:99 npx playwright test e2e/my-test.spec.ts --headed --project=chromium --workers=1
+```
+
+### VNC Configuration
+
+| Setting    | Value               |
+| ---------- | ------------------- |
+| Display    | `:99`               |
+| Resolution | `1400x900x24`       |
+| VNC Port   | `5900`              |
+| noVNC Port | `6080` (web access) |
 
 ## Files
 
@@ -74,6 +128,7 @@ This means all services (devcontainer, postgres, redis) are accessible via `loca
 | `init-db.sql`          | PostgreSQL initialization script                |
 | `post-create.sh`       | Runs once on container creation                 |
 | `post-start.sh`        | Runs on every container start                   |
+| `start-vnc.sh`         | Starts VNC server for browser testing           |
 | **Documentation**      |                                                 |
 | `README.md`            | This file - DevContainer overview               |
 | `DATABASE_SETUP.md`    | Detailed database setup and troubleshooting     |


### PR DESCRIPTION
## Summary
- Add VNC section to devcontainer README with access instructions
- Update Coder README with VNC URLs and usage examples
- Add VNC to architecture diagrams and service tables
- Document Playwright headed mode testing workflow

## Changes
- `.devcontainer/README.md` - Added VNC Browser Access section with:
  - Access instructions for Coder and local dev
  - Manual VNC startup commands
  - Playwright headed mode testing examples
  - VNC configuration table
  
- `.coder/README.md` - Added VNC documentation:
  - VNC URL in environment URLs section
  - VNC service in services table
  - VNC Browser (UI Testing) section with usage examples
  - Updated architecture diagram with VNC routing

## Related
This documents the VNC feature added in commit ffa6e949.

## Test plan
- [ ] Verify VNC URLs are correctly documented
- [ ] Test Playwright headed mode instructions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)